### PR TITLE
Change formula for CREATE2 address

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -366,7 +366,7 @@ bool Executive::createOpcode(Address const& _sender, u256 const& _endowment, u25
 
 bool Executive::create2Opcode(Address const& _sender, u256 const& _endowment, u256 const& _gasPrice, u256 const& _gas, bytesConstRef _init, Address const& _origin, u256 const& _salt)
 {
-    m_newAddress = right160(sha3(_sender.asBytes() + toBigEndian(_salt) + _init));
+    m_newAddress = right160(sha3(bytes{0xff} +_sender.asBytes() + toBigEndian(_salt) + sha3(_init)));
     return executeCreate(_sender, _endowment, _gasPrice, _gas, _init, _origin);
 }
 

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -133,7 +133,7 @@ public:
     bytes code = fromHex("368060006000376101238160006000f55050");
 
     Address expectedAddress =
-        right160(sha3(address.asBytes() + toBigEndian(0x123_cppui256) + inputData));
+        right160(sha3(fromHex("ff") +address.asBytes() + toBigEndian(0x123_cppui256) + sha3(inputData)));
 
     std::unique_ptr<VMFace> vm;
 };


### PR DESCRIPTION
The consensus about CREATE2 address calculation leans towards the formula
```
sha3( 0xff ++ msg.sender ++ salt ++ SHA3(init_code)))
```
https://github.com/ethereum/EIPs/pull/1014#issuecomment-412106601

cc @winsvega 