### PR TITLE
Fix EWASMSchedule

### DIFF
--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -126,8 +126,6 @@ static const EVMSchedule EWASMSchedule = []
 {
     EVMSchedule schedule = ByzantiumSchedule;
     schedule.maxCodeSize = std::numeric_limits<unsigned>::max();
-    // Ensure that zero bytes are not subsidised and are charged the same as non-zero bytes.
-    schedule.txDataZeroGas = schedule.txDataNonZeroGas;
     return schedule;
 }();
 


### PR DESCRIPTION
This resolves the problem of incorrect gas when syncing with the testnet https://github.com/ewasm/testnet/issues/88#issuecomment-432760539

Though I tried it only with modified aleth v1.4.0 (waiting for Hera to switch to EVMC6 to try with aleth master)