### PR TITLE
Windows build requires cryptopp include dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if ("${TARGET_PLATFORM}" STREQUAL "w64")
 		/usr/x86_64-w64-mingw32
 	)
 
+	include_directories(/usr/x86_64-w64-mingw32/include/cryptopp)
+
 	set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 	set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 	set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Since we're including the cryptopp headers directly in our source, we need to explicitly add the cryptopp include directory to our include path.
