### PR TITLE
Remove clang bug workarounds fixed with latest XCode 5.1 tools release.

### DIFF
--- a/libethereum/AddressState.h
+++ b/libethereum/AddressState.h
@@ -43,17 +43,7 @@ public:
 	AddressState(u256 _balance, u256 _nonce, u256s _memory): m_type(AddressType::Contract), m_balance(_balance), m_nonce(_nonce), m_haveMemory(true)
 	{
 		for (unsigned i = 0; i < _memory.size(); ++i)
-#ifdef __clang__
-		{
-			auto mFinder = m_memory.find((u256)i);
-			if (mFinder == m_memory.end())
-				m_memory.insert(std::make_pair((u256)i,_memory[i]));
-			else
-				mFinder->second = _memory[i];
-		}
-#else
 			m_memory[(u256)i] = _memory[i];
-#endif
 	}
 
 	void incNonce() { m_nonce++; }

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -146,14 +146,7 @@ void State::ensureCached(Address _a, bool _requireMemory, bool _forceCreate) con
 		TrieDB<h256, Overlay> memdb(const_cast<Overlay*>(&m_db), it->second.oldRoot());		// promise we won't alter the overlay! :)
 		map<u256, u256>& mem = it->second.setHaveMemory();
 		for (auto const& i: memdb)
-#ifdef __clang__
-			if (mem.find(i.first) == mem.end())
-				mem.insert(make_pair(i.first, RLP(i.second).toInt<u256>()));
-			else
-				mem.at(i.first) = RLP(i.second).toInt<u256>();
-#else
 			mem[i.first] = RLP(i.second).toInt<u256>();
-#endif
 	}
 }
 
@@ -715,14 +708,7 @@ void State::executeBare(Transaction const& _t, Address _sender)
 		m_cache[newAddress] = AddressState(_t.value, 0, AddressType::Contract);
 		auto& mem = m_cache[newAddress].memory();
 		for (uint i = 0; i < _t.data.size(); ++i)
-#ifdef __clang__
-			if (mem.find(i) == mem.end())
-				mem.insert(make_pair(i, _t.data[i]));
-			else
-				mem.at(i) = _t.data[i];
-#else
 			mem[i] = _t.data[i];
-#endif
 	}
 
 #if ETH_DEBUG

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -262,17 +262,7 @@ public:
 	void setStore(u256 _n, u256 _v)
 	{
 		if (_v)
-		{
-#ifdef __clang__
-			auto it = m_store->find(_n);
-			if (it == m_store->end())
-				m_store->insert(std::make_pair(_n, _v));
-			else
-				m_store->at(_n) = _v;
-#else
 			(*m_store)[_n] = _v;
-#endif
-		}
 		else
 			m_store->erase(_n);
 	}
@@ -323,15 +313,7 @@ inline std::ostream& operator<<(std::ostream& _out, State const& _s)
 				for (auto const& j: memdb)
 				{
 					_out << std::endl << "    [" << j.first << ":" << toHex(j.second) << "]";
-#ifdef __clang__
-					auto mFinder = mem.find(j.first);
-					if (mFinder == mem.end())
-						mem.insert(std::make_pair(j.first, RLP(j.second).toInt<u256>()));
-					else
-						mFinder->second = RLP(j.second).toInt<u256>();
-#else
 					mem[j.first] = RLP(j.second).toInt<u256>();
-#endif
 				}
 				_out << std::endl << mem;
 			}
@@ -360,15 +342,7 @@ inline std::ostream& operator<<(std::ostream& _out, State const& _s)
 					for (auto const& j: memdb)
 					{
 						_out << std::endl << "    [" << j.first << ":" << toHex(j.second) << "]";
-#ifdef __clang__
-						auto mFinder = mem.find(j.first);
-						if (mFinder == mem.end())
-							mem.insert(std::make_pair(j.first, RLP(j.second).toInt<u256>()));
-						else
-							mFinder->second = RLP(j.second).toInt<u256>();
-#else
 						mem[j.first] = RLP(j.second).toInt<u256>();
-#endif
 					}
 					_out << std::endl << mem;
 				}

