### PR TITLE
Add support for macOS Mojave

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -78,9 +78,12 @@ Darwin)
         10.13)
             echo "Installing cpp-ethereum dependencies on macOS 10.13 High Sierra."
             ;;
+        10.14)
+            echo "Installing solidity dependencies on macOS 10.14 Mojave."
+            ;;
         *)
             echo "Unsupported macOS version."
-            echo "We only support Mavericks, Yosemite, El Capitan, Sierra and High Sierra."
+            echo "We only support Mavericks, Yosemite, El Capitan, Sierra, High Sierra and Mojave."
             exit 1
             ;;
     esac


### PR DESCRIPTION
Adding mention that macOS Mojave does work with the dependencies script.