### PR TITLE
alethzero: if ETH_SERPENT is undefined, compiler fails on invalid syntax

### DIFF
--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -987,8 +987,8 @@ void Main::on_data_textChanged()
 					errors.push_back("Serpent " + err);
 				}
 			}
-#endif
 			else
+#endif
 				lll = "<h4>Opt</h4><pre>" + QString::fromStdString(asmcodeopt).toHtmlEscaped() + "</pre><h4>Pre</h4><pre>" + QString::fromStdString(asmcode).toHtmlEscaped() + "</pre>";
 		}
 		QString errs;


### PR DESCRIPTION
Introduced in 75abdad3c4b8afb46ff19ee851515936632b4c02.
