### PR TITLE
Update astyle options

### DIFF
--- a/astylerc
+++ b/astylerc
@@ -6,6 +6,6 @@ min-conditional-indent=1
 pad-oper
 pad-header
 unpad-paren
-delete-empty-lines
 align-pointer=type
-
+keep-one-line-blocks
+close-templates


### PR DESCRIPTION
- "delete-empty-lines" removed as it removes single empty lines also
- "keep-one-line-blocks" added to keep one-line inline methods implementations
- "close-templates" added - places template angle bracket together
