### PR TITLE
Remove static linking support for evmjit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "evmjit"]
-	path = evmjit
-	url = https://github.com/ethereum/evmjit
-	branch = develop
 [submodule "test/jsontests"]
 	path = test/jsontests
 	url = https://github.com/ethereum/tests.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,6 @@ add_subdirectory(libethashseal)
 add_subdirectory(libwebthree)
 add_subdirectory(libweb3jsonrpc)
 
-if (EVMJIT)
-    add_subdirectory(evmjit)
-endif()
-
 add_subdirectory(aleth)
 
 if (TOOLS)

--- a/circle.yml
+++ b/circle.yml
@@ -240,7 +240,7 @@ jobs:
       - checkout
       - run:
           name: "Update required git submodules"
-          command: git submodule update --init --recursive evmc evmjit
+          command: git submodule update --init --recursive evmc
       - setup_remote_docker
       - run:
           name: "Build aleth docker image"

--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -24,7 +24,6 @@ macro(configure_project)
     # components
     option(TESTS "Build with tests" ON)
     option(TOOLS "Build additional tools" ON)
-    option(EVMJIT "Build with EVMJIT module enabled" OFF)
     option(HERA "Build with HERA module enabled" OFF)
 
     # Resolve any clashes between incompatible options.
@@ -90,7 +89,6 @@ macro(print_config)
     message("------------------------------------------------------------- components")
     message("-- TESTS            Build tests                              ${TESTS}")
     message("-- TOOLS            Build tools                              ${TOOLS}")
-    message("-- EVMJIT           Build LLVM-based JIT EVM                 ${EVMJIT}")
     message("-- HERA             Build Hera eWASM VM                      ${HERA}")
     message("------------------------------------------------------------- tests")
     message("-- FASTCTEST        Run only test suites in ctest            ${FASTCTEST}")

--- a/libevm/CMakeLists.txt
+++ b/libevm/CMakeLists.txt
@@ -23,11 +23,6 @@ if(EVM_OPTIMIZE)
     target_compile_definitions(evm PRIVATE EVM_OPTIMIZE)
 endif()
 
-if(EVMJIT)
-    target_link_libraries(evm PRIVATE evmjit)
-    target_compile_definitions(evm PRIVATE ETH_EVMJIT)
-endif()
-
 if(HERA)
     target_link_libraries(evm PRIVATE hera)
     target_compile_definitions(evm PRIVATE ETH_HERA)

--- a/libevm/VMFactory.cpp
+++ b/libevm/VMFactory.cpp
@@ -23,10 +23,6 @@
 
 #include <evmc/loader.h>
 
-#if ETH_EVMJIT
-#include <evmjit.h>
-#endif
-
 #if ETH_HERA
 #include <hera/hera.h>
 #endif
@@ -64,9 +60,6 @@ struct VMKindTableEntry
 VMKindTableEntry vmKindsTable[] = {
     {VMKind::Interpreter, "interpreter"},
     {VMKind::Legacy, "legacy"},
-#if ETH_EVMJIT
-    {VMKind::JIT, "jit"},
-#endif
 #if ETH_HERA
     {VMKind::Hera, "hera"},
 #endif
@@ -189,10 +182,6 @@ VMPtr VMFactory::create(VMKind _kind)
 
     switch (_kind)
     {
-#ifdef ETH_EVMJIT
-    case VMKind::JIT:
-        return {new EVMC{evmjit_create()}, default_delete};
-#endif
 #ifdef ETH_HERA
     case VMKind::Hera:
         return {new EVMC{evmc_create_hera()}, default_delete};

--- a/libevm/VMFactory.h
+++ b/libevm/VMFactory.h
@@ -27,7 +27,6 @@ namespace eth
 enum class VMKind
 {
     Interpreter,
-    JIT,
     Hera,
     Legacy,
     DLL


### PR DESCRIPTION
Depends on #5257.

Preferable wait merging this until `release/1.4` is merged back to `master`.