### PR TITLE
Severity in log messages

### DIFF
--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -66,7 +66,7 @@ ThreadLocalLogName g_logThreadName("main");
 
 auto const g_timestampFormatter =
     (boost::log::expressions::stream
-        << EthViolet << boost::log::expressions::format_date_time(timestamp, "%Y-%m-%d %H:%M:%S")
+        << EthViolet << boost::log::expressions::format_date_time(timestamp, "%m-%d %H:%M:%S")
         << EthReset " ");
 
 std::string verbosityToString(int _verbosity)
@@ -76,24 +76,26 @@ std::string verbosityToString(int _verbosity)
     case VerbosityError:
         return "ERROR";
     case VerbosityWarning:
-        return "WARN ";
+        return "WARN";
     case VerbosityInfo:
-        return "INFO ";
+        return "INFO";
     case VerbosityDebug:
         return "DEBUG";
     case VerbosityTrace:
         return "TRACE";
     }
-    return "     ";
+    return {};
 }
 
 void formatter(boost::log::record_view const& _rec, boost::log::formatting_ostream& _strm)
 {
-    _strm << verbosityToString(_rec.attribute_values()[severity].get()) << " ";
+    _strm << std::setw(5) << std::left << verbosityToString(_rec.attribute_values()[severity].get())
+          << " ";
 
     g_timestampFormatter(_rec, _strm);
 
-    _strm << EthNavy << _rec[threadName] << EthReset " " << _rec[channel] << " ";
+    _strm << EthNavy << std::setw(4) << std::left << _rec[threadName] << EthReset " ";
+    _strm << std::setw(6) << std::left << _rec[channel] << " ";
     if (boost::log::expressions::has_attr(context)(_rec))
         _strm << EthNavy << _rec[context] << EthReset " ";
 

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -47,6 +47,12 @@ using log_sink = boost::log::sinks::synchronous_sink<T>;
 
 namespace dev
 {
+BOOST_LOG_ATTRIBUTE_KEYWORD(channel, "Channel", std::string)
+BOOST_LOG_ATTRIBUTE_KEYWORD(context, "Context", std::string)
+BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", int)
+BOOST_LOG_ATTRIBUTE_KEYWORD(threadName, "ThreadName", std::string)
+BOOST_LOG_ATTRIBUTE_KEYWORD(timestamp, "TimeStamp", boost::posix_time::ptime)
+
 namespace
 {
 /// Associate a name with each thread for nice logging.
@@ -57,6 +63,43 @@ struct ThreadLocalLogName
 };
 
 ThreadLocalLogName g_logThreadName("main");
+
+auto const g_timestampFormatter =
+    (boost::log::expressions::stream
+        << EthViolet << boost::log::expressions::format_date_time(timestamp, "%Y-%m-%d %H:%M:%S")
+        << EthReset " ");
+
+std::string verbosityToString(int _verbosity)
+{
+    switch (_verbosity)
+    {
+    case VerbosityError:
+        return "ERROR";
+    case VerbosityWarning:
+        return "WARN ";
+    case VerbosityInfo:
+        return "INFO ";
+    case VerbosityDebug:
+        return "DEBUG";
+    case VerbosityTrace:
+        return "TRACE";
+    }
+    return "     ";
+}
+
+void formatter(boost::log::record_view const& _rec, boost::log::formatting_ostream& _strm)
+{
+    _strm << verbosityToString(_rec.attribute_values()[severity].get()) << " ";
+
+    g_timestampFormatter(_rec, _strm);
+
+    _strm << EthNavy << _rec[threadName] << EthReset " " << _rec[channel] << " ";
+    if (boost::log::expressions::has_attr(context)(_rec))
+        _strm << EthNavy << _rec[context] << EthReset " ";
+
+    _strm << _rec[boost::log::expressions::smessage];
+}
+
 }  // namespace
 
 std::string getThreadName()
@@ -82,11 +125,6 @@ void setThreadName(std::string const& _n)
 #endif
 }
 
