### PR TITLE
Modified cmake to generate 'make test' target: runs testeth binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,9 @@ if (NOT HEADLESS)
 	add_subdirectory(walleth)
 endif ()
 
+enable_testing()
+add_test(NAME alltests WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test COMMAND testeth)
+
 unset(HEADLESS CACHE)
 #unset(TARGET_PLATFORM CACHE)
 


### PR DESCRIPTION
Still requires the ethereum/tests repo to be git-cloned next to build directory. Will address that in future update
