### PR TITLE
Do not assume that the build dir is called cpp-ethereum-build.

### DIFF
--- a/alephzero/alephzero.pro
+++ b/alephzero/alephzero.pro
@@ -15,7 +15,7 @@ CONFIG(debug, debug|release): DEFINES += ETH_DEBUG
 QMAKE_CXXFLAGS += -std=c++11
 
 QMAKE_LIBDIR += ../libethereum ../../cpp-ethereum-build/libethereum ../../secp256k1 ../../cryptopp562
-LIBS += -Wl,-rpath,../libethereu -Wl,-rpath,../../cpp-ethereum-build/libethereum -Wl,-rpath,../../secp256k1 -Wl,-rpath,../../cryptopp562 -lethereum -lcryptopp -lminiupnpc -lsecp256k1 -lleveldb -lgmp -lboost_filesystem -lboost_system
+LIBS += -Wl,-rpath,../libethereum -Wl,-rpath,../../cpp-ethereum-build/libethereum -Wl,-rpath,../../secp256k1 -Wl,-rpath,../../cryptopp562 -lethereum -lcryptopp -lminiupnpc -lsecp256k1 -lleveldb -lgmp -lboost_filesystem -lboost_system
 INCLUDEPATH = ../../secp256k1/include ../../cpp-ethereum
 
 SOURCES += main.cpp \


### PR DESCRIPTION
Added include paths not going 2 levels deep. The ../.. are probably useless, unless someone is building part of the tree directly in the sources.
