### PR TITLE
std::unordered_map for blockdetail hash 

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -290,7 +290,7 @@ BlockDetails const& BlockChain::details(h256 _h) const
 		{
 			lock_guard<mutex> l(m_lock);
 			bool ok;
-			tie(it, ok) = m_details.insert(make_pair(_h, BlockDetails(RLP(s))));
+			tie(it, ok) = m_details.insert(std::make_pair(_h, BlockDetails(RLP(s))));
 		}
 	}
 	return it->second;

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -48,7 +48,7 @@ struct BlockDetails
 	h256s children;
 };
 
-typedef std::hash_map<h256, BlockDetails, H256Hash> BlockDetailsHash;
+typedef std::unordered_map<h256, BlockDetails, H256Hash> BlockDetailsHash;
 
 static const BlockDetails NullBlockDetails;
 static const h256s NullH256s;
@@ -74,7 +74,7 @@ public:
 	/// (Potentially) renders invalid existing bytesConstRef returned by lastBlock.
 	/// To be called from main loop every 100ms or so.
 	void process();
-	
+
 	/// Attempt to import the given block.
 	bool attemptImport(bytes const& _block, Overlay const& _stateDB);
 

--- a/libethereum/Common.h
+++ b/libethereum/Common.h
@@ -40,7 +40,6 @@
 #include <chrono>
 #include <array>
 #include <map>
-#include <hash_map>
 #include <unordered_map>
 #include <set>
 #include <array>
@@ -182,7 +181,7 @@ using HexMap = std::map<bytes, std::string>;
 static const u256 Invalid256 = ~(u256)0;
 static const bytes NullBytes;
 
-// This is the helper class for the std::hash_map lookup; it converts the input 256bit hash into a size_t sized hash value
+// This is the helper class for the std::unordered_map lookup; it converts the input 256bit hash into a size_t sized hash value
 // and does an exact comparison of two hash entries.
 class H256Hash
 {
@@ -262,8 +261,8 @@ public:
 		{
 			time_t rawTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 			char buf[24];
-			if (strftime(buf, 24, "%X", localtime(&rawTime)) == 0) 
-				buf[0] = '\0'; // empty if case strftime fails  
+			if (strftime(buf, 24, "%X", localtime(&rawTime)) == 0)
+				buf[0] = '\0'; // empty if case strftime fails
 			sstr << Id::name() << " [ " << buf << " | " << *(t_logThreadName.m_name.get()) << (_term ? " ] " : "");
 		}
 	}

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -266,7 +266,7 @@ public:
 #ifdef __clang__
 			auto it = m_store->find(_n);
 			if (it == m_store->end())
-				m_store->insert(make_pair(_n, _v));
+				m_store->insert(std::make_pair(_n, _v));
 			else
 				m_store->at(_n) = _v;
 #else

--- a/libethereum/VM.h
+++ b/libethereum/VM.h
@@ -482,11 +482,11 @@ template <class Ext> void eth::VM::go(Ext& _ext, uint64_t _steps)
 		{
 			require(1);
 #ifdef __clang__
-			auto mFinder = tempMem.find(stack.back());
-			if (mFinder != tempMem.end())
-				stack.back() = mFinder->second;
+			auto mFinder = m_temp.find(m_stack.back());
+			if (mFinder != m_temp.end())
+				m_stack.back() = mFinder->second;
 			else
-				stack.back() = 0;
+				m_stack.back() = 0;
 #else
 			m_stack.back() = m_temp[m_stack.back()];
 #endif
@@ -496,11 +496,11 @@ template <class Ext> void eth::VM::go(Ext& _ext, uint64_t _steps)
 		{
 			require(2);
 #ifdef __clang__
-			auto mFinder = tempMem.find(stack.back());
-			if (mFinder == tempMem.end())
-				tempMem.insert(make_pair(stack.back(), stack[stack.size() - 2]));
+			auto mFinder = m_temp.find(m_stack.back());
+			if (mFinder == m_temp.end())
+				m_temp.insert(std::make_pair(m_stack.back(), m_stack[m_stack.size() - 2]));
 			else
-				mFinder->second = stack[stack.size() - 2];
+				mFinder->second = m_stack[m_stack.size() - 2];
 #else
 			m_temp[m_stack.back()] = m_stack[m_stack.size() - 2];
 #endif


### PR DESCRIPTION
- use std::unordered_map for blockdetails hash
- hashing class defined in Common.h (credit JW Ratcliff)
- fix m_stack/m_temp in VM clang sections
- explicit namespace for std::make_pair calls
