### PR TITLE
ungly fix for compiling exp on mac

### DIFF
--- a/exp/main.cpp
+++ b/exp/main.cpp
@@ -20,6 +20,7 @@
  * Ethereum client.
  */
 #include <functional>
+#include <libethereum/AccountDiff.h>
 #include <libdevcore/Log.h>
 #include <libdevcore/Common.h>
 #include <libdevcore/CommonData.h>


### PR DESCRIPTION
fix for [this line](https://github.com/ethereum/cpp-ethereum/blob/develop/exp/main.cpp#L95) complaining _"operator << should be declared prior to the call or in a namespace dev::eth"_

That's ugly fix. It should be fixed differently in future.
