### PR TITLE
Fix clearing storage in case of CREATE2 with empty init code

### DIFF
--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -407,6 +407,8 @@ bool Executive::executeCreate(Address const& _sender, u256 const& _endowment, u2
         newNonce += 1;
     m_s.setNonce(m_newAddress, newNonce);
 
+    m_s.clearStorage(m_newAddress);
+
     // Schedule _init execution if not empty.
     if (!_init.empty())
         m_ext = make_shared<ExtVM>(m_s, m_envInfo, m_sealEngine, m_newAddress, _sender, _origin,
@@ -449,7 +451,6 @@ bool Executive::go(OnOpFunc const& _onOp)
             auto vm = VMFactory::create();
             if (m_isCreation)
             {
-                m_s.clearStorage(m_ext->myAddress);
                 auto out = vm->exec(m_gas, *m_ext, _onOp);
                 if (m_res)
                 {


### PR DESCRIPTION
Storage of the newly created account was cleared only if init code is non-empty (in `Executive::go()`.

That could be a problem in case of new account address collision when nonce is zero and code is empty, but storage is not empty. Creation should succeed in this case (account still is considered empty) and the storage should be cleared.