### PR TITLE
Fixing segfault for solc if stdin is given as input file

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -255,7 +255,22 @@ bool CommandLineInterface::processInput()
 	}
 	else
 		for (string const& infile: m_args["input-file"].as<vector<string>>())
+		{
+			auto path = boost::filesystem::path(infile);
+			if (!boost::filesystem::exists(path))
+			{
+				cout << "Skipping non existant input file \"" << infile << "\"" << endl;
+				continue;
+			}
+
+			if (!boost::filesystem::is_regular_file(path))
+			{
+				cout << "\"" << infile << "\" is not a valid file. Skipping" << endl;
+				continue;
+			}
+
 			m_sourceCodes[infile] = asString(dev::contents(infile));
+		}
 
 	try
 	{


### PR DESCRIPTION
- Solc should now check its input files and skip them if they don't
  exist or if they are not a valid file
