### PR TITLE
Init order bug fix to units and code standardisation fix

### DIFF
--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -52,9 +52,9 @@ Main::Main(QWidget *parent) :
 #endif
 
 	on_verbosity_sliderMoved();
+	initUnits(ui->valueUnits);
 	on_destination_textChanged();
 
-	initUnits(ui->valueUnits);
 	statusBar()->addPermanentWidget(ui->balance);
 	statusBar()->addPermanentWidget(ui->peerCount);
 	statusBar()->addPermanentWidget(ui->blockCount);

--- a/libethereum/AddressState.h
+++ b/libethereum/AddressState.h
@@ -47,7 +47,7 @@ public:
 		{
 			auto mFinder = m_memory.find((u256)i);
 			if (mFinder == m_memory.end())
-				m_memory.insert(std::pair<u256,u256>((u256)i,_memory[i]));
+				m_memory.insert(std::make_pair((u256)i,_memory[i]));
 			else
 				mFinder->second = _memory[i];
 		}


### PR DESCRIPTION
(1) Simple fix to use make_pair instead of std::pair<>

(2) The initialisation of the units is currently happening after the on_destination_textChanged() call expects it be initialised.

Call stack:

```
#0  0x0000000100006e29 in boost::multiprecision::backends::cpp_int_base<256u, 256u, (boost::multiprecision::cpp_integer_type)0, (boost::multiprecision::cpp_int_check_type)0, void, false>::normalize (this=0x7fff5fbfeac8) at cpp_int.hpp:629
#1  0x0000000100006c5f in boost::multiprecision::backends::eval_multiply<256u, 256u, (boost::multiprecision::cpp_integer_type)0, (boost::multiprecision::cpp_int_check_type)0, void, 256u, 256u, (boost::multiprecision::cpp_integer_type)0, (boost::multiprecision::cpp_int_check_type)0, void> (result=@0x7fff5fbfeac8, a=@0x1038014c0, val=@0x7fff5fbfea74) at multiply.hpp:47
#2  0x000000010000693e in boost::multiprecision::backends::eval_multiply<256u, 256u, (boost::multiprecision::cpp_integer_type)0, (boost::multiprecision::cpp_int_check_type)0, void, 256u, 256u, (boost::multiprecision::cpp_integer_type)0, (boost::multiprecision::cpp_int_check_type)0, void> (result=@0x7fff5fbfeac8, a=@0x1038014c0, val=@0x7fff5fbfeb5c) at multiply.hpp:205
#3  0x00000001000329d8 in boost::multiprecision::operator*<int, boost::multiprecision::backends::cpp_int_backend<256u, 256u, (boost::multiprecision::cpp_integer_type)0, (boost::multiprecision::cpp_int_check_type)0, void> > (a=@0x7fff5fbfeb5c, b=@0x1038014c0) at no_et_ops.hpp:121
#4  0x0000000100018daf in Main::value (this=0x7fff5fbff7a0) at /Users/dan/Sources/GitClones/cpp-ethereum/alethzero/MainWin.cpp:433
#5  0x0000000100018dfc in Main::total (this=0x7fff5fbff7a0) at /Users/dan/Sources/GitClones/cpp-ethereum/alethzero/MainWin.cpp:438
#6  0x00000001000180c4 in Main::updateFee (this=0x7fff5fbff7a0) at /Users/dan/Sources/GitClones/cpp-ethereum/alethzero/MainWin.cpp:444
#7  0x0000000100011338 in Main::on_destination_textChanged (this=0x7fff5fbff7a0) at /Users/dan/Sources/GitClones/cpp-ethereum/alethzero/MainWin.cpp:415
#8  0x000000010000ae0d in Main::Main (this=0x7fff5fbff7a0, parent=0x0) at /Users/dan/Sources/GitClones/cpp-ethereum/alethzero/MainWin.cpp:55
#9  0x000000010000a38d in Main::Main (this=0x7fff5fbff7a0, parent=0x0) at /Users/dan/Sources/GitClones/cpp-ethereum/alethzero/MainWin.cpp:61
#10 0x0000000100004bda in main (argc=1, argv=0x7fff5fbff880) at /Users/dan/Sources/GitClones/cpp-ethereum/alethzero/main.cpp:7
```

Basically initUnits() isn't called yet, and the call to ui->valueUnits->currentIndex() returns a random index which causes the memory access violation.

Moving the initUnits call to infront of the on_destination_textChanged does the trick.
