### PR TITLE
Fix memNeed overflow

### DIFF
--- a/libevm/VM.h
+++ b/libevm/VM.h
@@ -92,7 +92,7 @@ private:
 // INLINE:
 template <class Ext> dev::bytesConstRef dev::eth::VM::go(Ext& _ext, OnOpFunc const& _onOp, uint64_t _steps)
 {
-	auto memNeed = [](dev::u256 _offset, dev::u256 _size) { return _size ? _offset + _size : 0; };
+	auto memNeed = [](dev::u256 _offset, dev::u256 _size) { return _size ? (bigint)_offset + _size : (bigint)0; };
 
 	if (m_jumpDests.empty())
 	{


### PR DESCRIPTION
Otherwise a function such as log can have offset = 2**256-1 and size 1, and the memNeed function would result in 0. This leads to segmentation fault and aborts the client.
