### PR TITLE
Bugfix: Swap before mod and div.

### DIFF
--- a/libsolidity/Compiler.cpp
+++ b/libsolidity/Compiler.cpp
@@ -336,9 +336,11 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 		append(eth::Instruction::MUL);
 		break;
 	case Token::DIV:
+		append(eth::Instruction::SWAP1);
 		append(isSigned ? eth::Instruction::SDIV : eth::Instruction::DIV);
 		break;
 	case Token::MOD:
+		append(eth::Instruction::SWAP1);
 		append(isSigned ? eth::Instruction::SMOD : eth::Instruction::MOD);
 		break;
 	default:

--- a/test/solidityCompiler.cpp
+++ b/test/solidityCompiler.cpp
@@ -193,7 +193,9 @@ BOOST_AUTO_TEST_CASE(arithmetics)
 					   byte(eth::Instruction::SWAP1),
 					   byte(eth::Instruction::SUB),
 					   byte(eth::Instruction::ADD),
+					   byte(eth::Instruction::SWAP1),
 					   byte(eth::Instruction::MOD),
+					   byte(eth::Instruction::SWAP1),
 					   byte(eth::Instruction::DIV),
 					   byte(eth::Instruction::MUL)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());


### PR DESCRIPTION
To compute `a % b`, the compiler first evaluates `a` and then `b` which results in `PUSH1 a PUSH1 b MOD`. This is incorrect since `MOD` computes `stack[0] % stack[1]`. Added `SWAP1` to fix this (can hopefully be optimized out at some later stage).
