### PR TITLE
Fix 64-bit VS2013 build

### DIFF
--- a/alethzero/MiningView.h
+++ b/alethzero/MiningView.h
@@ -27,7 +27,9 @@
 
 #include <list>
 #include <QtWidgets/QWidget>
+#ifndef Q_MOC_RUN
 #include <libethereum/Client.h>
+#endif
 
 namespace eth
 {


### PR DESCRIPTION
Do not pull in libethereum/Client.h into QT.
This is not necessary the most sane thing to do, but without it I cannot avoid getting 
C:/Program Files (x86)/Windows Kits/8.1/Include/um/winsock2.h(949): error : Can't concatenate non identifier tokens
erros.
