### PR TITLE
Little fixes found using clang on OSX10.9:

### DIFF
--- a/libethereum/PeerNetwork.cpp
+++ b/libethereum/PeerNetwork.cpp
@@ -959,7 +959,7 @@ bool PeerServer::process(BlockChain& _bc, TransactionQueue& _tq, Overlay& _o)
 			}
 			m_latestBlockSent = h;
 
-			for (bool accepted = 1; accepted;)
+			for (int accepted = 1; accepted;)
 			{
 				accepted = 0;
 				if (m_incomingBlocks.size())

--- a/libethereum/PeerNetwork.h
+++ b/libethereum/PeerNetwork.h
@@ -117,7 +117,7 @@ enum class NodeMode
 	PeerServer
 };
 
-class UPnP;
+struct UPnP;
 
 class PeerServer
 {

--- a/libethereum/RLP.h
+++ b/libethereum/RLP.h
@@ -169,7 +169,7 @@ public:
 	/// Converts to bytearray. @returns the empty byte array if not a string.
 	bytes toBytes() const { if (!isString()) return bytes(); return bytes(payload().data(), payload().data() + items()); }
 	/// Converts to bytearray. @returns the empty byte array if not a string.
-	bytesConstRef toBytesConstRef() const { if (!isString()) return bytesConstRef(); payload().cropped(0, items()); }
+	bytesConstRef toBytesConstRef() const { if (!isString()) return bytesConstRef(); return payload().cropped(0, items()); }
 	/// Converts to string. @returns the empty string if not a string.
 	std::string toString() const { if (!isString()) return std::string(); return payload().cropped(0, items()).toString(); }
 	/// Converts to string. @throws BadCast if not a string.


### PR DESCRIPTION
- bool to int as its incremented in PeerNetwork.cpp
- class to struct to match .cpp of UPnP in PeerNetwork.h
- Add missing return to string case in RLP.toBytesConstRef
