### PR TITLE
Fixed peer hanging when receiving a bad synchronisation token

### DIFF
--- a/libethereum/PeerSession.cpp
+++ b/libethereum/PeerSession.cpp
@@ -564,7 +564,11 @@ void PeerSession::doRead()
 				while (m_incoming.size() > 8)
 				{
 					if (m_incoming[0] != 0x22 || m_incoming[1] != 0x40 || m_incoming[2] != 0x08 || m_incoming[3] != 0x91)
-						doRead();
+					{
+						cwarn << "INVALID SYNCHRONISATION TOKEN; expected = 22400891; received = " << toHex(bytesConstRef(m_incoming.data(), 4));
+						disconnect(BadProtocol);
+						return;
+					}
 					else
 					{
 						uint32_t len = fromBigEndian<uint32_t>(bytesConstRef(m_incoming.data() + 4, 4));


### PR DESCRIPTION
AlethZero seems to irrevocably hang when peer receives network data with an improper synchronisation token.

How to see it on linux:
- Run AlethZero
- Enable network
- Run `top` or equivalent on a terminal
- Run `dd if=/dev/zero bs=9 count=1 | nc localhost 30303` and watch AlethZero spike to 100% CPU and hang.

---

PS: not knowing how the peer should behave in this case, I assumed it should "gracefully disconnect" like it tries to do with an invalid message.
