### PR TITLE
Fixed an array bound check in Main::on_debugStep_triggered()

### DIFF
--- a/alethzero/MainWin.cpp
+++ b/alethzero/MainWin.cpp
@@ -1513,7 +1513,7 @@ void Main::on_create_triggered()
 void Main::on_debugStep_triggered()
 {
 	auto l = m_history[ui->debugTimeline->value()].levels.size();
-	if (ui->debugTimeline->value() < m_history.size() && m_history[ui->debugTimeline->value() + 1].levels.size() > l)
+	if ((ui->debugTimeline->value() + 1) < m_history.size() && m_history[ui->debugTimeline->value() + 1].levels.size() > l)
 	{
 		on_debugStepInto_triggered();
 		if (m_history[ui->debugTimeline->value()].levels.size() > l)


### PR DESCRIPTION
Alethzero debugger crashed on me on STOP opcodes.
This off by one check in Main::on_debugStep_triggered() seems to be the cause.