-BOOST_LOG_ATTRIBUTE_KEYWORD(channel, "Channel", std::string)
-BOOST_LOG_ATTRIBUTE_KEYWORD(context, "Context", std::string)
-BOOST_LOG_ATTRIBUTE_KEYWORD(threadName, "ThreadName", std::string)
-BOOST_LOG_ATTRIBUTE_KEYWORD(timestamp, "TimeStamp", boost::posix_time::ptime)
-
 void setupLogging(LoggingOptions const& _options)
 {
     auto sink = boost::make_shared<log_sink<boost::log::sinks::text_ostream_backend>>();
@@ -94,7 +132,7 @@ void setupLogging(LoggingOptions const& _options)
     boost::shared_ptr<std::ostream> stream{&std::cout, boost::null_deleter{}};
     sink->locked_backend()->add_stream(stream);
     sink->set_filter([_options](boost::log::attribute_value_set const& _set) {
-        if (_set["Severity"].extract<int>() > _options.verbosity)
+        if (_set[severity] > _options.verbosity)
             return false;
 
         auto const messageChannel = _set[channel];
@@ -103,13 +141,7 @@ void setupLogging(LoggingOptions const& _options)
                !contains(_options.excludeChannels, messageChannel);
     });
 
-    namespace expr = boost::log::expressions;
-    sink->set_formatter(expr::stream
-                        << EthViolet << expr::format_date_time(timestamp, "%Y-%m-%d %H:%M:%S")
-                        << EthReset " " EthNavy << threadName << EthReset " " << channel
-                        << expr::if_(expr::has_attr(
-                               context))[expr::stream << " " EthNavy << context << EthReset]
-                        << " " << expr::smessage);
+    sink->set_formatter(&formatter);
 
     boost::log::core::get()->add_sink(sink);
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -30,7 +30,6 @@
 
 namespace dev
 {
-
 /// Set the current thread's log name.
 ///
 /// It appears that there is not currently any cross-platform way of setting
@@ -54,6 +53,8 @@ namespace dev
 /// musl mailng list posting "pthread set name on MIPs" which includes the
 /// information that musl doesn't currently implement 'pthread_setname_np'
 /// https://marc.info/?l=musl&m=146171729013062&w=1
+///
+/// For better formatting it is recommended to limit thread name to max 4 characters.
 void setThreadName(std::string const& _n);
 
 /// Set the current thread's log name.
@@ -119,6 +120,7 @@ struct LoggingOptions
 void setupLogging(LoggingOptions const& _options);
 
 // Simple non-thread-safe logger with fixed severity and channel for each message
+// For better formatting it is recommended to limit channel name to max 6 characters.
 using Logger = boost::log::sources::severity_channel_logger<>;
 inline Logger createLogger(int _severity, std::string const& _channel)
 {


### PR DESCRIPTION
`aleth -v 4` output now looks like

```
aleth, a C++ Ethereum client
TRACE 08-27 15:25:39 main trace  ReadingC:\Users\andrei\AppData\Roaming\Web3\keys\9854d1d2-3a5d-1bd5-88e3-cdbb6d3edb86.json
TRACE 08-27 15:25:39 main trace  ReadingC:\Users\andrei\AppData\Roaming\Web3\keys\bcd6b183-7ab4-4aa2-c1a6-8bcf9cee577e.json
TRACE 08-27 15:25:39 main trace  ReadingC:\Users\andrei\AppData\Roaming\Web3\keys\e31724e9-a08c-368d-1d6a-a11f9c20e498.json
INFO  08-27 15:25:39 main net    Id: ##880be959ΓÇª
TRACE 08-27 15:25:39 main trace  Opened blockchain DB. Latest: #09f75789ΓÇª(rebuild not needed)
TRACE 08-27 15:25:39 main statedb Opened state DB.
DEBUG 08-27 15:25:39 main overlaydb Closing state DB
DEBUG 08-27 15:25:39 main overlaydb Closing state DB
DEBUG 08-27 15:25:39 main overlaydb Closing state DB
DEBUG 08-27 15:25:39 main overlaydb Closing state DB
DEBUG 08-27 15:25:39 main overlaydb Closing state DB
DEBUG 08-27 15:25:39 main overlaydb Closing state DB
DEBUG 08-27 15:25:39 eth  client startedWorking()
DEBUG 08-27 15:25:39 eth  overlaydb Closing state DB
DEBUG 08-27 15:25:39 eth  overlaydb Closing state DB
aleth 1.5.0.dev2+commit.ddf69ea0.dirty
DEBUG 08-27 15:25:41 main overlaydb Closing state DB
DEBUG 08-27 15:25:41 main overlaydb Closing state DB
DEBUG 08-27 15:25:41 main client Post state changed.
Mining Beneficiary: 00000000-0000-0000-0000-000000000000 - e2a6f75d132c092f63a4778d593713d2e44496a9
TRACE 08-27 15:25:41 eth  trace  No transactions to process. 0 pending, 0 queued, 0 future, 0 unverified
INFO  08-27 15:25:41 p2p  info   UPnP device not found.
TRACE 08-27 15:25:41 p2p  net    Listening on local port 30303 (public: 0.0.0.0:0)
DEBUG 08-27 15:25:41 p2p  net    p2p.started id: ##880be959ΓÇª
Node ID: enode://880be959c14827ae445b1fc4dd8643efbf1ca88188a862ea69ce9b9d5646df5a3564369b9f7165a43f5fbb53e4af9f438c7634c694bc5e38a0ee5341940dc97b@0.0.0.0:0
INFO  08-27 15:25:41 main rpc    JSON-RPC socket path: \\.\pipe\\geth.ipc
JSONRPC Admin Session Key: UivvcSsD59Y=
DEBUG 08-27 15:25:41 main discov addNode pending for 13.84.180.240 UDP 30303 TCP 30303
DEBUG 08-27 15:25:41 main discov addNode pending for 52.16.188.185 UDP 30303 TCP 30303
DEBUG 08-27 15:25:41 main discov addNode pending for 13.93.211.84 UDP 30303 TCP 30303
DEBUG 08-27 15:25:41 main discov addNode pending for 191.235.84.50 UDP 30303 TCP 30303
DEBUG 08-27 15:25:41 main discov addNode pending for 52.169.14.227 UDP 30303 TCP 30303
DEBUG 08-27 15:25:41 main discov addNode pending for 13.75.154.138 UDP 30303 TCP 30303
DEBUG 08-27 15:25:41 main discov addNode pending for 52.74.57.123 UDP 30303 TCP 30303
TRACE 08-27 15:25:41 p2p  net    Attempting connection to node ##a979fb57ΓÇª@52.16.188.185:30303 from ##880be959ΓÇª
```

Boost API around formatting is a bit weird.