### PR TITLE
WIP - Re-enable Mining_3_mineBlockWithUncles.

### DIFF
--- a/test/libethereum/BlockChain.cpp
+++ b/test/libethereum/BlockChain.cpp
@@ -192,14 +192,6 @@ BOOST_AUTO_TEST_CASE(Mining_2_mineUncles)
 	testMiningFunc(threadFunc);
 }
 
-
-/*
-
-Often broken test disabled 5th September 2016, until we have time to
-troubleshoot the root cause.
-
-See https://github.com/ethereum/cpp-ethereum/issues/3256.
-
 BOOST_AUTO_TEST_CASE(Mining_3_mineBlockWithUncles)
 {
 	auto const threadFunc = []()
@@ -251,8 +243,6 @@ BOOST_AUTO_TEST_CASE(Mining_3_mineBlockWithUncles)
 
 	testMiningFunc(threadFunc);
 }
-*/
-
 
 /*
 


### PR DESCRIPTION
This test is unreliable, so is currently disabled.

This PR re-adds it, with the intention of exposing the build break.   Then we need to fix it :-)

See https://github.com/ethereum/cpp-ethereum/issues/3256
