### PR TITLE
Fix broken links in database.rst

### DIFF
--- a/doc/database_layout.rst
+++ b/doc/database_layout.rst
@@ -33,7 +33,7 @@ Every record is:
 
 Low-level access to both Blocks and Extras databases is encapsulated in
 `BlockChain
-class <https://github.com/ethereum/cpp-ethereum/blob/develop/libethereum/BlockChain.h>`__.
+class <https://github.com/ethereum/aleth/blob/master/libethereum/BlockChain.h>`__.
 
 Extras
 ------
@@ -99,11 +99,11 @@ database stores the nodes of this trie.
    ``hash + 255 => preimage`` (``+`` is concatenation).
 
 For the code managing the state see `State
-class <https://github.com/ethereum/cpp-ethereum/blob/develop/libethereum/State.h>`__
+class <https://github.com/ethereum/aleth/blob/master/libethereum/State.h>`__
 (also note free function ``commit`` there). Merkle Patricia Trie
 implemenation is in
-`TrieDB.h <https://github.com/ethereum/cpp-ethereum/blob/develop/libdevcore/TrieDB.h>`__.
+`TrieDB.h <https://github.com/ethereum/aleth/blob/master/libdevcore/TrieDB.h>`__.
 For lower-level code accessing the database itself see
-`OverlayDB <https://github.com/ethereum/cpp-ethereum/blob/develop/libdevcore/OverlayDB.h>`__
+`OverlayDB <https://github.com/ethereum/aleth/blob/master/libdevcore/OverlayDB.h>`__
 and
-`MemoryDB <https://github.com/ethereum/cpp-ethereum/blob/develop/libdevcore/MemoryDB.h>`__.
+`MemoryDB <https://github.com/ethereum/aleth/blob/master/libdevcore/MemoryDB.h>`__.


### PR DESCRIPTION
Links were broken because they included the old primary branch name (develop instead of master)