### PR TITLE
fix for "call to operator << is not visible in template definition" on osx

### DIFF
--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <boost/thread.hpp>
 #include "vector_ref.h"
+#include "CommonIO.h"
 
 namespace dev
 {


### PR DESCRIPTION
[libdevcore/Log.h, 103](https://github.com/ethereum/cpp-ethereum/blob/279c671c46211967afabdd1eaff46d21e9f6f1b5/libdevcore/Log.h#L103) operator << definition was not visible. build was failing on osx.
