### PR TITLE
Corrected license headers (Foobar -> cpp-ethereum)

### DIFF
--- a/eth/main.cpp
+++ b/eth/main.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file main.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/AddressState.cpp
+++ b/libethereum/AddressState.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file AddressState.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/AddressState.h
+++ b/libethereum/AddressState.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file AddressState.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockChain.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockChain.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/BlockInfo.cpp
+++ b/libethereum/BlockInfo.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockInfo.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/BlockInfo.h
+++ b/libethereum/BlockInfo.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file BlockInfo.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Client.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Client.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Common.cpp
+++ b/libethereum/Common.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Common.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Common.h
+++ b/libethereum/Common.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Common.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Defaults.cpp
+++ b/libethereum/Defaults.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Defaults.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Defaults.h
+++ b/libethereum/Defaults.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Defaults.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/FileSystem.cpp
+++ b/libethereum/FileSystem.cpp
@@ -12,7 +12,7 @@
         GNU General Public License for more details.
 
         You should have received a copy of the GNU General Public License
-        along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+        along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file FileSystem.cpp
  * @authors

--- a/libethereum/FileSystem.h
+++ b/libethereum/FileSystem.h
@@ -12,7 +12,7 @@
         GNU General Public License for more details.
 
         You should have received a copy of the GNU General Public License
-        along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+        along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file FileSystem.h
  * @authors

--- a/libethereum/MemTrie.cpp
+++ b/libethereum/MemTrie.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file MemTrie.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/MemTrie.h
+++ b/libethereum/MemTrie.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file MemTrie.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/PeerNetwork.cpp
+++ b/libethereum/PeerNetwork.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file PeerNetwork.cpp
  * @authors:

--- a/libethereum/PeerNetwork.h
+++ b/libethereum/PeerNetwork.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file PeerNetwork.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/RLP.cpp
+++ b/libethereum/RLP.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file RLP.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/RLP.h
+++ b/libethereum/RLP.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file RLP.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file State.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file State.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Transaction.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/Transaction.h
+++ b/libethereum/Transaction.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file Transaction.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TransactionQueue.cpp
+++ b/libethereum/TransactionQueue.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TransactionQueue.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TransactionQueue.h
+++ b/libethereum/TransactionQueue.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TransactionQueue.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TrieCommon.cpp
+++ b/libethereum/TrieCommon.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TrieCommon.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TrieCommon.h
+++ b/libethereum/TrieCommon.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TrieCommon.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TrieDB.cpp
+++ b/libethereum/TrieDB.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TrieDB.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TrieDB.h
+++ b/libethereum/TrieDB.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TrieDB.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TrieHash.cpp
+++ b/libethereum/TrieHash.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TrieHash.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/TrieHash.h
+++ b/libethereum/TrieHash.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file TrieHash.h
  * @author Gav Wood <i@gavwood.com>

--- a/libethereum/UPnP.cpp
+++ b/libethereum/UPnP.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file UPnP.cpp
  * @authors:

--- a/libethereum/UPnP.h
+++ b/libethereum/UPnP.h
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file UPnP.h
  * @authors:

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file crypto.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/test/dagger.cpp
+++ b/test/dagger.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file dagger.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/test/hexPrefix.cpp
+++ b/test/hexPrefix.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file main.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file main.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/test/peer.cpp
+++ b/test/peer.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file peer.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/test/rlp.cpp
+++ b/test/rlp.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file rlp.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file state.cpp
  * @author Gav Wood <i@gavwood.com>

--- a/test/trie.cpp
+++ b/test/trie.cpp
@@ -12,7 +12,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file trie.cpp
  * @author Gav Wood <i@gavwood.com>


### PR DESCRIPTION
Cosmetic fix, replaces "Foobar" with the proper name of the project.
