### PR TITLE
fix NoProof block signature

### DIFF
--- a/libethashseal/Ethash.h
+++ b/libethashseal/Ethash.h
@@ -66,7 +66,6 @@ public:
 
     eth::GenericFarm<EthashProofOfWork>& farm() { return m_farm; }
 
-    enum { MixHashField = 0, NonceField = 1 };
     static h256 seedHash(BlockHeader const& _bi);
     static Nonce nonce(BlockHeader const& _bi) { return _bi.seal<Nonce>(NonceField); }
     static h256 mixHash(BlockHeader const& _bi) { return _bi.seal<h256>(MixHashField); }

--- a/libethcore/BasicAuthority.cpp
+++ b/libethcore/BasicAuthority.cpp
@@ -50,8 +50,11 @@ void BasicAuthority::generateSeal(BlockHeader const& _bi)
 	BlockHeader bi = _bi;
 	h256 h = bi.hash(WithoutSeal);
 	Signature s = sign(m_secret, h);
-	setSig(bi, s);
-	SealEngineBase::generateSeal(bi);
+    setSig(bi, s);
+    RLPStream ret;
+    bi.streamRLP(ret);
+    if (m_onSealGenerated)
+        m_onSealGenerated(ret.out());
 }
 
 bool BasicAuthority::onOptionChanging(std::string const& _name, bytes const& _value)

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -29,6 +29,17 @@ void NoProof::init()
     ETH_REGISTER_SEAL_ENGINE(NoProof);
 }
 
+void NoProof::generateSeal(BlockHeader const& _bi)
+{
+    BlockHeader header(_bi);
+    header.setSeal(NonceField, h64{0});
+    header.setSeal(MixHashField, h256{0});
+    RLPStream ret;
+    header.streamRLP(ret);
+    if (m_onSealGenerated)
+        m_onSealGenerated(ret.out());
+}
+
 void SealEngineFace::verify(Strictness _s, BlockHeader const& _bi, BlockHeader const& _parent, bytesConstRef _block) const
 {
     _bi.verify(_s, _parent, _block);

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -97,14 +97,12 @@ private:
 class SealEngineBase: public SealEngineFace
 {
 public:
-	void generateSeal(BlockHeader const& _bi) override
-	{
-		RLPStream ret;
-		_bi.streamRLP(ret);
-		if (m_onSealGenerated)
-			m_onSealGenerated(ret.out());
-	}
-	void onSealGenerated(std::function<void(bytes const&)> const& _f) override { m_onSealGenerated = _f; }
+    enum
+    {
+        MixHashField = 0,
+        NonceField = 1
+    };
+    void onSealGenerated(std::function<void(bytes const&)> const& _f) override { m_onSealGenerated = _f; }
 	EVMSchedule const& evmSchedule(u256 const& _blockNumber) const override;
 	u256 blockReward(u256 const& _blockNumber) const override;
 
@@ -139,6 +137,7 @@ class NoProof: public eth::SealEngineBase
 public:
     static std::string name() { return "NoProof"; }
     static void init();
+    void generateSeal(BlockHeader const& _bi) override;
 };
 
 }

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -112,8 +112,12 @@ json_spirit::mValue StateTestSuite::doTests(json_spirit::mValue const& _input, b
 			if (!foundResults)
 			{
 				Options const& opt = Options::get();
-				BOOST_ERROR("Transaction not found! (Network: " + (opt.singleTestNet.empty() ? "Any" : opt.singleTestNet) + ", dataInd: " + toString(opt.trDataIndex) + ", gasInd: " + toString(opt.trGasIndex) + ", valInd: " + toString(opt.trValueIndex) + ")");
-			}
+                BOOST_ERROR("Transaction not found! (Test: '" + testname + "', Network: " +
+                            (opt.singleTestNet.empty() ? "Any" : opt.singleTestNet) +
+                            ", dataInd: " + toString(opt.trDataIndex) +
+                            ", gasInd: " + toString(opt.trGasIndex) +
+                            ", valInd: " + toString(opt.trValueIndex) + ")");
+            }
 
 			if (Options::get().statediff)
 				importer.traceStateDiff();

--- a/test/unittests/libethereum/BlockChainInsert.cpp
+++ b/test/unittests/libethereum/BlockChainInsert.cpp
@@ -152,8 +152,6 @@ void syncStateTrie(bytesConstRef _block, OverlayDB const& _dbSource, OverlayDB& 
 BOOST_AUTO_TEST_CASE(bcBasicInsert)
 {
     BasicAuthority::init();
-    BasicAuthority::init();
-
     KeyPair me = Secret(sha3("Gav Wood"));
     KeyPair myMiner = Secret(sha3("Gav's Miner"));
 


### PR DESCRIPTION
Other devs report that It is better if NoProof blocks still have the signature. but the signature is just ignored. 
Rather then absence of signature as it is now. 