### PR TITLE
Get rid of operator precedence warning.

### DIFF
--- a/libethereum/Common.h
+++ b/libethereum/Common.h
@@ -155,7 +155,7 @@ public:
 		{
 			size_t h = 0;
 			for (auto i: value.m_data)
-				h = (h << 5 - h) + i;
+				h = (h << (5 - h)) + i;
 			return h;
 		}
 	};


### PR DESCRIPTION
clang complains about implicit operator precedence. Silence this warning once and for all!
