### PR TITLE
libp2p - refactoring around Capability

### DIFF
--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -226,7 +226,7 @@ void BlockChainSync::onPeerStatus(std::shared_ptr<EthereumPeer> _peer)
     if (disconnectReason)
     {
         LOG(m_logger) << "Peer not suitable for sync: " << disconnectReason;
-        _peer->disconnect();
+        session->disconnect(UserReason);
         return;
     }
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -236,7 +236,7 @@ bool EthereumPeer::isCriticalSyncing() const
     return m_asking == Asking::BlockHeaders || m_asking == Asking::State || (m_asking == Asking::BlockBodies && m_protocolVersion == 62);
 }
 
-bool EthereumPeer::interpret(unsigned _id, RLP const& _r)
+bool EthereumPeer::interpretCapabilityPacket(unsigned _id, RLP const& _r)
 {
     auto observer = m_observer.lock();
     auto hostData = m_hostData.lock();

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -54,7 +54,7 @@ static string toString(Asking _a)
     return "?";
 }
 
-EthereumPeer::EthereumPeer(std::shared_ptr<SessionFace> _s, std::string const& _name,
+EthereumPeer::EthereumPeer(std::weak_ptr<SessionFace> _s, std::string const& _name,
     unsigned _messageCount, unsigned _offset, CapDesc const& _cap)
   : Capability(std::move(_s), _name, _messageCount, _offset), m_peerCapabilityVersion(_cap.second)
 {

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -54,9 +54,9 @@ static string toString(Asking _a)
     return "?";
 }
 
-EthereumPeer::EthereumPeer(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _i, CapDesc const& _cap):
-    Capability(_s, _h, _i),
-    m_peerCapabilityVersion(_cap.second)
+EthereumPeer::EthereumPeer(std::shared_ptr<SessionFace> _s, std::string const& _name,
+    unsigned _messageCount, unsigned _offset, CapDesc const& _cap)
+  : Capability(_s, _name, _messageCount, _offset), m_peerCapabilityVersion(_cap.second)
 {
     session()->addNote("manners", isRude() ? "RUDE" : "nice");
 }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -56,7 +56,7 @@ static string toString(Asking _a)
 
 EthereumPeer::EthereumPeer(std::shared_ptr<SessionFace> _s, std::string const& _name,
     unsigned _messageCount, unsigned _offset, CapDesc const& _cap)
-  : Capability(_s, _name, _messageCount, _offset), m_peerCapabilityVersion(_cap.second)
+  : Capability(std::move(_s), _name, _messageCount, _offset), m_peerCapabilityVersion(_cap.second)
 {
     session()->addNote("manners", isRude() ? "RUDE" : "nice");
 }

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -87,7 +87,7 @@ class EthereumPeer: public p2p::Capability
 
 public:
     /// Basic constructor.
-    EthereumPeer(std::shared_ptr<p2p::SessionFace> _s, std::string const& _name,
+    EthereumPeer(std::weak_ptr<p2p::SessionFace> _s, std::string const& _name,
         unsigned _messageCount, unsigned _offset, p2p::CapDesc const& _cap);
 
     /// Basic destructor.
@@ -138,7 +138,7 @@ private:
     unsigned askOverride() const;
 
     /// Interpret an incoming message.
-    virtual bool interpretCapabilityPacket(unsigned _id, RLP const& _r);
+    bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override;
 
     /// Request status. Called from constructor
     void requestStatus(u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash);

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -40,7 +40,7 @@ namespace eth
 class EthereumPeerObserverFace
 {
 public:
-    virtual ~EthereumPeerObserverFace() {}
+    virtual ~EthereumPeerObserverFace() = default;
 
     virtual void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) = 0;
 
@@ -64,7 +64,7 @@ public:
 class EthereumHostDataFace
 {
 public:
-    virtual ~EthereumHostDataFace() {}
+    virtual ~EthereumHostDataFace() = default;
 
     virtual std::pair<bytes, unsigned> blockHeaders(RLP const& _blockId, unsigned _maxHeaders, u256 _skip, bool _reverse) const = 0;
 
@@ -91,7 +91,7 @@ public:
         unsigned _messageCount, unsigned _offset, p2p::CapDesc const& _cap);
 
     /// Basic destructor.
-    virtual ~EthereumPeer();
+    ~EthereumPeer() override;
 
     /// What is our name?
     static std::string name() { return "eth"; }

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file EthereumPeer.h
  * @author Gav Wood <i@gavwood.com>
@@ -40,39 +40,39 @@ namespace eth
 class EthereumPeerObserverFace
 {
 public:
-	virtual ~EthereumPeerObserverFace() {}
+    virtual ~EthereumPeerObserverFace() {}
 
-	virtual void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) = 0;
+    virtual void onPeerStatus(std::shared_ptr<EthereumPeer> _peer) = 0;
 
-	virtual void onPeerTransactions(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
+    virtual void onPeerTransactions(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
 
-	virtual void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _headers) = 0;
+    virtual void onPeerBlockHeaders(std::shared_ptr<EthereumPeer> _peer, RLP const& _headers) = 0;
 
-	virtual void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
+    virtual void onPeerBlockBodies(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
 
-	virtual void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes) = 0;
+    virtual void onPeerNewHashes(std::shared_ptr<EthereumPeer> _peer, std::vector<std::pair<h256, u256>> const& _hashes) = 0;
 
-	virtual void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
+    virtual void onPeerNewBlock(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
 
-	virtual void onPeerNodeData(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
+    virtual void onPeerNodeData(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
 
-	virtual void onPeerReceipts(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
+    virtual void onPeerReceipts(std::shared_ptr<EthereumPeer> _peer, RLP const& _r) = 0;
 
-	virtual void onPeerAborting() = 0;
+    virtual void onPeerAborting() = 0;
 };
 
 class EthereumHostDataFace
 {
 public:
-	virtual ~EthereumHostDataFace() {}
+    virtual ~EthereumHostDataFace() {}
 
-	virtual std::pair<bytes, unsigned> blockHeaders(RLP const& _blockId, unsigned _maxHeaders, u256 _skip, bool _reverse) const = 0;
+    virtual std::pair<bytes, unsigned> blockHeaders(RLP const& _blockId, unsigned _maxHeaders, u256 _skip, bool _reverse) const = 0;
 
-	virtual std::pair<bytes, unsigned> blockBodies(RLP const& _blockHashes) const = 0;
+    virtual std::pair<bytes, unsigned> blockBodies(RLP const& _blockHashes) const = 0;
 
-	virtual strings nodeData(RLP const& _dataHashes) const = 0;
+    virtual strings nodeData(RLP const& _dataHashes) const = 0;
 
-	virtual std::pair<bytes, unsigned> receipts(RLP const& _blockHashes) const = 0;
+    virtual std::pair<bytes, unsigned> receipts(RLP const& _blockHashes) const = 0;
 };
 
 /**
@@ -82,118 +82,118 @@ public:
  */
 class EthereumPeer: public p2p::Capability
 {
-	friend class EthereumHost; //TODO: remove this
-	friend class BlockChainSync; //TODO: remove this
+    friend class EthereumHost; //TODO: remove this
+    friend class BlockChainSync; //TODO: remove this
 
 public:
-	/// Basic constructor.
-	EthereumPeer(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& _cap);
+    /// Basic constructor.
+    EthereumPeer(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& _cap);
 
-	/// Basic destructor.
-	virtual ~EthereumPeer();
+    /// Basic destructor.
+    virtual ~EthereumPeer();
 
-	/// What is our name?
-	static std::string name() { return "eth"; }
+    /// What is our name?
+    static std::string name() { return "eth"; }
 
-	/// What is our version?
-	static u256 version() { return c_protocolVersion; }
+    /// What is our version?
+    static u256 version() { return c_protocolVersion; }
 
-	/// How many message types do we have?
-	static unsigned messageCount() { return PacketCount; }
+    /// How many message types do we have?
+    static unsigned messageCount() { return PacketCount; }
 
-	void init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<EthereumHostDataFace> _hostData, std::shared_ptr<EthereumPeerObserverFace> _observer);
+    void init(unsigned _hostProtocolVersion, u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash, std::shared_ptr<EthereumHostDataFace> _hostData, std::shared_ptr<EthereumPeerObserverFace> _observer);
 
-	p2p::NodeID id() const { return session()->id(); }
+    p2p::NodeID id() const { return session()->id(); }
 
-	/// Abort sync and reset fetch
-	void setIdle();
+    /// Abort sync and reset fetch
+    void setIdle();
 
-	/// Request hashes for given parent hash.
-	void requestBlockHeaders(h256 const& _startHash, unsigned _count, unsigned _skip, bool _reverse);
-	void requestBlockHeaders(unsigned _startNumber, unsigned _count, unsigned _skip, bool _reverse);
+    /// Request hashes for given parent hash.
+    void requestBlockHeaders(h256 const& _startHash, unsigned _count, unsigned _skip, bool _reverse);
+    void requestBlockHeaders(unsigned _startNumber, unsigned _count, unsigned _skip, bool _reverse);
 
-	/// Request specified blocks from peer.
-	void requestBlockBodies(h256s const& _blocks);
+    /// Request specified blocks from peer.
+    void requestBlockBodies(h256s const& _blocks);
 
-	/// Request values for specified keys from peer.
-	void requestNodeData(h256s const& _hashes);
+    /// Request values for specified keys from peer.
+    void requestNodeData(h256s const& _hashes);
 
-	/// Request receipts for specified blocks from peer.
-	void requestReceipts(h256s const& _blocks);
+    /// Request receipts for specified blocks from peer.
+    void requestReceipts(h256s const& _blocks);
 
-	/// Check if this node is rude.
-	bool isRude() const;
+    /// Check if this node is rude.
+    bool isRude() const;
 
-	/// Set that it's a rude node.
-	void setRude();
+    /// Set that it's a rude node.
+    void setRude();
 
-	/// Abort the sync operation.
-	void abortSync();
+    /// Abort the sync operation.
+    void abortSync();
 
 private:
-	using p2p::Capability::sealAndSend;
+    using p2p::Capability::sealAndSend;
 
-	/// Figure out the amount of blocks we should be asking for.
-	unsigned askOverride() const;
+    /// Figure out the amount of blocks we should be asking for.
+    unsigned askOverride() const;
 
-	/// Interpret an incoming message.
-	virtual bool interpret(unsigned _id, RLP const& _r);
+    /// Interpret an incoming message.
+    virtual bool interpretCapabilityPacket(unsigned _id, RLP const& _r);
 
-	/// Request status. Called from constructor
-	void requestStatus(u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash);
+    /// Request status. Called from constructor
+    void requestStatus(u256 _hostNetworkId, u256 _chainTotalDifficulty, h256 _chainCurrentHash, h256 _chainGenesisHash);
 
-	/// Clear all known transactions.
-	void clearKnownTransactions() { std::lock_guard<std::mutex> l(x_knownTransactions); m_knownTransactions.clear(); }
+    /// Clear all known transactions.
+    void clearKnownTransactions() { std::lock_guard<std::mutex> l(x_knownTransactions); m_knownTransactions.clear(); }
 
-	// Request of type _packetType with _hashes as input parameters
-	void requestByHashes(h256s const& _hashes, Asking _asking, SubprotocolPacketType _packetType);
+    // Request of type _packetType with _hashes as input parameters
+    void requestByHashes(h256s const& _hashes, Asking _asking, SubprotocolPacketType _packetType);
 
-	/// Update our asking state.
-	void setAsking(Asking _g);
+    /// Update our asking state.
+    void setAsking(Asking _g);
 
-	/// Do we presently need syncing with this peer?
-	bool needsSyncing() const { return !isRude() && !!m_latestHash; }
+    /// Do we presently need syncing with this peer?
+    bool needsSyncing() const { return !isRude() && !!m_latestHash; }
 
-	/// Are we presently in the process of communicating with this peer?
-	bool isConversing() const;
+    /// Are we presently in the process of communicating with this peer?
+    bool isConversing() const;
 
-	/// Are we presently in a critical part of the syncing process with this peer?
-	bool isCriticalSyncing() const;
+    /// Are we presently in a critical part of the syncing process with this peer?
+    bool isCriticalSyncing() const;
 
-	/// Runs period checks to check up on the peer.
-	void tick();
+    /// Runs period checks to check up on the peer.
+    void tick();
 
-	unsigned m_hostProtocolVersion = 0;
+    unsigned m_hostProtocolVersion = 0;
 
-	/// Peer's protocol version.
-	unsigned m_protocolVersion;
+    /// Peer's protocol version.
+    unsigned m_protocolVersion;
 
-	/// Peer's network id.
-	u256 m_networkId;
+    /// Peer's network id.
+    u256 m_networkId;
 
-	/// What, if anything, we last asked the other peer for.
-	Asking m_asking = Asking::Nothing;
-	/// When we asked for it. Allows a time out.
-	std::atomic<time_t> m_lastAsk;
+    /// What, if anything, we last asked the other peer for.
+    Asking m_asking = Asking::Nothing;
+    /// When we asked for it. Allows a time out.
+    std::atomic<time_t> m_lastAsk;
 
-	/// These are determined through either a Status message or from NewBlock.
-	h256 m_latestHash;						///< Peer's latest block's hash that we know about or default null value if no need to sync.
-	u256 m_totalDifficulty;					///< Peer's latest block's total difficulty.
-	h256 m_genesisHash;						///< Peer's genesis hash
+    /// These are determined through either a Status message or from NewBlock.
+    h256 m_latestHash;						///< Peer's latest block's hash that we know about or default null value if no need to sync.
+    u256 m_totalDifficulty;					///< Peer's latest block's total difficulty.
+    h256 m_genesisHash;						///< Peer's genesis hash
 
-	u256 const m_peerCapabilityVersion;			///< Protocol version this peer supports received as capability
-	/// Have we received a GetTransactions packet that we haven't yet answered?
-	bool m_requireTransactions = false;
+    u256 const m_peerCapabilityVersion;			///< Protocol version this peer supports received as capability
+    /// Have we received a GetTransactions packet that we haven't yet answered?
+    bool m_requireTransactions = false;
 
-	Mutex x_knownBlocks;
-	h256Hash m_knownBlocks;					///< Blocks that the peer already knows about (that don't need to be sent to them).
-	Mutex x_knownTransactions;
-	h256Hash m_knownTransactions;			///< Transactions that the peer already knows of.
-	unsigned m_unknownNewBlocks = 0;		///< Number of unknown NewBlocks received from this peer
-	unsigned m_lastAskedHeaders = 0;		///< Number of hashes asked
+    Mutex x_knownBlocks;
+    h256Hash m_knownBlocks;					///< Blocks that the peer already knows about (that don't need to be sent to them).
+    Mutex x_knownTransactions;
+    h256Hash m_knownTransactions;			///< Transactions that the peer already knows of.
+    unsigned m_unknownNewBlocks = 0;		///< Number of unknown NewBlocks received from this peer
+    unsigned m_lastAskedHeaders = 0;		///< Number of hashes asked
 
-	std::weak_ptr<EthereumPeerObserverFace> m_observer;
-	std::weak_ptr<EthereumHostDataFace> m_hostData;
+    std::weak_ptr<EthereumPeerObserverFace> m_observer;
+    std::weak_ptr<EthereumHostDataFace> m_hostData;
 
     Logger m_logger{createLogger(VerbosityDebug, "peer")};
     /// Logger for messages about impolite behaivour of peers.

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -87,7 +87,8 @@ class EthereumPeer: public p2p::Capability
 
 public:
     /// Basic constructor.
-    EthereumPeer(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& _cap);
+    EthereumPeer(std::shared_ptr<p2p::SessionFace> _s, std::string const& _name,
+        unsigned _messageCount, unsigned _offset, p2p::CapDesc const& _cap);
 
     /// Basic destructor.
     virtual ~EthereumPeer();

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -56,7 +56,7 @@ void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId
         _chainGenesisHash, snapshotBlockHash, snapshotBlockNumber);
 }
 
-bool WarpPeerCapability::interpret(unsigned _id, RLP const& _r)
+bool WarpPeerCapability::interpretCapabilityPacket(unsigned _id, RLP const& _r)
 {
     std::shared_ptr<WarpPeerObserverFace> observer(m_observer.lock());
     // TODO: we still want to answer some messages when we only give out imported snapshot

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -27,8 +27,9 @@ namespace dev
 namespace eth
 {
 WarpPeerCapability::WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s,
-    p2p::HostCapabilityFace* _h, unsigned _i, p2p::CapDesc const& /* _cap */)
-  : Capability(_s, _h, _i)
+    std::string const& _name, unsigned _messageCount, unsigned _offset,
+    p2p::CapDesc const& /* _cap */)
+  : Capability(_s, _name, _messageCount, _offset)
 {}
 
 void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId,

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -26,9 +26,8 @@ namespace dev
 {
 namespace eth
 {
-WarpPeerCapability::WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s,
-    std::string const& _name, unsigned _messageCount, unsigned _offset,
-    p2p::CapDesc const& /* _cap */)
+WarpPeerCapability::WarpPeerCapability(std::weak_ptr<p2p::SessionFace> _s, std::string const& _name,
+    unsigned _messageCount, unsigned _offset, p2p::CapDesc const& /* _cap */)
   : Capability(std::move(_s), _name, _messageCount, _offset)
 {}
 

--- a/libethereum/WarpPeerCapability.cpp
+++ b/libethereum/WarpPeerCapability.cpp
@@ -29,7 +29,7 @@ namespace eth
 WarpPeerCapability::WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s,
     std::string const& _name, unsigned _messageCount, unsigned _offset,
     p2p::CapDesc const& /* _cap */)
-  : Capability(_s, _name, _messageCount, _offset)
+  : Capability(std::move(_s), _name, _messageCount, _offset)
 {}
 
 void WarpPeerCapability::init(unsigned _hostProtocolVersion, u256 _hostNetworkId,

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -61,8 +61,8 @@ public:
 class WarpPeerCapability : public p2p::Capability
 {
 public:
-    WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, p2p::HostCapabilityFace* _h,
-        unsigned _i, p2p::CapDesc const& _cap);
+    WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, std::string const& _name,
+        unsigned _messageCount, unsigned _offset, p2p::CapDesc const& _cap);
 
     static std::string name() { return "par"; }
 

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -97,7 +97,7 @@ public:
 private:
     using p2p::Capability::sealAndSend;
 
-    bool interpret(unsigned _id, RLP const& _r) override;
+    bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override;
 
     void onDisconnect() override;
 

--- a/libethereum/WarpPeerCapability.h
+++ b/libethereum/WarpPeerCapability.h
@@ -61,7 +61,7 @@ public:
 class WarpPeerCapability : public p2p::Capability
 {
 public:
-    WarpPeerCapability(std::shared_ptr<p2p::SessionFace> _s, std::string const& _name,
+    WarpPeerCapability(std::weak_ptr<p2p::SessionFace> _s, std::string const& _name,
         unsigned _messageCount, unsigned _offset, p2p::CapDesc const& _cap);
 
     static std::string name() { return "par"; }

--- a/libp2p/Capability.cpp
+++ b/libp2p/Capability.cpp
@@ -35,12 +35,6 @@ Capability::Capability(std::shared_ptr<SessionFace> _s, string const& _name, uns
     cnetdetails << "New session for capability " << m_name << "; idOffset: " << m_idOffset;
 }
 
-void Capability::disconnect()
-{
-    if (auto s = session())
-        s->disconnect(UserReason);
-}
-
 void Capability::disable(std::string const& _problem)
 {
     cnetdetails << "DISABLE: Disabling capability '" << m_name << "'. Reason: " << _problem;

--- a/libp2p/Capability.cpp
+++ b/libp2p/Capability.cpp
@@ -28,8 +28,8 @@ using namespace std;
 using namespace dev;
 using namespace dev::p2p;
 
-Capability::Capability(std::shared_ptr<SessionFace> _s, string const& _name, unsigned _messageCount,
-    unsigned _idOffset)
+Capability::Capability(
+    std::weak_ptr<SessionFace> _s, string const& _name, unsigned _messageCount, unsigned _idOffset)
   : m_session(std::move(_s)), m_name(_name), m_messageCount(_messageCount), m_idOffset(_idOffset)
 {
     cnetdetails << "New session for capability " << m_name << "; idOffset: " << m_idOffset;

--- a/libp2p/Capability.cpp
+++ b/libp2p/Capability.cpp
@@ -30,7 +30,7 @@ using namespace dev::p2p;
 
 Capability::Capability(std::shared_ptr<SessionFace> _s, string const& _name, unsigned _messageCount,
     unsigned _idOffset)
-  : m_session(_s), m_name(_name), m_messageCount(_messageCount), m_idOffset(_idOffset)
+  : m_session(std::move(_s)), m_name(_name), m_messageCount(_messageCount), m_idOffset(_idOffset)
 {
     cnetdetails << "New session for capability " << m_name << "; idOffset: " << m_idOffset;
 }

--- a/libp2p/Capability.cpp
+++ b/libp2p/Capability.cpp
@@ -28,11 +28,11 @@ using namespace std;
 using namespace dev;
 using namespace dev::p2p;
 
-Capability::Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset):
-    m_session(_s), m_hostCap(_h), m_idOffset(_idOffset)
+Capability::Capability(std::shared_ptr<SessionFace> _s, string const& _name, unsigned _messageCount,
+    unsigned _idOffset)
+  : m_session(_s), m_name(_name), m_messageCount(_messageCount), m_idOffset(_idOffset)
 {
-    cnetdetails << "New session for capability " << m_hostCap->name()
-                << "; idOffset: " << m_idOffset;
+    cnetdetails << "New session for capability " << m_name << "; idOffset: " << m_idOffset;
 }
 
 void Capability::disconnect()
@@ -43,8 +43,7 @@ void Capability::disconnect()
 
 void Capability::disable(std::string const& _problem)
 {
-    cnetdetails << "DISABLE: Disabling capability '" << m_hostCap->name()
-                << "'. Reason: " << _problem;
+    cnetdetails << "DISABLE: Disabling capability '" << m_name << "'. Reason: " << _problem;
     m_enabled = false;
 }
 

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -34,7 +34,7 @@ class ReputationManager;
 class Capability: public std::enable_shared_from_this<Capability>
 {
 public:
-    Capability(std::shared_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
+    Capability(std::weak_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
         unsigned _idOffset);
     virtual ~Capability() = default;
 

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -36,7 +36,7 @@ class Capability: public std::enable_shared_from_this<Capability>
 public:
     Capability(std::shared_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
         unsigned _idOffset);
-    virtual ~Capability() {}
+    virtual ~Capability() = default;
 
     // Implement these in the derived class.
     // static std::string name() { return ""; }

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -54,9 +54,6 @@ public:
         return interpretCapabilityPacket(_packetType - m_idOffset, _rlp);
     }
 
-    void disconnect();
-
-    // TODO replace with a signal in Session
     virtual void onDisconnect() {}
 
 protected:

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -34,18 +34,19 @@ class ReputationManager;
 class Capability: public std::enable_shared_from_this<Capability>
 {
 public:
-    Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset);
+    Capability(std::shared_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
+        unsigned _idOffset);
     virtual ~Capability() {}
 
-    /*  TODO
-        virtual std::string name() = 0;
-        virtual u256 version() = 0;
-        virtual unsigned messageCount() = 0;
-    */
+    // Implement these in the derived class.
+    // static std::string name() { return ""; }
+    // static u256 version() { return 0; }
+    // static unsigned messageCount() { return 0; }
+
     bool enabled() const { return m_enabled; }
     bool canHandle(unsigned _packetType) const
     {
-        return _packetType >= m_idOffset && _packetType < m_hostCap->messageCount() + m_idOffset;
+        return _packetType >= m_idOffset && _packetType < m_messageCount + m_idOffset;
     }
 
     bool interpret(unsigned _packetType, RLP const& _rlp)
@@ -70,9 +71,10 @@ protected:
 
 private:
     std::weak_ptr<SessionFace> m_session;
-    HostCapabilityFace* m_hostCap;
     bool m_enabled = true;
-    unsigned m_idOffset;
+    std::string const m_name;
+    unsigned const m_messageCount;
+    unsigned const m_idOffset;
 };
 
 }

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -33,28 +33,36 @@ class ReputationManager;
 
 class Capability: public std::enable_shared_from_this<Capability>
 {
-    friend class Session;
-
 public:
     Capability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset);
     virtual ~Capability() {}
 
-    // Implement these in the derived class.
-/*  static std::string name() { return ""; }
-    static u256 version() { return 0; }
-    static unsigned messageCount() { return 0; }
-*/
-
+    /*  TODO
+        virtual std::string name() = 0;
+        virtual u256 version() = 0;
+        virtual unsigned messageCount() = 0;
+    */
     bool enabled() const { return m_enabled; }
+    bool canHandle(PacketType _packetType) const
+    {
+        return static_cast<unsigned>(_packetType) >= m_idOffset &&
+               static_cast<unsigned>(_packetType) < m_hostCap->messageCount() + m_idOffset;
+    }
+
+    // TODO is PacketType reasonable type here, enum arithmetics is weird
+    bool interpret(PacketType _packetType, RLP const& _rlp)
+    {
+        return interpret(_packetType - m_idOffset, _rlp);
+    }
 
     void disconnect();
 
+    // TODO replace with a signal in Session
+    virtual void onDisconnect() {}
+
 protected:
     std::shared_ptr<SessionFace> session() const { return m_session.lock(); }
-    HostCapabilityFace* hostCapability() const { return m_hostCap; }
-
     virtual bool interpret(unsigned _id, RLP const&) = 0;
-    virtual void onDisconnect() {}
 
     void disable(std::string const& _problem);
 

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -43,16 +43,14 @@ public:
         virtual unsigned messageCount() = 0;
     */
     bool enabled() const { return m_enabled; }
-    bool canHandle(PacketType _packetType) const
+    bool canHandle(unsigned _packetType) const
     {
-        return static_cast<unsigned>(_packetType) >= m_idOffset &&
-               static_cast<unsigned>(_packetType) < m_hostCap->messageCount() + m_idOffset;
+        return _packetType >= m_idOffset && _packetType < m_hostCap->messageCount() + m_idOffset;
     }
 
-    // TODO is PacketType reasonable type here, enum arithmetics is weird
-    bool interpret(PacketType _packetType, RLP const& _rlp)
+    bool interpret(unsigned _packetType, RLP const& _rlp)
     {
-        return interpret(_packetType - m_idOffset, _rlp);
+        return interpretCapabilityPacket(_packetType - m_idOffset, _rlp);
     }
 
     void disconnect();
@@ -62,7 +60,7 @@ public:
 
 protected:
     std::shared_ptr<SessionFace> session() const { return m_session.lock(); }
-    virtual bool interpret(unsigned _id, RLP const&) = 0;
+    virtual bool interpretCapabilityPacket(unsigned _id, RLP const&) = 0;
 
     void disable(std::string const& _problem);
 

--- a/libp2p/HostCapability.h
+++ b/libp2p/HostCapability.h
@@ -64,7 +64,7 @@ public:
     std::shared_ptr<Capability> newPeerCapability(
         std::shared_ptr<SessionFace> const& _s, unsigned _idOffset, CapDesc const& _cap) override
     {
-        auto p = std::make_shared<PeerCap>(_s, this, _idOffset, _cap);
+        auto p = std::make_shared<PeerCap>(_s, name(), messageCount(), _idOffset, _cap);
         _s->registerCapability(_cap, p);
         return p;
     }

--- a/libp2p/HostCapability.h
+++ b/libp2p/HostCapability.h
@@ -64,7 +64,8 @@ public:
     std::shared_ptr<Capability> newPeerCapability(
         std::shared_ptr<SessionFace> const& _s, unsigned _idOffset, CapDesc const& _cap) override
     {
-        auto p = std::make_shared<PeerCap>(_s, name(), messageCount(), _idOffset, _cap);
+        auto p = std::make_shared<PeerCap>(
+            std::weak_ptr<SessionFace>{_s}, name(), messageCount(), _idOffset, _cap);
         _s->registerCapability(_cap, p);
         return p;
     }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -116,28 +116,27 @@ template <class T> vector<T> randomSelection(vector<T> const& _t, unsigned _n)
     return ret;
 }
 
-bool Session::readPacket(uint16_t _capId, PacketType _t, RLP const& _r)
+bool Session::readPacket(uint16_t _capId, PacketType _packetType, RLP const& _r)
 {
     m_lastReceived = chrono::steady_clock::now();
-    clog(VerbosityTrace, "net") << "-> " << _t << " " << _r;
+    clog(VerbosityTrace, "net") << "-> " << _packetType << " " << _r;
     try // Generic try-catch block designed to capture RLP format errors - TODO: give decent diagnostics, make a bit more specific over what is caught.
     {
         // v4 frame headers are useless, offset packet type used
         // v5 protocol type is in header, packet type not offset
-        if (_capId == 0 && _t < UserPacket)
-            return interpret(_t, _r);
+        if (_capId == 0 && _packetType < UserPacket)
+            return interpret(_packetType, _r);
 
         for (auto const& i: m_capabilities)
-            if (_t >= (int)i.second->m_idOffset && _t - i.second->m_idOffset < i.second->hostCapability()->messageCount())
-                return i.second->enabled() ? i.second->interpret(_t - i.second->m_idOffset, _r) :
-                                             true;
+            if (i.second->canHandle(_packetType))
+                return i.second->enabled() ? i.second->interpret(_packetType, _r) : true;
 
         return false;
     }
     catch (std::exception const& _e)
     {
         cnetlog << "Exception caught in p2p::Session::interpret(): " << _e.what()
-                << ". PacketType: " << _t << ". RLP: " << _r;
+                << ". PacketType: " << _packetType << ". RLP: " << _r;
         disconnect(BadProtocol);
         return true;
     }

--- a/test/unittests/libethereum/EthereumPeerTest.cpp
+++ b/test/unittests/libethereum/EthereumPeerTest.cpp
@@ -111,11 +111,11 @@ public:
 class EthereumPeerTestFixture: public TestOutputHelperFixture
 {
 public:
-    EthereumPeerTestFixture():
-        session(std::make_shared<MockSession>()),
+    EthereumPeerTestFixture()
+      : session(std::make_shared<MockSession>()),
         observer(std::make_shared<MockEthereumPeerObserver>()),
         offset(UserPacket),
-        peer(session, &hostCap, offset, { "eth", 0 })
+        peer(session, hostCap.name(), hostCap.messageCount(), offset, {"eth", 0})
     {
         peer.init(63, 2, 0, h256(0), h256(0), std::shared_ptr<EthereumHostDataFace>(), observer);
     }

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -44,7 +44,10 @@ struct P2PFixture: public TestOutputHelperFixture
 class TestCapability: public Capability
 {
 public:
-    TestCapability(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset, CapDesc const&): Capability(_s, _h, _idOffset), m_cntReceivedMessages(0), m_testSum(0) {}
+    TestCapability(std::shared_ptr<SessionFace> _s, std::string const& _name,
+        unsigned _messageCount, unsigned _idOffset, CapDesc const&)
+      : Capability(_s, _name, _messageCount, _idOffset), m_cntReceivedMessages(0), m_testSum(0)
+    {}
     virtual ~TestCapability() {}
     int countReceivedMessages() { return m_cntReceivedMessages; }
     int testSum() { return m_testSum; }

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -44,11 +44,10 @@ struct P2PFixture: public TestOutputHelperFixture
 class TestCapability: public Capability
 {
 public:
-    TestCapability(std::shared_ptr<SessionFace> _s, std::string const& _name,
-        unsigned _messageCount, unsigned _idOffset, CapDesc const&)
+    TestCapability(std::weak_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
+        unsigned _idOffset, CapDesc const&)
       : Capability(_s, _name, _messageCount, _idOffset), m_cntReceivedMessages(0), m_testSum(0)
     {}
-    virtual ~TestCapability() {}
     int countReceivedMessages() { return m_cntReceivedMessages; }
     int testSum() { return m_testSum; }
     static std::string name() { return "test"; }
@@ -57,7 +56,7 @@ public:
     void sendTestMessage(int _i) { RLPStream s; sealAndSend(prep(s, UserPacket, 1) << _i); }
 
 protected:
-    virtual bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override;
+    bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override;
 
     int m_cntReceivedMessages;
     int m_testSum;

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -54,13 +54,13 @@ public:
     void sendTestMessage(int _i) { RLPStream s; sealAndSend(prep(s, UserPacket, 1) << _i); }
 
 protected:
-    virtual bool interpret(unsigned _id, RLP const& _r) override;
+    virtual bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override;
 
     int m_cntReceivedMessages;
     int m_testSum;
 };
 
-bool TestCapability::interpret(unsigned _id, RLP const& _r) 
+bool TestCapability::interpretCapabilityPacket(unsigned _id, RLP const& _r)
 {
     //cnote << "Capability::interpret(): custom message received";
     ++m_cntReceivedMessages;

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -50,7 +50,10 @@ public:
     static unsigned messageCount() { return UserPacket + 1; }
 
 protected:
-    virtual bool interpret(unsigned _id, RLP const& _r) override { return _id > 0 || _r.size() > 0; }
+    virtual bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override
+    {
+        return _id > 0 || _r.size() > 0;
+    }
 };
 
 class TestHostCap: public HostCapability<TestCap>, public Worker

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -43,7 +43,10 @@ struct P2PPeerFixture: public TestOutputHelperFixture
 class TestCap: public Capability
 {
 public:
-    TestCap(std::shared_ptr<SessionFace> _s, HostCapabilityFace* _h, unsigned _idOffset, CapDesc const&): Capability(_s, _h, _idOffset) {}
+    TestCap(std::shared_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
+        unsigned _idOffset, CapDesc const&)
+      : Capability(_s, _name, _messageCount, _idOffset)
+    {}
     virtual ~TestCap() {}
     static std::string name() { return "p2pTestCapability"; }
     static u256 version() { return 2; }

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -43,17 +43,16 @@ struct P2PPeerFixture: public TestOutputHelperFixture
 class TestCap: public Capability
 {
 public:
-    TestCap(std::shared_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
+    TestCap(std::weak_ptr<SessionFace> _s, std::string const& _name, unsigned _messageCount,
         unsigned _idOffset, CapDesc const&)
       : Capability(_s, _name, _messageCount, _idOffset)
     {}
-    virtual ~TestCap() {}
     static std::string name() { return "p2pTestCapability"; }
     static u256 version() { return 2; }
     static unsigned messageCount() { return UserPacket + 1; }
 
 protected:
-    virtual bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override
+    bool interpretCapabilityPacket(unsigned _id, RLP const& _r) override
     {
         return _id > 0 || _r.size() > 0;
     }


### PR DESCRIPTION
- Got rid of `Session` being friend of `Capability`
- Got rid of raw pointer to `HostCapabilityFace` as a member of `Capability`
- Removed `Capability::disconnect()` (`SessionFace::disconnect` is enough for this)

A couple of small refactoring more will go to the next PR.