### PR TITLE
fixed macdeployqt options order

### DIFF
--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -61,12 +61,13 @@ macro(eth_install_executable EXECUTABLE)
 	
 	if (ETH_INSTALL_EXECUTABLE_QMLDIR)
 		set(eth_qml_dir "-qmldir=${ETH_INSTALL_EXECUTABLE_QMLDIR}")
+		message(STATUS "${EXECUTABLE} qmldir: ${eth_qml_dir}")
 	endif()
 
 	if (APPLE)
 		# First have qt5 install plugins and frameworks
 		add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
-			COMMAND ${MACDEPLOYQT_APP} ${eth_qml_dir} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${EXECUTABLE}.app
+			COMMAND ${MACDEPLOYQT_APP} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${EXECUTABLE}.app ${eth_qml_dir}
 			WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 			
 		# This tool and next will inspect linked libraries in order to determine which dependencies are required


### PR DESCRIPTION
macdeployqt options were in wrong order. because of that, mix libraries were not copied to the bundle

thx  @arkpar 
