### PR TITLE
added pthread to cmake

### DIFF
--- a/eth/CMakeLists.txt
+++ b/eth/CMakeLists.txt
@@ -13,6 +13,9 @@ link_directories(../libethereum)
 
 add_executable(eth ${SRC_LIST})
 
+find_package(Threads REQUIRED)
+target_link_libraries(eth ${CMAKE_THREAD_LIBS_INIT})
+
 target_link_libraries(eth ethereum)
 target_link_libraries(eth leveldb)
 target_link_libraries(eth secp256k1)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,9 @@ link_directories(../libethereum)
 
 add_executable(testeth ${SRC_LIST})
 
+find_package(Threads REQUIRED)
+target_link_libraries(testeth ${CMAKE_THREAD_LIBS_INIT})
+
 target_link_libraries(testeth ethereum)
 target_link_libraries(testeth cryptopp)
 target_link_libraries(testeth secp256k1)


### PR DESCRIPTION
I got these errors:

```
/usr/bin/ld: ../libethereum/libethereum.a(PeerNetwork.cpp.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```

and could resolve them by adding Threads (pthreads)
