### PR TITLE
fixed macdeplyqt path on macos

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -17,6 +17,11 @@ if (WIN32)
 	#set (CMAKE_PREFIX_PATH "C:/Program Files/Windows Kits/8.1/Lib/winv6.3/um/x64")
 endif()
 
+# homebrew installs qts in opt
+if (APPLE)
+	set (CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "/usr/local/opt/qt5")
+endif()
+
 # Dependencies must have a version number, to ensure reproducible build. The version provided here is the one that is in the extdep repository. If you use system libraries, version numbers may be different.
 
 find_package (CryptoPP 5.6.2 EXACT REQUIRED)
@@ -101,6 +106,12 @@ if (NOT HEADLESS)
 	find_package (Qt5Widgets REQUIRED)
 	find_package (Qt5WebKit REQUIRED)
 	find_package (Qt5WebKitWidgets REQUIRED)
+
+	# we need to find path to macdeployqt on mac
+	if (APPLE)
+		set (MACDEPLOYQT_APP ${Qt5Core_DIR}/../../../bin/macdeployqt)
+		message(" - macdeployqt path: ${MACDEPLOYQT_APP}")
+	endif()
 
 endif() #HEADLESS
 

--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -66,7 +66,7 @@ macro(eth_install_executable EXECUTABLE)
 	if (APPLE)
 		# First have qt5 install plugins and frameworks
 		add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
-			COMMAND ${ETH_DEPENDENCY_INSTALL_DIR}/bin/macdeployqt ${eth_qml_dir} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${EXECUTABLE}.app
+			COMMAND ${MACDEPLOYQT_APP} ${eth_qml_dir} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${EXECUTABLE}.app
 			WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 			
 		# This tool and next will inspect linked libraries in order to determine which dependencies are required


### PR DESCRIPTION
fixed macdeployqt path on macos. it's not hardcoded anymore.

*update: it also fixes finding qt packages on mac