--- a/libethereum/VM.h
+++ b/libethereum/VM.h
@@ -479,29 +479,13 @@ template <class Ext> void eth::VM::go(Ext& _ext, uint64_t _steps)
 		case Instruction::MLOAD:
 		{
 			require(1);
-#ifdef __clang__
-			auto mFinder = m_temp.find(m_stack.back());
-			if (mFinder != m_temp.end())
-				m_stack.back() = mFinder->second;
-			else
-				m_stack.back() = 0;
-#else
 			m_stack.back() = m_temp[m_stack.back()];
-#endif
 			break;
 		}
 		case Instruction::MSTORE:
 		{
 			require(2);
-#ifdef __clang__
-			auto mFinder = m_temp.find(m_stack.back());
-			if (mFinder == m_temp.end())
-				m_temp.insert(std::make_pair(m_stack.back(), m_stack[m_stack.size() - 2]));
-			else
-				mFinder->second = m_stack[m_stack.size() - 2];
-#else
 			m_temp[m_stack.back()] = m_stack[m_stack.size() - 2];
-#endif
 			m_stack.pop_back();
 			m_stack.pop_back();
 			break;

--- a/test/vm.cpp
+++ b/test/vm.cpp
@@ -45,31 +45,11 @@ public:
 
 	u256 store(u256 _n)
 	{
-#ifdef __clang__
-		tuple<u256, u256, u256, map<u256, u256> > & address = addresses[myAddress];
-		map<u256, u256> & third = get<3>(address);
-		auto sFinder = third.find(_n);
-		if (sFinder != third.end())
-			return sFinder->second;
-		else
-			return 0;
-#else
 		return get<3>(addresses[myAddress])[_n];
-#endif
 	}
 	void setStore(u256 _n, u256 _v)
 	{
-#ifdef __clang__
-		tuple<u256, u256, u256, map<u256, u256> > & address = addresses[myAddress];
-		map<u256, u256> & third = get<3>(address);
-		auto sFinder = third.find(_n);
-		if (sFinder != third.end())
-			sFinder->second = _v;
-		else
-			third.insert(std::make_pair(_n, _v));
-#else
 		get<3>(addresses[myAddress])[_n] = _v;
-#endif
 	}
 	void mktx(Transaction& _t)
 	{
@@ -86,17 +66,7 @@ public:
 	u256 txCount(Address _a) { return get<1>(addresses[_a]); }
 	u256 extro(Address _a, u256 _pos)
 	{
-#ifdef __clang__
-		tuple<u256, u256, u256, map<u256, u256> > & address = addresses[_a];
-		map<u256, u256> & third = get<3>(address);
-		auto sFinder = third.find(_pos);
-		if (sFinder != third.end())
-			return sFinder->second;
-		else
-			return 0;
-#else
 		return get<3>(addresses[_a])[_pos];
-#endif
 	}
 	u256 extroPrice(Address _a) { return get<2>(addresses[_a]); }
 	void suicide(Address _a)
@@ -125,19 +95,7 @@ public:
 		get<1>(addresses[_a]) = _myNonce;
 		get<2>(addresses[_a]) = 0;
 		for (unsigned i = 0; i < _myData.size(); ++i)
-#ifdef __clang__
-		{
-			tuple<u256, u256, u256, map<u256, u256> > & address = addresses[_a];
-			map<u256, u256> & third = get<3>(address);
-			auto sFinder = third.find(i);
-			if (sFinder != third.end())
-				sFinder->second = _myData[i];
-			else
-				third.insert(std::make_pair(i, _myData[i]));
-		}
-#else
 			get<3>(addresses[_a])[i] = _myData[i];
-#endif
 	}
 
 	mObject exportEnv()
@@ -245,36 +203,13 @@ public:
 				{
 					u256 adr(j.first);
 					for (auto const& k: j.second.get_array())
-#ifdef __clang__
-					{
-						map<u256, u256> & third = get<3>(a);
-						auto sFinder = third.find(adr);
-						if (sFinder != third.end())
-							sFinder->second = toInt(k);
-						else
-							third.insert(std::make_pair(adr, toInt(k)));
-						adr++;
-					}
-#else
 						get<3>(a)[adr++] = toInt(k);
-#endif
 				}
 			if (o.count("code"))
 			{
 				u256s d = compileLisp(o["code"].get_str());
 				for (unsigned i = 0; i < d.size(); ++i)
-#ifdef __clang__
-				{
-					map<u256, u256> & third = get<3>(a);
-					auto sFinder = third.find(i);
-					if (sFinder != third.end())
-						sFinder->second = d[i];
-					else
-						third.insert(std::make_pair(i, d[i]));
-				}
-#else
 					get<3>(a)[(u256)i] = d[i];
-#endif
 			}
 		}
 	}


### PR DESCRIPTION
Latest XCode release (11/03/2014) includes a fix for the broken map operator[](Apple LLVM 5.1 clang-503.0.38).

This patch removes those workarounds and guards previously necessary for compilation on OSX.
