### PR TITLE
Fixed all the VS2013 build issues.

### DIFF
--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -217,6 +217,16 @@ inline h160 left160(h256 const& _t)
 	return ret;
 }
 
+inline std::string toString(h256s const& _bs)
+{
+	std::ostringstream out;
+	out << "[ ";
+	for (auto i: _bs)
+		out << i.abridged() << ", ";
+	out << "]";
+	return out.str();
+}
+
 }
 
 namespace std

--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -178,10 +178,59 @@ public:
 	/// Converts to string. @throws BadCast if not a string.
 	std::string toStringStrict() const { if (!isData()) throw BadCast(); return payload().cropped(0, length()).toString(); }
 
-	template <class T> std::vector<T> toVector() const { std::vector<T> ret; if (isList()) { ret.reserve(itemCount()); for (auto const& i: *this) ret.push_back((T)i); } return ret; }
-	template <class T> std::set<T> toSet() const { std::set<T> ret; if (isList()) { for (auto const& i: *this) ret.insert((T)i); } return ret; }
-	template <class T, class U> std::pair<T, U> toPair() const { std::pair<T, U> ret; if (isList()) { ret.first = (T)((*this)[0]); ret.second = (U)((*this)[1]); } return ret; }
-	template <class T, size_t N> std::array<T, N> toArray() const { if (itemCount() != N || !isList()) throw BadCast(); std::array<T, N> ret; for (unsigned i = 0; i < N; ++i) ret[i] = (T)operator[](i); return ret; }
+	template <class T>
+	std::vector<T> toVector() const
+	{
+		std::vector<T> ret;
+		if (isList())
+		{
+			ret.reserve(itemCount());
+			for (auto const& i: *this)
+			{
+				ret.push_back((T)i);
+			}
+		 }
+		 return ret;
+	}
+
+	template <class T>
+	std::set<T> toSet() const
+	{
+		std::set<T> ret;
+		if (isList())
+		{
+			for (auto const& i: *this)
+			{
+				ret.insert((T)i);
+			}
+		}
+		return ret;
+	}
+	
+	template <class T, class U>
+	std::pair<T, U> toPair() const
+	{
+		std::pair<T, U> ret;
+		if (isList())
+		{
+			ret.first = (*this)[0].operator T();
+			ret.second = (*this)[1].operator U();
+		}
+		return ret;
+	}
+
+	template <class T, size_t N>
+	std::array<T, N> toArray() const
+	{
+		if (itemCount() != N || !isList())
+			throw BadCast();
+		std::array<T, N> ret;
+		for (unsigned i = 0; i < N; ++i)
+		{
+			ret[i] = (T)operator[](i);
+		}
+		return ret;
+	}
 
 	/// Int conversion flags
 	enum

--- a/libdevcore/_libdevcore.cpp
+++ b/libdevcore/_libdevcore.cpp
@@ -1,0 +1,8 @@
+#include "All.h"
+#include "Common.cpp"
+#include "CommonData.cpp"
+#include "CommonIO.cpp"
+#include "FixedHash.cpp"
+#include "Guards.cpp"
+#include "Log.cpp"
+#include "RLP.cpp"

--- a/libethcore/All.h
+++ b/libethcore/All.h
@@ -3,10 +3,6 @@
 #include "BlockInfo.h"
 #include "CommonEth.h"
 #include "Dagger.h"
-#include "FileSystem.h"
-#include "MemoryDB.h"
-#include "OverlayDB.h"
-#include "SHA3.h"
-#include "TrieCommon.h"
-#include "TrieDB.h"
-#include "UPnP.h"
+#include "CryptoHeaders.h"
+#include "Exceptions.h"
+

--- a/libethcore/_libethcore.cpp
+++ b/libethcore/_libethcore.cpp
@@ -1,0 +1,4 @@
+#include "All.h"
+#include "BlockInfo.cpp"
+#include "CommonEth.cpp"
+#include "Dagger.cpp"

