### PR TITLE
fixed crashes on shutdown

### DIFF
--- a/alethzero/MainWin.h
+++ b/alethzero/MainWin.h
@@ -255,7 +255,7 @@ private:
 	QString m_logHistory;
 	bool m_logChanged = true;
 
-	std::unique_ptr<WebThreeStubServer> m_server;
 	QWebThreeConnector m_qwebConnector;
+	std::unique_ptr<WebThreeStubServer> m_server;
 	QWebThree* m_qweb = nullptr;
 };

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -62,8 +62,8 @@ Host::Host(std::string const& _clientVersion, NetworkPreferences const& _n, bool
 	m_clientVersion(_clientVersion),
 	m_netPrefs(_n),
 	m_ioService(new ba::io_service),
-	m_acceptor(*m_ioService),
-	m_socket(*m_ioService),
+	m_acceptor(new bi::tcp::acceptor(*m_ioService)),
+	m_socket(new bi::tcp::socket(*m_ioService)),
 	m_key(KeyPair::create())
 {
 	populateAddresses();
@@ -91,11 +91,11 @@ void Host::start()
 		bi::tcp::endpoint endpoint(bi::tcp::v4(), i ? 0 : m_netPrefs.listenPort);
 		try
 		{
-			m_acceptor.open(endpoint.protocol());
-			m_acceptor.set_option(ba::socket_base::reuse_address(true));
-			m_acceptor.bind(endpoint);
-			m_acceptor.listen();
-			m_listenPort = i ? m_acceptor.local_endpoint().port() : m_netPrefs.listenPort;
+			m_acceptor->open(endpoint.protocol());
+			m_acceptor->set_option(ba::socket_base::reuse_address(true));
+			m_acceptor->bind(endpoint);
+			m_acceptor->listen();
+			m_listenPort = i ? m_acceptor->local_endpoint().port() : m_netPrefs.listenPort;
 			break;
 		}
 		catch (...)
@@ -105,7 +105,7 @@ void Host::start()
 				cwarn << "Couldn't start accepting connections on host. Something very wrong with network?\n" << boost::current_exception_diagnostic_information();
 				return;
 			}
-			m_acceptor.close();
+			m_acceptor->close();
 			continue;
 		}
 	}
@@ -118,20 +118,24 @@ void Host::start()
 
 void Host::stop()
 {
+	// if there's no ioService, it means we've had quit() called - bomb out - we're not allowed in here.
+	if (!m_ioService)
+		return;
+
 	for (auto const& h: m_capabilities)
 		h.second->onStopping();
 
 	stopWorking();
 
-	if (m_acceptor.is_open())
+	if (m_acceptor->is_open())
 	{
 		if (m_accepting)
-			m_acceptor.cancel();
-		m_acceptor.close();
+			m_acceptor->cancel();
+		m_acceptor->close();
 		m_accepting = false;
 	}
-	if (m_socket.is_open())
-		m_socket.close();
+	if (m_socket->is_open())
+		m_socket->close();
 	disconnectPeers();
 
 	if (!!m_ioService)
@@ -147,6 +151,8 @@ void Host::quit()
 	// such tasks may involve socket reads from Capabilities that maintain references
 	// to resources we're about to free.
 	stop();
+	m_acceptor.reset();
+	m_socket.reset();
 	m_ioService.reset();
 	// m_acceptor & m_socket are DANGEROUS now.
 }
@@ -463,18 +469,18 @@ void Host::ensureAccepting()
 	{
 		clog(NetConnect) << "Listening on local port " << m_listenPort << " (public: " << m_public << ")";
 		m_accepting = true;
-		m_acceptor.async_accept(m_socket, [=](boost::system::error_code ec)
+		m_acceptor->async_accept(*m_socket, [=](boost::system::error_code ec)
 		{
 			if (!ec)
 			{
 				try
 				{
 					try {
-						clog(NetConnect) << "Accepted connection from " << m_socket.remote_endpoint();
+						clog(NetConnect) << "Accepted connection from " << m_socket->remote_endpoint();
 					} catch (...){}
-					bi::address remoteAddress = m_socket.remote_endpoint().address();
+					bi::address remoteAddress = m_socket->remote_endpoint().address();
 					// Port defaults to 0 - we let the hello tell us which port the peer listens to
-					auto p = std::make_shared<Session>(this, std::move(m_socket), bi::tcp::endpoint(remoteAddress, 0));
+					auto p = std::make_shared<Session>(this, std::move(*m_socket), bi::tcp::endpoint(remoteAddress, 0));
 					p->start();
 				}
 				catch (Exception const& _e)

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -214,8 +214,8 @@ private:
 	int m_listenPort = NetworkStopped;										///< What port are we listening on?
 
 	std::unique_ptr<ba::io_service> m_ioService;							///< IOService for network stuff.
-	bi::tcp::acceptor m_acceptor;											///< Listening acceptor.
-	bi::tcp::socket m_socket;												///< Listening socket.
+	std::unique_ptr<bi::tcp::acceptor> m_acceptor;											///< Listening acceptor.
+	std::unique_ptr<bi::tcp::socket> m_socket;												///< Listening socket.
 
 	UPnP* m_upnp = nullptr;													///< UPnP helper.
 	bi::tcp::endpoint m_public;												///< Our public listening endpoint.


### PR DESCRIPTION
1. In libp2p/Host: m_socked and m_acceptor should not outlive m_ioService, as it is required for proper destruction. Causes a segfault on windows.
   http://www.boost.org/doc/libs/1_56_0/doc/html/boost_asio/reference/basic_io_object/_basic_io_object.html
   http://stackoverflow.com/questions/18553886/clear-boostasioio-service-after-stop
2. In alethzero/MainWin: Changed destruction order to match the reverse construction order. WebThreeStubServer destructor requires connector to be alive.
