### PR TITLE
Circle CI: Decouple docker nightly build from "all tests" job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -319,6 +319,4 @@ workflows:
             - master
     jobs:
       - linux-gcc6-nightly
-      - docker-aleth-nightly:
-          requires:
-            - linux-gcc6-nightly
+      - docker-aleth-nightly


### PR DESCRIPTION
@winsvega We have `testeth --all` tests for some time, but because nobody is paying attention to them they are also failing for some time. https://circleci.com/gh/ethereum/aleth/6946

 