### PR TITLE
Deadlock when sending a new transaction; missing coinbase when mining the first block

### DIFF
--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -182,13 +182,16 @@ void BlockChain::run(BlockQueue& _bq, OverlayDB const& _stateDB, std::function<v
 			m_stop.store(false, std::memory_order_release);
 			while (!m_stop.load(std::memory_order_acquire))
 			{
-				std::lock_guard<std::recursive_mutex> l(m_sync);
-				if (_bq.items().first > 0 || _bq.items().second > 0)
 				{
-					h256s blocks = sync(_bq, m_workingStateDB, 100);
-					_cb(blocks, m_workingStateDB);
-				} else
-					this_thread::sleep_for(chrono::milliseconds(250));
+					std::lock_guard<std::recursive_mutex> l(m_sync);
+					if (_bq.items().first > 0 || _bq.items().second > 0)
+					{
+						h256s blocks = sync(_bq, m_workingStateDB, 100);
+						_cb(blocks, m_workingStateDB);
+						continue;
+					}
+				}
+				this_thread::sleep_for(chrono::milliseconds(250));
 			}
 		}));
 }

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -275,7 +275,7 @@ public:
 	/// Change whether we check block validity prior to mining.
 	void setParanoia(bool _p) { m_paranoia = _p; }
 	/// Set the coinbase address.
-	void setAddress(Address _us) { m_preMine.setAddress(_us); }
+	void setAddress(Address _us) { m_preMine.setAddress(_us); m_postMine.setAddress(_us); }
 	/// Get the coinbase address.
 	Address address() const { return m_preMine.address(); }
 	/// Start mining.


### PR DESCRIPTION
When sending a new transaction, the client is very likely to deadlock.

How to reproduce:
- Execute a new transaction, e.g. `(suicide (caller))`

Reason:

BlockChain::run() calls BlockChain::sync() right before checking if its worker thread is running.
The lambda thread locks x_sync in while loop and never unlocks it.
BlockChain::sync() tries to lock x_sync as well.
If BlockChain::run() gets called while its lambda is already running on another thread, its initial call to BlockChain::sync() will be stuck.

---

When the client starts mining before Client::sync() ever got called (e.g. when the client has never seen any new block and there are no pending transactions), the coinbase is null because Client::setAddress() was setting the coinbase only for m_premine

How to reproduce:
- Disable network, kill blockchain, mine one block, check its coinbase and/or your balance
