### PR TITLE
Fixed EXP operation

### DIFF
--- a/libethereum/VM.h
+++ b/libethereum/VM.h
@@ -228,11 +228,12 @@ template <class Ext> eth::bytesConstRef eth::VM::go(Ext& _ext, uint64_t _steps)
 		{
 			// TODO: better implementation?
 			require(2);
-			auto n = m_stack.back();
+			auto base = m_stack.back();
 			auto x = m_stack[m_stack.size() - 2];
 			m_stack.pop_back();
+			u256 n = 1;
 			for (u256 i = 0; i < x; ++i)
-				n *= n;
+				n = (u256) n * base;
 			m_stack.back() = n;
 			break;
 		}


### PR DESCRIPTION
In VM.h the exponential was being calculated incorrectly. This is the simple fix.

Tested using contract:

```
{
    [0x0] "LOOP TESTING"
    (call 0x929b11b8eeea00966e873a241d4b67f7540d1f38 0 0 0 11 0 0)
    (for (MSTORE 0x1 0) (< (MLOAD 0x1) 40) (MSTORE 0x1 (+ (MLOAD 0x1) 1)) (SSTORE (MLOAD 0x1) (* (EXP 2 (MLOAD 0x1)) 0x1)))
}
{
    (call 0x929b11b8eeea00966e873a241d4b67f7540d1f38 0 0 0 0 0 0)
    (suicide)
}
```
