### PR TITLE
Upgrade Hera

### DIFF
--- a/libevm/VMFactory.cpp
+++ b/libevm/VMFactory.cpp
@@ -28,7 +28,7 @@
 #endif
 
 #if ETH_HERA
-#include <hera.h>
+#include <hera/hera.h>
 #endif
 
 namespace po = boost::program_options;


### PR DESCRIPTION
Hera is moving its public header. This change pulls the Hera with the moved header and adjust include path in Aleth.

This will go to Aleth 1.4 to allow Hera testing with this version.