### PR TITLE
Add memsize calculation for EXTCODECOPY

### DIFF
--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -157,7 +157,11 @@ template <class Ext> dev::bytesConstRef dev::eth::VM::go(Ext& _ext, OnOpFunc con
 			require(3);
 			newTempSize = memNeed(m_stack.back(), m_stack[m_stack.size() - 3]);
 			break;
-
+		case Instruction::EXTCODECOPY:
+			require(4);
+			newTempSize = memNeed(m_stack[m_stack.size() - 2], m_stack[m_stack.size() - 4]);
+			break;
+			
 		case Instruction::BALANCE:
 			runGas = c_balanceGas;
 			break;


### PR DESCRIPTION
Added memory calculation for EXTCODECOPY op code
Basically same as CODECOPY, but top is address, so reading items one further back on the stack.