--- a/libethereum/CommonNet.cpp
+++ b/libethereum/CommonNet.cpp
@@ -23,3 +23,6 @@
 using namespace std;
 using namespace dev;
 using namespace dev::eth;
+
+#pragma GCC diagnostic ignored "-Wunused-variable"
+namespace { char dummy; };

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -91,16 +91,6 @@ void EthereumPeer::startInitialSync()
 	}
 }
 
-inline string toString(h256s const& _bs)
-{
-	ostringstream out;
-	out << "[ ";
-	for (auto i: _bs)
-		out << i.abridged() << ", ";
-	out << "]";
-	return out.str();
-}
-
 void EthereumPeer::giveUpOnFetch()
 {
 	clogS(NetNote) << "GIVE UP FETCH; can't get" << toString(m_askedBlocks);

--- a/libethereum/Interface.cpp
+++ b/libethereum/Interface.cpp
@@ -20,3 +20,6 @@
  */
 
 #include "Interface.h"
+
+#pragma GCC diagnostic ignored "-Wunused-variable"
+namespace { char dummy; };

--- a/libethereum/PastMessage.cpp
+++ b/libethereum/PastMessage.cpp
@@ -23,3 +23,6 @@
 using namespace std;
 using namespace dev;
 using namespace dev::eth;
+
+#pragma GCC diagnostic ignored "-Wunused-variable"
+namespace { char dummy; };

--- a/libevm/_libevm.cpp
+++ b/libevm/_libevm.cpp
@@ -1,0 +1,4 @@
+#include "All.h"
+#include "ExtVMFace.cpp"
+#include "FeeStructure.cpp"
+#include "VM.cpp"

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -70,7 +70,7 @@ public:
 	/// Register a peer-capability; all new peer connections will have this capability.
 	template <class T> std::shared_ptr<T> registerCapability(T* _t) { _t->m_host = this; auto ret = std::shared_ptr<T>(_t); m_capabilities[T::staticName()] = ret; return ret; }
 
-	bool haveCapability(std::string const& _name) const { return m_capabilities.count(_name); }
+	bool haveCapability(std::string const& _name) const { return m_capabilities.count(_name) != 0; }
 	std::vector<std::string> caps() const { std::vector<std::string> ret; for (auto const& i: m_capabilities) ret.push_back(i.first); return ret; }
 	template <class T> std::shared_ptr<T> cap() const { try { return std::static_pointer_cast<T>(m_capabilities.at(T::staticName())); } catch (...) { return nullptr; } }
 

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -23,6 +23,7 @@
 
 #include <mutex>
 #include <array>
+#include <deque>
 #include <set>
 #include <memory>
 #include <utility>

--- a/libp2p/_libp2p.cpp
+++ b/libp2p/_libp2p.cpp
@@ -1,0 +1,8 @@
+#include "All.h"
+#include "Capability.cpp"
+#include "Common.cpp"
+#include "Host.cpp"
+#include "HostCapability.cpp"
+#include "Session.cpp"
+#include "UPnP.cpp"
+

--- a/libwhisper/Common.h
+++ b/libwhisper/Common.h
@@ -33,6 +33,7 @@ namespace dev
 namespace shh
 {
 
+/* this makes these symbols ambiguous on VS2013
 using h256 = dev::h256;
 using h512 = dev::h512;
 using h256s = dev::h256s;
@@ -42,6 +43,7 @@ using RLP = dev::RLP;
 using bytesRef = dev::bytesRef;
 using bytesConstRef = dev::bytesConstRef;
 using h256Set = dev::h256Set;
+*/
 
 class WhisperHost;
 class WhisperPeer;

--- a/libwhisper/WhisperPeer.h
+++ b/libwhisper/WhisperPeer.h
@@ -95,7 +95,7 @@ class MessageFilter
 public:
 	MessageFilter() {}
 	MessageFilter(std::vector<std::pair<bytes, bytes> > const& _m): m_topicMasks(_m) {}
-	MessageFilter(RLP const& _r): m_topicMasks((std::vector<std::pair<bytes, bytes> >)_r) {}
+	MessageFilter(RLP const& _r): m_topicMasks(_r.operator std::vector<std::pair<bytes, bytes>>()) {}
 
 	void fillStream(RLPStream& _s) const { _s << m_topicMasks; }
 	h256 sha3() const { RLPStream s; fillStream(s); return dev::eth::sha3(s.out()); }

--- a/libwhisper/_libwhisper.cpp
+++ b/libwhisper/_libwhisper.cpp
@@ -1,0 +1,3 @@
+#include "All.h"
+#include "Common.cpp"
+#include "WhisperPeer.cpp"

--- a/windows/LibEthereum.vcxproj
+++ b/windows/LibEthereum.vcxproj
@@ -19,22 +19,69 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\libethcore\BlockInfo.cpp" />
-    <ClCompile Include="..\libethcore\CommonEth.cpp" />
-    <ClCompile Include="..\libethcore\Dagger.cpp" />
-    <ClCompile Include="..\libethcore\FileSystem.cpp" />
-    <ClCompile Include="..\libethcore\MemoryDB.cpp" />
-    <ClCompile Include="..\libethcore\OverlayDB.cpp" />
-    <ClCompile Include="..\libethcore\SHA3.cpp" />
-    <ClCompile Include="..\libethcore\TrieCommon.cpp" />
-    <ClCompile Include="..\libethcore\TrieDB.cpp" />
-    <ClCompile Include="..\libethcore\UPnP.cpp" />
-    <ClCompile Include="..\libethential\Common.cpp" />
-    <ClCompile Include="..\libethential\CommonData.cpp" />
-    <ClCompile Include="..\libethential\CommonIO.cpp" />
-    <ClCompile Include="..\libethential\FixedHash.cpp" />
-    <ClCompile Include="..\libethential\Log.cpp" />
-    <ClCompile Include="..\libethential\RLP.cpp" />
+    <ClCompile Include="..\libdevcore\CommonData.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\CommonIO.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\FixedHash.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\Guards.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\Log.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\RLP.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\_libdevcore.cpp" />
+    <ClCompile Include="..\libdevcrypto\Common.cpp" />
+    <ClCompile Include="..\libdevcrypto\FileSystem.cpp" />
+    <ClCompile Include="..\libdevcrypto\MemoryDB.cpp" />
+    <ClCompile Include="..\libdevcrypto\OverlayDB.cpp" />
+    <ClCompile Include="..\libdevcrypto\SHA3.cpp" />
+    <ClCompile Include="..\libdevcrypto\TrieCommon.cpp" />
+    <ClCompile Include="..\libdevcrypto\TrieDB.cpp" />
+    <ClCompile Include="..\libethcore\BlockInfo.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libethcore\CommonEth.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libethcore\Dagger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libethcore\_libethcore.cpp" />
     <ClCompile Include="..\libethereum\AccountDiff.cpp" />
     <ClCompile Include="..\libethereum\AddressState.cpp" />
     <ClCompile Include="..\libethereum\BlockChain.cpp" />
@@ -44,9 +91,10 @@
     <ClCompile Include="..\libethereum\CommonNet.cpp" />
     <ClCompile Include="..\libethereum\Defaults.cpp" />
     <ClCompile Include="..\libethereum\EthereumHost.cpp" />
-    <ClCompile Include="..\libethereum\EthereumSession.cpp" />
+    <ClCompile Include="..\libethereum\EthereumPeer.cpp" />
     <ClCompile Include="..\libethereum\Executive.cpp" />
     <ClCompile Include="..\libethereum\ExtVM.cpp" />
+    <ClCompile Include="..\libethereum\Interface.cpp" />
     <ClCompile Include="..\libethereum\Manifest.cpp" />
     <ClCompile Include="..\libethereum\MessageFilter.cpp" />
     <ClCompile Include="..\libethereum\Miner.cpp" />
@@ -56,14 +104,68 @@
     <ClCompile Include="..\libethereum\TransactionQueue.cpp" />
     <ClCompile Include="..\libethereum\Utility.cpp" />
     <ClCompile Include="..\libevmface\Instruction.cpp" />
-    <ClCompile Include="..\libevm\ExtVMFace.cpp" />
-    <ClCompile Include="..\libevm\FeeStructure.cpp" />
-    <ClCompile Include="..\libevm\VM.cpp" />
+    <ClCompile Include="..\libevm\ExtVMFace.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libevm\FeeStructure.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libevm\VM.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libevm\_libevm.cpp" />
     <ClCompile Include="..\liblll\Assembly.cpp" />
     <ClCompile Include="..\liblll\CodeFragment.cpp" />
     <ClCompile Include="..\liblll\Compiler.cpp" />
     <ClCompile Include="..\liblll\CompilerState.cpp" />
     <ClCompile Include="..\liblll\Parser.cpp" />
+    <ClCompile Include="..\libp2p\Capability.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\Host.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\HostCapability.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\Session.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\UPnP.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\_libp2p.cpp" />
+    <ClCompile Include="..\libwhisper\WhisperPeer.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\libwhisper\_libwhisper.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -73,30 +175,114 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\libethcore\All.h" />
-    <ClInclude Include="..\libethcore\BlockInfo.h" />
-    <ClInclude Include="..\libethcore\CommonEth.h" />
-    <ClInclude Include="..\libethcore\CryptoHeaders.h" />
-    <ClInclude Include="..\libethcore\Dagger.h" />
-    <ClInclude Include="..\libethcore\Exceptions.h" />
-    <ClInclude Include="..\libethcore\FileSystem.h" />
-    <ClInclude Include="..\libethcore\MemoryDB.h" />
-    <ClInclude Include="..\libethcore\OverlayDB.h" />
-    <ClInclude Include="..\libethcore\SHA3.h" />
-    <ClInclude Include="..\libethcore\TrieCommon.h" />
-    <ClInclude Include="..\libethcore\TrieDB.h" />
-    <ClInclude Include="..\libethcore\UPnP.h" />
-    <ClInclude Include="..\libethential\All.h" />
-    <ClInclude Include="..\libethential\Common.h" />
-    <ClInclude Include="..\libethential\CommonData.h" />
-    <ClInclude Include="..\libethential\CommonIO.h" />
-    <ClInclude Include="..\libethential\Exceptions.h" />
-    <ClInclude Include="..\libethential\FixedHash.h" />
-    <ClInclude Include="..\libethential\Log.h" />
-    <ClInclude Include="..\libethential\RLP.h" />
-    <ClInclude Include="..\libethential\vector_ref.h" />
+    <ClInclude Include="..\libdevcore\All.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Common.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\CommonData.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\CommonIO.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Exceptions.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\FixedHash.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Guards.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Log.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\RLP.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\vector_ref.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\All.h" />
+    <ClInclude Include="..\libdevcrypto\Common.h" />
+    <ClInclude Include="..\libdevcrypto\CryptoHeaders.h" />
+    <ClInclude Include="..\libdevcrypto\FileSystem.h" />
+    <ClInclude Include="..\libdevcrypto\MemoryDB.h" />
+    <ClInclude Include="..\libdevcrypto\OverlayDB.h" />
+    <ClInclude Include="..\libdevcrypto\SHA3.h" />
+    <ClInclude Include="..\libdevcrypto\TrieCommon.h" />
+    <ClInclude Include="..\libdevcrypto\TrieDB.h" />
+    <ClInclude Include="..\libethcore\All.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\BlockInfo.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\CommonEth.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\CryptoHeaders.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\Dagger.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\Exceptions.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\libethereum\AccountDiff.h" />
     <ClInclude Include="..\libethereum\AddressState.h" />
+    <ClInclude Include="..\libethereum\All.h" />
     <ClInclude Include="..\libethereum\BlockChain.h" />
     <ClInclude Include="..\libethereum\BlockDetails.h" />
     <ClInclude Include="..\libethereum\BlockQueue.h" />
@@ -104,9 +290,10 @@
     <ClInclude Include="..\libethereum\CommonNet.h" />
     <ClInclude Include="..\libethereum\Defaults.h" />
     <ClInclude Include="..\libethereum\EthereumHost.h" />
-    <ClInclude Include="..\libethereum\EthereumSession.h" />
+    <ClInclude Include="..\libethereum\EthereumPeer.h" />
     <ClInclude Include="..\libethereum\Executive.h" />
     <ClInclude Include="..\libethereum\ExtVM.h" />
+    <ClInclude Include="..\libethereum\Interface.h" />
     <ClInclude Include="..\libethereum\Manifest.h" />
     <ClInclude Include="..\libethereum\MessageFilter.h" />
     <ClInclude Include="..\libethereum\Miner.h" />
@@ -116,10 +303,30 @@
     <ClInclude Include="..\libethereum\TransactionQueue.h" />
     <ClInclude Include="..\libethereum\Utility.h" />
     <ClInclude Include="..\libevmface\Instruction.h" />
-    <ClInclude Include="..\libevm\All.h" />
-    <ClInclude Include="..\libevm\ExtVMFace.h" />
-    <ClInclude Include="..\libevm\FeeStructure.h" />
-    <ClInclude Include="..\libevm\VM.h" />
+    <ClInclude Include="..\libevm\All.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libevm\ExtVMFace.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libevm\FeeStructure.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libevm\VM.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\liblll\All.h" />
     <ClInclude Include="..\liblll\Assembly.h" />
     <ClInclude Include="..\liblll\CodeFragment.h" />
@@ -127,6 +334,60 @@
     <ClInclude Include="..\liblll\CompilerState.h" />
     <ClInclude Include="..\liblll\Exceptions.h" />
     <ClInclude Include="..\liblll\Parser.h" />
+    <ClInclude Include="..\libp2p\All.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Capability.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Common.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Host.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\HostCapability.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Session.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\UPnP.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libwhisper\Common.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\libwhisper\WhisperPeer.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>

--- a/windows/LibEthereum.vcxproj.filters
+++ b/windows/LibEthereum.vcxproj.filters
@@ -22,15 +22,6 @@
     <ClCompile Include="..\libethereum\ExtVM.cpp">
       <Filter>libethereum</Filter>
     </ClCompile>
-    <ClCompile Include="..\libethereum\PeerNetwork.cpp">
-      <Filter>libethereum</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethereum\PeerServer.cpp">
-      <Filter>libethereum</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethereum\PeerSession.cpp">
-      <Filter>libethereum</Filter>
-    </ClCompile>
     <ClCompile Include="..\libethereum\State.cpp">
       <Filter>libethereum</Filter>
     </ClCompile>
@@ -39,15 +30,6 @@
     </ClCompile>
     <ClCompile Include="..\libethereum\TransactionQueue.cpp">
       <Filter>libethereum</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\BlockInfo.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\CommonEth.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\Dagger.cpp">
-      <Filter>libethcore</Filter>
     </ClCompile>
     <ClCompile Include="..\libevm\ExtVMFace.cpp">
       <Filter>libevm</Filter>
@@ -58,47 +40,8 @@
     <ClCompile Include="..\libevm\VM.cpp">
       <Filter>libevm</Filter>
     </ClCompile>
-    <ClCompile Include="..\libethential\Common.cpp">
-      <Filter>libethential</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethential\CommonData.cpp">
-      <Filter>libethential</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethential\CommonIO.cpp">
-      <Filter>libethential</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethential\FixedHash.cpp">
-      <Filter>libethential</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethential\Log.cpp">
-      <Filter>libethential</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethential\RLP.cpp">
-      <Filter>libethential</Filter>
-    </ClCompile>
     <ClCompile Include="..\libevmface\Instruction.cpp">
       <Filter>libevmface</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\FileSystem.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\MemoryDB.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\OverlayDB.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\SHA3.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\TrieCommon.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\TrieDB.cpp">
-      <Filter>libethcore</Filter>
-    </ClCompile>
-    <ClCompile Include="..\libethcore\UPnP.cpp">
-      <Filter>libethcore</Filter>
     </ClCompile>
     <ClCompile Include="..\liblll\Assembly.cpp">
       <Filter>liblll</Filter>
@@ -136,6 +79,102 @@
     <ClCompile Include="..\libethereum\AccountDiff.cpp">
       <Filter>libethereum</Filter>
     </ClCompile>
+    <ClCompile Include="..\libdevcrypto\Common.cpp">
+      <Filter>libdevcrypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcrypto\FileSystem.cpp">
+      <Filter>libdevcrypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcrypto\MemoryDB.cpp">
+      <Filter>libdevcrypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcrypto\OverlayDB.cpp">
+      <Filter>libdevcrypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcrypto\SHA3.cpp">
+      <Filter>libdevcrypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcrypto\TrieCommon.cpp">
+      <Filter>libdevcrypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcrypto\TrieDB.cpp">
+      <Filter>libdevcrypto</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethcore\BlockInfo.cpp">
+      <Filter>libethcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethcore\CommonEth.cpp">
+      <Filter>libethcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethcore\Dagger.cpp">
+      <Filter>libethcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\CommonData.cpp">
+      <Filter>libdevcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\CommonIO.cpp">
+      <Filter>libdevcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\FixedHash.cpp">
+      <Filter>libdevcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\Guards.cpp">
+      <Filter>libdevcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\Log.cpp">
+      <Filter>libdevcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\RLP.cpp">
+      <Filter>libdevcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libdevcore\_libdevcore.cpp">
+      <Filter>libdevcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethcore\_libethcore.cpp">
+      <Filter>libethcore</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libevm\_libevm.cpp">
+      <Filter>libevm</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethereum\CommonNet.cpp">
+      <Filter>libethereum</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethereum\EthereumHost.cpp">
+      <Filter>libethereum</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethereum\PastMessage.cpp">
+      <Filter>libethereum</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethereum\EthereumPeer.cpp">
+      <Filter>libethereum</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libethereum\Interface.cpp">
+      <Filter>libethereum</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\Capability.cpp">
+      <Filter>libp2p</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\Host.cpp">
+      <Filter>libp2p</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\HostCapability.cpp">
+      <Filter>libp2p</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\Session.cpp">
+      <Filter>libp2p</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\UPnP.cpp">
+      <Filter>libp2p</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libp2p\_libp2p.cpp">
+      <Filter>libp2p</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libwhisper\_libwhisper.cpp">
+      <Filter>libwhisper</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libwhisper\WhisperPeer.cpp">
+      <Filter>libwhisper</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -159,15 +198,6 @@
     <ClInclude Include="..\libethereum\ExtVM.h">
       <Filter>libethereum</Filter>
     </ClInclude>
-    <ClInclude Include="..\libethereum\PeerNetwork.h">
-      <Filter>libethereum</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethereum\PeerServer.h">
-      <Filter>libethereum</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethereum\PeerSession.h">
-      <Filter>libethereum</Filter>
-    </ClInclude>
     <ClInclude Include="..\libethereum\State.h">
       <Filter>libethereum</Filter>
     </ClInclude>
@@ -176,18 +206,6 @@
     </ClInclude>
     <ClInclude Include="..\libethereum\TransactionQueue.h">
       <Filter>libethereum</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\BlockInfo.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\CommonEth.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\Dagger.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\Exceptions.h">
-      <Filter>libethcore</Filter>
     </ClInclude>
     <ClInclude Include="..\libevm\ExtVMFace.h">
       <Filter>libevm</Filter>
@@ -198,65 +216,11 @@
     <ClInclude Include="..\libevm\VM.h">
       <Filter>libevm</Filter>
     </ClInclude>
-    <ClInclude Include="..\libethential\All.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\Common.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\CommonData.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\CommonIO.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\Exceptions.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\FixedHash.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\Log.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\RLP.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethential\vector_ref.h">
-      <Filter>libethential</Filter>
-    </ClInclude>
     <ClInclude Include="..\libevm\All.h">
       <Filter>libevm</Filter>
     </ClInclude>
     <ClInclude Include="..\libevmface\Instruction.h">
       <Filter>libevmface</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\All.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\CryptoHeaders.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\FileSystem.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\MemoryDB.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\OverlayDB.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\SHA3.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\TrieCommon.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\TrieDB.h">
-      <Filter>libethcore</Filter>
-    </ClInclude>
-    <ClInclude Include="..\libethcore\UPnP.h">
-      <Filter>libethcore</Filter>
     </ClInclude>
     <ClInclude Include="..\liblll\All.h">
       <Filter>liblll</Filter>
@@ -300,6 +264,126 @@
     <ClInclude Include="..\libethereum\AccountDiff.h">
       <Filter>libethereum</Filter>
     </ClInclude>
+    <ClInclude Include="..\libdevcrypto\All.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\Common.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\CryptoHeaders.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\FileSystem.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\MemoryDB.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\OverlayDB.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\SHA3.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\TrieCommon.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcrypto\TrieDB.h">
+      <Filter>libdevcrypto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\All.h">
+      <Filter>libethcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\BlockInfo.h">
+      <Filter>libethcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\CommonEth.h">
+      <Filter>libethcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\CryptoHeaders.h">
+      <Filter>libethcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\Dagger.h">
+      <Filter>libethcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethcore\Exceptions.h">
+      <Filter>libethcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\All.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Common.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\CommonData.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\CommonIO.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Exceptions.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\FixedHash.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Guards.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\Log.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\RLP.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libdevcore\vector_ref.h">
+      <Filter>libdevcore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethereum\CommonNet.h">
+      <Filter>libethereum</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethereum\EthereumHost.h">
+      <Filter>libethereum</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethereum\PastMessage.h">
+      <Filter>libethereum</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethereum\All.h">
+      <Filter>libethereum</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethereum\EthereumPeer.h">
+      <Filter>libethereum</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libethereum\Interface.h">
+      <Filter>libethereum</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\All.h">
+      <Filter>libp2p</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Capability.h">
+      <Filter>libp2p</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Common.h">
+      <Filter>libp2p</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Host.h">
+      <Filter>libp2p</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\HostCapability.h">
+      <Filter>libp2p</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\Session.h">
+      <Filter>libp2p</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libp2p\UPnP.h">
+      <Filter>libp2p</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libwhisper\Common.h">
+      <Filter>libwhisper</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libwhisper\WhisperPeer.h">
+      <Filter>libwhisper</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -317,11 +401,20 @@
     <Filter Include="libevmface">
       <UniqueIdentifier>{ed9ad1b3-700c-47f9-8548-a90b5ef179ac}</UniqueIdentifier>
     </Filter>
-    <Filter Include="libethential">
-      <UniqueIdentifier>{35c32f6c-3f19-4603-8084-1b88ec9ae498}</UniqueIdentifier>
-    </Filter>
     <Filter Include="liblll">
       <UniqueIdentifier>{e6332606-e0ca-48aa-8a6b-303971ba7a93}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libdevcrypto">
+      <UniqueIdentifier>{fae2102b-d574-40fc-9f90-1b9ed0d117ac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libdevcore">
+      <UniqueIdentifier>{35c32f6c-3f19-4603-8084-1b88ec9ae498}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libp2p">
+      <UniqueIdentifier>{fc2cb618-ab0c-45b6-8eb9-6d88e0336fa9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="libwhisper">
+      <UniqueIdentifier>{36748e80-c977-4fee-84e6-699c039dff87}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Updated projects after all the re-potting.
- For simplicity, there's just one VS project for all the libethereum projects, however VS doesn't like duplicate source file names within the same project. To get around this I've created some "single compilation units" for some folders, these probably also compile faster than multiple files.
- Some 32bit only compile errors in RLP (cryptic template ambiguity) were resolved by explicitly invoking operator T() rather than doing a cast to T.
- Moved multiple implementations of toString(h256s const& _bs) into FixedHash.h
- Release shutdown deadlock problem is outstanding.
