### PR TITLE
Fix empty unclesHash for Genesis

### DIFF
--- a/libdevcrypto/SHA3.cpp
+++ b/libdevcrypto/SHA3.cpp
@@ -30,6 +30,7 @@ namespace dev
 {
 
 h256 EmptySHA3 = sha3(bytesConstRef());
+h256 EmptyListSHA3 = sha3(RLPEmptyList);
 
 std::string sha3(std::string const& _input, bool _hex)
 {

--- a/libdevcrypto/SHA3.h
+++ b/libdevcrypto/SHA3.h
@@ -58,6 +58,8 @@ inline h256 sha3(std::string const& _input) { return sha3(bytesConstRef(_input))
 
 extern h256 EmptySHA3;
 
+extern h256 EmptyListSHA3;
+
 // Other crypto convenience routines
 
 bytes aesDecrypt(bytesConstRef _cipher, std::string const& _password, unsigned _rounds = 2000, bytesConstRef _salt = bytesConstRef());

--- a/libethcore/BlockInfo.cpp
+++ b/libethcore/BlockInfo.cpp
@@ -56,8 +56,6 @@ h256 BlockInfo::headerHashWithoutNonce() const
 	return sha3(s.out());
 }
 
-auto static const c_sha3EmptyList = sha3(RLPEmptyList);
-
 void BlockInfo::streamRLP(RLPStream& _s, bool _nonce) const
 {
 	_s.appendList(_nonce ? 15 : 14)

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -103,7 +103,7 @@ bytes BlockChain::createGenesisBlock()
 
 	block.appendList(15)
 			// TODO: maybe make logbloom correct?
-		<< h256() << EmptySHA3 << h160() << stateRoot << EmptyTrie << EmptyTrie << LogBloom() << c_genesisDifficulty << 0 << 0 << 1000000 << 0 << (unsigned)0 << string() << sha3(bytes(1, 42));
+		<< h256() << EmptyListSHA3 << h160() << stateRoot << EmptyTrie << EmptyTrie << LogBloom() << c_genesisDifficulty << 0 << 0 << 1000000 << 0 << (unsigned)0 << string() << sha3(bytes(1, 42));
 	block.appendRaw(RLPEmptyList);
 	block.appendRaw(RLPEmptyList);
 	return block.out();


### PR DESCRIPTION
My guess is that something went wrong during the reversion of empty-list hashes -> ''
The empty uncleHash in the genesis block was not reverted back to `sha3(rlp([]))`  = `sha3('\xc0')`
