### PR TITLE
Make --evmc option a multitoken one

### DIFF
--- a/libevm/VMFactory.cpp
+++ b/libevm/VMFactory.cpp
@@ -167,6 +167,7 @@ po::options_description vmProgramOptions(unsigned _lineLength)
 
     add(c_evmcPrefix,
         po::value<std::vector<std::string>>()
+            ->multitoken()
             ->value_name("<option>=<value>")
             ->notifier(parseEvmcOptions),
         "EVMC option\n");

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -157,11 +157,20 @@ Options::Options(int argc, const char** argv)
             printVersion();
             exit(0);
         }
-        else if (arg == "--vm" || arg == "--evmc")
+        else if (arg == "--vm")
         {
             // Skip VM options because they are handled by vmProgramOptions().
             throwIfNoArgumentFollows();
             ++i;
+        }
+        else if (arg == "--evmc")
+        {
+            // Skip VM options because they are handled by vmProgramOptions().
+            throwIfNoArgumentFollows();
+
+            // --evmc is a multitoken option so skip all tokens.
+            while (i + 1 < argc && argv[i + 1][0] != '-')
+                ++i;
         }
         else if (arg == "--vmtrace")
         {


### PR DESCRIPTION
It optionally allows shortening EVMC options from `--evmc a=1 --evmc b=2` to `--evmc a=1 b=2`.
Of course I had to hack testeth's hackish option handler.