### PR TITLE
Fix stackoverflow bug in VM

### DIFF
--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -206,9 +206,7 @@ template <class Ext> dev::bytesConstRef dev::eth::VM::go(Ext& _ext, OnOpFunc con
 		{
 			unsigned n = (unsigned)inst - (unsigned)Instruction::LOG0;
 			require(n + 2);
-			runGas = m_stack[m_stack.size() - 2];
-			runGas *= c_logDataGas;
-			runGas += c_logGas + c_logTopicGas * n;
+			runGas = c_logGas + c_logTopicGas * n + (bigint)c_logDataGas * m_stack[m_stack.size() - 2];
 			newTempSize = memNeed(m_stack[m_stack.size() - 1], m_stack[m_stack.size() - 2]);
 			break;
 		}
@@ -216,8 +214,7 @@ template <class Ext> dev::bytesConstRef dev::eth::VM::go(Ext& _ext, OnOpFunc con
 		case Instruction::CALL:
 		case Instruction::CALLCODE:
 			require(7);
-			runGas = m_stack[m_stack.size() - 1];
-			runGas += c_callGas;
+			runGas = (bigint)c_callGas + m_stack[m_stack.size() - 1];
 			newTempSize = std::max(memNeed(m_stack[m_stack.size() - 6], m_stack[m_stack.size() - 7]), memNeed(m_stack[m_stack.size() - 4], m_stack[m_stack.size() - 5]));
 			break;
 


### PR DESCRIPTION
Values of m_stack can be 2*_256-1 , if one uses an operator such as "+" or "_" the result can become larger than max of u256. But using those operators on two u256 values will always return an u256 value, but we should use bigint properly here. Which is done now. (This fixes the CallRecursiveBomb2 test)
