### PR TITLE
Bugfix: Special case of statements starting with type conversion.

### DIFF
--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -290,10 +290,10 @@ ASTPointer<Statement> Parser::parseStatement()
 		// We have a variable definition if we ge a keyword that specifies a type name, or
 		// in the case of a user-defined type, we have two identifiers following each other.
 		if (m_scanner->getCurrentToken() == Token::MAPPING ||
-			m_scanner->getCurrentToken() == Token::VAR ||
-			Token::isElementaryTypeName(m_scanner->getCurrentToken()) ||
-			(m_scanner->getCurrentToken() == Token::IDENTIFIER &&
-			 m_scanner->peekNextToken() == Token::IDENTIFIER))
+				m_scanner->getCurrentToken() == Token::VAR ||
+				((Token::isElementaryTypeName(m_scanner->getCurrentToken()) ||
+				m_scanner->getCurrentToken() == Token::IDENTIFIER) &&
+				m_scanner->peekNextToken() == Token::IDENTIFIER))
 			statement = parseVariableDefinition();
 		else // "ordinary" expression
 			statement = parseExpression();

--- a/test/solidityParser.cpp
+++ b/test/solidityParser.cpp
@@ -211,7 +211,15 @@ BOOST_AUTO_TEST_CASE(else_if_statement)
 	BOOST_CHECK_NO_THROW(parseText(text));
 }
 
-
+BOOST_AUTO_TEST_CASE(statement_starting_with_type_conversion)
+{
+	char const* text = "contract test {\n"
+					   "  function fun() {\n"
+					   "    uint64(2);\n"
+					   "  }\n"
+					   "}\n";
+	BOOST_CHECK_NO_THROW(parseText(text));
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Previously, "uint64(2)" was parsed as a variable definition (leading to a parse error), now it is parsed as an expression.
