### PR TITLE
 test: Introduce aleth-unittests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,10 +9,12 @@ set(unittest_sources
     unittests/libdevcore/FixedHash.cpp
     unittests/libdevcore/RangeMask.cpp
     unittests/libdevcore/rlp.cpp
+
+    unittests/libdevcrypto/AES.cpp
 )
 
 add_executable(aleth-unittests ${unittest_sources})
-target_link_libraries(aleth-unittests PRIVATE devcore GTest::gtest GTest::main)
+target_link_libraries(aleth-unittests PRIVATE devcrypto devcore GTest::gtest GTest::main)
 gtest_add_tests(TARGET aleth-unittests)
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,19 @@
-file(GLOB_RECURSE sources "*.cpp" "*.h" "*.sol")
+
+hunter_add_package(GTest)
+find_package(GTest CONFIG REQUIRED)
+
+set(unittest_sources
+    unittests/libdevcore/CommonJS.cpp
+    unittests/libdevcore/core.cpp
+)
+
+add_executable(aleth-unittests ${unittest_sources})
+target_link_libraries(aleth-unittests PRIVATE devcore GTest::gtest GTest::main)
+
+file(GLOB_RECURSE sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cpp" "*.h" "*.sol" )
+
+# Skip unit tests included in aleth-unittests.
+list(REMOVE_ITEM sources ${unittest_sources})
 
 # search for test names and create ctest tests
 set(excludeSuites jsonrpc \"customTestSuite\" BlockQueueSuite)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ set(unittest_sources
 
 add_executable(aleth-unittests ${unittest_sources})
 target_link_libraries(aleth-unittests PRIVATE devcrypto devcore GTest::gtest GTest::main)
-gtest_add_tests(TARGET aleth-unittests)
+gtest_add_tests(TARGET aleth-unittests TEST_PREFIX unittests/)
 
 
 file(GLOB_RECURSE sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cpp" "*.h" "*.sol" )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(unittest_sources
     unittests/libdevcore/CommonJS.cpp
     unittests/libdevcore/core.cpp
     unittests/libdevcore/FixedHash.cpp
+    unittests/libdevcore/RangeMask.cpp
 )
 
 add_executable(aleth-unittests ${unittest_sources})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(unittest_sources
     unittests/libdevcore/core.cpp
     unittests/libdevcore/FixedHash.cpp
     unittests/libdevcore/RangeMask.cpp
+    unittests/libdevcore/rlp.cpp
 )
 
 add_executable(aleth-unittests ${unittest_sources})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(GTest CONFIG REQUIRED)
 set(unittest_sources
     unittests/libdevcore/CommonJS.cpp
     unittests/libdevcore/core.cpp
+    unittests/libdevcore/FixedHash.cpp
 )
 
 add_executable(aleth-unittests ${unittest_sources})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+include(GoogleTest)
 
 hunter_add_package(GTest)
 find_package(GTest CONFIG REQUIRED)
@@ -9,6 +10,8 @@ set(unittest_sources
 
 add_executable(aleth-unittests ${unittest_sources})
 target_link_libraries(aleth-unittests PRIVATE devcore GTest::gtest GTest::main)
+gtest_add_tests(TARGET aleth-unittests)
+
 
 file(GLOB_RECURSE sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cpp" "*.h" "*.sol" )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ set(unittest_sources
     unittests/libdevcore/core.cpp
     unittests/libdevcore/FixedHash.cpp
     unittests/libdevcore/RangeMask.cpp
-    unittests/libdevcore/rlp.cpp
+    unittests/libdevcore/RLP.cpp
 
     unittests/libdevcrypto/AES.cpp
 )

--- a/test/tools/jsontests/RLPTests.cpp
+++ b/test/tools/jsontests/RLPTests.cpp
@@ -1,0 +1,285 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/// @file
+/// RLP unit tests.
+
+#include <json_spirit/JsonSpiritHeaders.h>
+#include <libdevcore/Common.h>
+#include <libdevcore/CommonIO.h>
+#include <libdevcore/Log.h>
+#include <libdevcore/RLP.h>
+#include <test/tools/libtesteth/TestHelper.h>
+#include <test/tools/libtesteth/TestOutputHelper.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+
+using namespace std;
+using namespace dev;
+namespace fs = boost::filesystem;
+namespace js = json_spirit;
+
+namespace dev
+{
+namespace test
+{
+void buildRLP(js::mValue const& _v, RLPStream& _rlp);
+void checkRLPAgainstJson(js::mValue const& v, RLP& u);
+enum class RlpType
+{
+    Valid,
+    Invalid,
+    Test
+};
+
+void doRlpTests(json_spirit::mValue const& _input)
+{
+    string testname;
+    for (auto& i : _input.get_obj())
+    {
+        js::mObject const& o = i.second.get_obj();
+
+        cnote << "  " << i.first;
+        testname = "(" + i.first + ") ";
+
+        BOOST_REQUIRE_MESSAGE(o.count("out") > 0, testname + "out not set!");
+        BOOST_REQUIRE_MESSAGE(!o.at("out").is_null(), testname + "out is set to null!");
+
+        // Check Encode
+        BOOST_REQUIRE_MESSAGE(o.count("in") > 0, testname + "in not set!");
+        RlpType rlpType = RlpType::Test;
+        if (o.at("in").type() == js::str_type)
+        {
+            if (o.at("in").get_str() == "INVALID")
+                rlpType = RlpType::Invalid;
+            else if (o.at("in").get_str() == "VALID")
+                rlpType = RlpType::Valid;
+        }
+
+        if (rlpType == RlpType::Test)
+        {
+            RLPStream s;
+            dev::test::buildRLP(o.at("in"), s);
+            string computedText = toHex(s.out());
+
+            string expectedText(o.at("out").get_str());
+            transform(expectedText.begin(), expectedText.end(), expectedText.begin(), ::tolower);
+
+            stringstream msg;
+            msg << "Encoding Failed: expected: " << expectedText << std::endl;
+            msg << " But Computed: " << computedText;
+            BOOST_CHECK_MESSAGE(expectedText == computedText, testname + msg.str());
+        }
+
+        // Check Decode
+        // Uses the same test cases as encoding but in reverse.
+        // We read into the string of hex values, convert to bytes,
+        // and then compare the output structure to the json of the
+        // input object.
+        bool was_exception = false;
+        js::mValue const& inputData = o.at("in");
+        try
+        {
+            bytes payloadToDecode = fromHex(o.at("out").get_str());
+            RLP payload(payloadToDecode);
+
+            // attempt to read all the contents of RLP
+            ostringstream() << payload;
+
+            if (rlpType == RlpType::Test)
+                dev::test::checkRLPAgainstJson(inputData, payload);
+        }
+        catch (Exception const& _e)
+        {
+            cnote << "Exception: " << diagnostic_information(_e);
+            was_exception = true;
+        }
+        catch (std::exception const& _e)
+        {
+            cnote << "rlp exception: " << _e.what();
+            was_exception = true;
+        }
+
+        // Expect exception as input is INVALID
+        if (rlpType == RlpType::Invalid && was_exception)
+            continue;
+
+        // Check that there was an exception as input is INVALID
+        if (rlpType == RlpType::Invalid && !was_exception)
+            BOOST_ERROR(testname + "Expected RLP Exception as rlp should be invalid!");
+
+        // input is VALID check that there was no exceptions
+        if (was_exception)
+            BOOST_ERROR(testname + "Unexpected RLP Exception!");
+    }
+}
+
+void buildRLP(js::mValue const& _v, RLPStream& _rlp)
+{
+    if (_v.type() == js::array_type)
+    {
+        RLPStream s;
+        for (auto& i : _v.get_array())
+            buildRLP(i, s);
+        _rlp.appendList(s.out());
+    }
+    else if (_v.type() == js::int_type)
+        _rlp.append(_v.get_uint64());
+    else if (_v.type() == js::str_type)
+    {
+        auto s = _v.get_str();
+        if (s.size() && s[0] == '#')
+            _rlp.append(bigint(s.substr(1)));
+        else
+            _rlp.append(s);
+    }
+}
+
+void checkRLPAgainstJson(js::mValue const& v, RLP& u)
+{
+    if (v.type() == js::str_type)
+    {
+        const string& expectedText = v.get_str();
+        if (!expectedText.empty() && expectedText.front() == '#')
+        {
+            // Deal with bigint instead of a raw string
+            string bigIntStr = expectedText.substr(1, expectedText.length() - 1);
+            stringstream bintStream(bigIntStr);
+            bigint val;
+            bintStream >> val;
+            BOOST_CHECK(!u.isList());
+            BOOST_CHECK(!u.isNull());
+            BOOST_CHECK(u == val);
+        }
+        else
+        {
+            BOOST_CHECK(!u.isList());
+            BOOST_CHECK(!u.isNull());
+            BOOST_CHECK(u.isData());
+            BOOST_CHECK(u.size() == expectedText.length());
+            BOOST_CHECK(u == expectedText);
+        }
+    }
+    else if (v.type() == js::int_type)
+    {
+        const int expectedValue = v.get_int();
+        BOOST_CHECK(u.isInt());
+        BOOST_CHECK(!u.isList());
+        BOOST_CHECK(!u.isNull());
+        BOOST_CHECK(u == expectedValue);
+    }
+    else if (v.type() == js::array_type)
+    {
+        BOOST_CHECK(u.isList());
+        BOOST_CHECK(!u.isInt());
+        BOOST_CHECK(!u.isData());
+        js::mArray const& arr = v.get_array();
+        BOOST_CHECK(u.itemCount() == arr.size());
+        unsigned i;
+        for (i = 0; i < arr.size(); i++)
+        {
+            RLP item = u[i];
+            checkRLPAgainstJson(arr[i], item);
+        }
+    }
+    else
+    {
+        BOOST_ERROR("Invalid Javascript object!");
+    }
+}
+}  // namespace test
+}  // namespace dev
+
+void runRlpTest(string _name, fs::path const& _path)
+{
+    fs::path const testPath = dev::test::getTestPath() / _path;
+
+    try
+    {
+        cnote << "TEST " << _name << ":";
+        json_spirit::mValue v;
+        string const s = asString(dev::contents(testPath / fs::path(_name + ".json")));
+        BOOST_REQUIRE_MESSAGE(
+            s.length() > 0, "Contents of " << (testPath / fs::path(_name + ".json")).string()
+                                           << " is empty. Have you cloned the 'tests' repo branch "
+                                              "develop and set ETHEREUM_TEST_PATH to its path?");
+        json_spirit::read_string(s, v);
+        // Listener::notifySuiteStarted(_name);
+        dev::test::doRlpTests(v);
+    }
+    catch (Exception const& _e)
+    {
+        BOOST_ERROR("Failed test with Exception: " << diagnostic_information(_e));
+    }
+    catch (std::exception const& _e)
+    {
+        BOOST_ERROR("Failed test with Exception: " << _e.what());
+    }
+}
+
+using namespace dev::test;
+
+BOOST_FIXTURE_TEST_SUITE(RlpTests, TestOutputHelperFixture)
+
+BOOST_AUTO_TEST_CASE(invalidRLPtest)
+{
+    runRlpTest("invalidRLPTest", "/RLPTests");
+}
+
+BOOST_AUTO_TEST_CASE(rlptest)
+{
+    runRlpTest("rlptest", "/RLPTests");
+}
+
+BOOST_AUTO_TEST_CASE(rlpRandom)
+{
+    fs::path testPath = dev::test::getTestPath();
+    testPath /= fs::path("RLPTests/RandomRLPTests");
+
+    vector<boost::filesystem::path> testFiles = test::getFiles(testPath, {".json"});
+    for (auto& path : testFiles)
+    {
+        try
+        {
+            cnote << "Testing ..." << path.filename();
+            json_spirit::mValue v;
+            string s = asString(dev::contents(path.string()));
+            BOOST_REQUIRE_MESSAGE(
+                s.length() > 0, "Content of " + path.string() +
+                                    " is empty. Have you cloned the 'tests' repo branch develop "
+                                    "and set ETHEREUM_TEST_PATH to its path?");
+            json_spirit::read_string(s, v);
+            // test::Listener::notifySuiteStarted(path.filename().string());
+            dev::test::doRlpTests(v);
+        }
+
+        catch (Exception const& _e)
+        {
+            BOOST_ERROR(path.filename().string() + "Failed test with Exception: "
+                        << diagnostic_information(_e));
+        }
+        catch (std::exception const& _e)
+        {
+            BOOST_ERROR(path.filename().string() + "Failed test with Exception: " << _e.what());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libdevcore/CommonJS.cpp
+++ b/test/unittests/libdevcore/CommonJS.cpp
@@ -1,136 +1,128 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file CommonJS.cpp
- * @author Lefteris Karapetsas <lefteris@refu.co>
- * @date 2015
- * Tests for functions in CommonJS.h
- */
 
-#include <boost/test/unit_test.hpp>
 #include <libdevcore/CommonJS.h>
-#include <test/tools/libtesteth/TestOutputHelper.h>
+
+#include <gtest/gtest.h>
 
 using namespace dev;
 using namespace std;
-using namespace test;
 
-BOOST_FIXTURE_TEST_SUITE(CommonJSTests, TestOutputHelperFixture)
-
-BOOST_AUTO_TEST_CASE(test_toJS)
+TEST(common_js, toJS)
 {
-	h64 a("0xbaadf00ddeadbeef");
-	u64 b("0xffff0000bbbaaaa");
-	uint64_t c = 38990234243;
-	bytes d = {0xff, 0x0, 0xef, 0xbc};
+    h64 a("0xbaadf00ddeadbeef");
+    u64 b("0xffff0000bbbaaaa");
+    uint64_t c = 38990234243;
+    bytes d = {0xff, 0x0, 0xef, 0xbc};
 
-	BOOST_CHECK(toJS(a) == "0xbaadf00ddeadbeef");
-	BOOST_CHECK(toJS(b) == "0xffff0000bbbaaaa");
-	BOOST_CHECK(toJS(c) == "0x913ffc283");
-	BOOST_CHECK(toJS(d) == "0xff00efbc");
+    EXPECT_EQ(toJS(a), "0xbaadf00ddeadbeef");
+    EXPECT_EQ(toJS(b), "0xffff0000bbbaaaa");
+    EXPECT_EQ(toJS(c), "0x913ffc283");
+    EXPECT_EQ(toJS(d), "0xff00efbc");
 }
 
-BOOST_AUTO_TEST_CASE(test_jsToBytes)
+TEST(common_js, jsToBytes)
 {
-	bytes a = {0xff, 0xaa, 0xbb, 0xcc};
-	bytes b = {0x03, 0x89, 0x90, 0x23, 0x42, 0x43};
-	BOOST_CHECK(a == jsToBytes("0xffaabbcc"));
-	BOOST_CHECK(b == jsToBytes("38990234243"));
-	BOOST_CHECK(bytes() == jsToBytes(""));
-	BOOST_CHECK(bytes() == jsToBytes("Invalid hex chars"));
+    bytes a = {0xff, 0xaa, 0xbb, 0xcc};
+    bytes b = {0x03, 0x89, 0x90, 0x23, 0x42, 0x43};
+    EXPECT_EQ(a, jsToBytes("0xffaabbcc"));
+    EXPECT_EQ(b, jsToBytes("38990234243"));
+    EXPECT_EQ(bytes(), jsToBytes(""));
+    EXPECT_EQ(bytes(), jsToBytes("Invalid hex chars"));
 }
 
-BOOST_AUTO_TEST_CASE(test_padded)
+TEST(common_js, padded)
 {
-	bytes a = {0xff, 0xaa};
-	BOOST_CHECK(bytes({0x00, 0x00, 0xff, 0xaa}) == padded(a, 4));
-	bytes b = {};
-	BOOST_CHECK(bytes({0x00, 0x00, 0x00, 0x00}) == padded(b, 4));
-	bytes c = {0xff, 0xaa, 0xbb, 0xcc};
-	BOOST_CHECK(bytes{0xcc} == padded(c, 1));
+    bytes a = {0xff, 0xaa};
+    EXPECT_EQ(bytes({0x00, 0x00, 0xff, 0xaa}), padded(a, 4));
+    bytes b = {};
+    EXPECT_EQ(bytes({0x00, 0x00, 0x00, 0x00}), padded(b, 4));
+    bytes c = {0xff, 0xaa, 0xbb, 0xcc};
+    EXPECT_EQ(bytes{0xcc}, padded(c, 1));
 }
 
-BOOST_AUTO_TEST_CASE(test_paddedRight)
+TEST(common_js, paddedRight)
 {
-	bytes a = {0xff, 0xaa};
-	BOOST_CHECK(bytes({0xff, 0xaa, 0x00, 0x00}) == paddedRight(a, 4));
-	bytes b = {};
-	BOOST_CHECK(bytes({0x00, 0x00, 0x00, 0x00}) == paddedRight(b, 4));
-	bytes c = {0xff, 0xaa, 0xbb, 0xcc};
-	BOOST_CHECK(bytes{0xff} == paddedRight(c, 1));
+    bytes a = {0xff, 0xaa};
+    EXPECT_EQ(bytes({0xff, 0xaa, 0x00, 0x00}), paddedRight(a, 4));
+    bytes b = {};
+    EXPECT_EQ(bytes({0x00, 0x00, 0x00, 0x00}), paddedRight(b, 4));
+    bytes c = {0xff, 0xaa, 0xbb, 0xcc};
+    EXPECT_EQ(bytes{0xff}, paddedRight(c, 1));
 }
 
-BOOST_AUTO_TEST_CASE(test_unpadded)
+TEST(common_js, unpadded)
 {
-	bytes a = {0xff, 0xaa, 0x00, 0x00, 0x00};
-	BOOST_CHECK(bytes({0xff, 0xaa}) == unpadded(a));
-	bytes b = {0x00, 0x00};
-	BOOST_CHECK(bytes() == unpadded(b));
-	bytes c = {};
-	BOOST_CHECK(bytes() == unpadded(c));
+    bytes a = {0xff, 0xaa, 0x00, 0x00, 0x00};
+    EXPECT_EQ(bytes({0xff, 0xaa}), unpadded(a));
+    bytes b = {0x00, 0x00};
+    EXPECT_EQ(bytes(), unpadded(b));
+    bytes c = {};
+    EXPECT_EQ(bytes(), unpadded(c));
 }
 
-BOOST_AUTO_TEST_CASE(test_unpaddedLeft)
+TEST(common_js, unpaddedLeft)
 {
-	bytes a = {0x00, 0x00, 0x00, 0xff, 0xaa};
-	BOOST_CHECK(bytes({0xff, 0xaa}) == unpadLeft(a));
-	bytes b = {0x00, 0x00};
-	BOOST_CHECK(bytes() == unpadLeft(b));
-	bytes c = {};
-	BOOST_CHECK(bytes() == unpadLeft(c));
+    bytes a = {0x00, 0x00, 0x00, 0xff, 0xaa};
+    EXPECT_EQ(bytes({0xff, 0xaa}), unpadLeft(a));
+    bytes b = {0x00, 0x00};
+    EXPECT_EQ(bytes(), unpadLeft(b));
+    bytes c = {};
+    EXPECT_EQ(bytes(), unpadLeft(c));
 }
 
-BOOST_AUTO_TEST_CASE(test_fromRaw)
+TEST(common_js, fromRaw)
 {
-	//non ascii characters means empty string
-	h256 a("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-	BOOST_CHECK("" == fromRaw(a));
-	h256 b("");
-	BOOST_CHECK("" == fromRaw(b));
-	h256 c("0x4173636969436861726163746572730000000000000000000000000000000000");
-	BOOST_CHECK("AsciiCharacters" == fromRaw(c));
+    // non ascii characters means empty string
+    h256 a("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    EXPECT_EQ("", fromRaw(a));
+    h256 b("");
+    EXPECT_EQ("", fromRaw(b));
+    h256 c("0x4173636969436861726163746572730000000000000000000000000000000000");
+    EXPECT_EQ("AsciiCharacters", fromRaw(c));
 }
 
-BOOST_AUTO_TEST_CASE(test_jsToFixed)
+TEST(common_js, jsToFixed)
 {
-	h256 a("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-	BOOST_CHECK(a == jsToFixed<32>("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-	h256 b("0x000000000000000000000000000000000000000000000000000000740c54b42f");
-	BOOST_CHECK(b == jsToFixed<32>("498423084079"));
-	BOOST_CHECK(h256() == jsToFixed<32>("NotAHexadecimalOrDecimal"));
+    h256 a("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    EXPECT_EQ(
+        a, jsToFixed<32>("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    h256 b("0x000000000000000000000000000000000000000000000000000000740c54b42f");
+    EXPECT_EQ(b, jsToFixed<32>("498423084079"));
+    EXPECT_EQ(h256(), jsToFixed<32>("NotAHexadecimalOrDecimal"));
 }
 
-BOOST_AUTO_TEST_CASE(test_jsToInt)
+TEST(common_js, jsToInt)
 {
-	BOOST_CHECK(43832124 == jsToInt("43832124"));
-	BOOST_CHECK(1342356623 == jsToInt("0x5002bc8f"));
-	BOOST_CHECK(3483942 == jsToInt("015224446"));
-	BOOST_CHECK(0 == jsToInt("NotAHexadecimalOrDecimal"));
+    EXPECT_EQ(43832124, jsToInt("43832124"));
+    EXPECT_EQ(1342356623, jsToInt("0x5002bc8f"));
+    EXPECT_EQ(3483942, jsToInt("015224446"));
+    EXPECT_EQ(0, jsToInt("NotAHexadecimalOrDecimal"));
 
-	BOOST_CHECK(u256("983298932490823474234") == jsToInt<32>("983298932490823474234"));
-	BOOST_CHECK(u256("983298932490823474234") == jsToInt<32>("0x354e03915c00571c3a"));
-	BOOST_CHECK(u256() == jsToInt<32>("NotAHexadecimalOrDecimal"));
-	BOOST_CHECK(u128("228273101986715476958866839113050921216") == jsToInt<16>("0xabbbccddeeff11223344556677889900"));
-	BOOST_CHECK(u128() == jsToInt<16>("NotAHexadecimalOrDecimal"));
+    EXPECT_EQ(u256("983298932490823474234"), jsToInt<32>("983298932490823474234"));
+    EXPECT_EQ(u256("983298932490823474234"), jsToInt<32>("0x354e03915c00571c3a"));
+    EXPECT_EQ(u256(), jsToInt<32>("NotAHexadecimalOrDecimal"));
+    EXPECT_EQ(u128("228273101986715476958866839113050921216"),
+        jsToInt<16>("0xabbbccddeeff11223344556677889900"));
+    EXPECT_EQ(u128(), jsToInt<16>("NotAHexadecimalOrDecimal"));
 }
 
-BOOST_AUTO_TEST_CASE(test_jsToU256)
+TEST(common_js, jsToU256)
 {
-	BOOST_CHECK(u256("983298932490823474234") == jsToU256("983298932490823474234"));
-	BOOST_CHECK(u256() == jsToU256("NotAHexadecimalOrDecimal"));
+    EXPECT_EQ(u256("983298932490823474234"), jsToU256("983298932490823474234"));
+    EXPECT_EQ(u256(), jsToU256("NotAHexadecimalOrDecimal"));
 }
-
-BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libdevcore/CommonJS.cpp
+++ b/test/unittests/libdevcore/CommonJS.cpp
@@ -22,7 +22,7 @@
 using namespace dev;
 using namespace std;
 
-TEST(common_js, toJS)
+TEST(CommonJS, toJS)
 {
     h64 a("0xbaadf00ddeadbeef");
     u64 b("0xffff0000bbbaaaa");
@@ -35,7 +35,7 @@ TEST(common_js, toJS)
     EXPECT_EQ(toJS(d), "0xff00efbc");
 }
 
-TEST(common_js, jsToBytes)
+TEST(CommonJS, jsToBytes)
 {
     bytes a = {0xff, 0xaa, 0xbb, 0xcc};
     bytes b = {0x03, 0x89, 0x90, 0x23, 0x42, 0x43};
@@ -45,7 +45,7 @@ TEST(common_js, jsToBytes)
     EXPECT_EQ(bytes(), jsToBytes("Invalid hex chars"));
 }
 
-TEST(common_js, padded)
+TEST(CommonJS, padded)
 {
     bytes a = {0xff, 0xaa};
     EXPECT_EQ(bytes({0x00, 0x00, 0xff, 0xaa}), padded(a, 4));
@@ -55,7 +55,7 @@ TEST(common_js, padded)
     EXPECT_EQ(bytes{0xcc}, padded(c, 1));
 }
 
-TEST(common_js, paddedRight)
+TEST(CommonJS, paddedRight)
 {
     bytes a = {0xff, 0xaa};
     EXPECT_EQ(bytes({0xff, 0xaa, 0x00, 0x00}), paddedRight(a, 4));
@@ -65,7 +65,7 @@ TEST(common_js, paddedRight)
     EXPECT_EQ(bytes{0xff}, paddedRight(c, 1));
 }
 
-TEST(common_js, unpadded)
+TEST(CommonJS, unpadded)
 {
     bytes a = {0xff, 0xaa, 0x00, 0x00, 0x00};
     EXPECT_EQ(bytes({0xff, 0xaa}), unpadded(a));
@@ -75,7 +75,7 @@ TEST(common_js, unpadded)
     EXPECT_EQ(bytes(), unpadded(c));
 }
 
-TEST(common_js, unpaddedLeft)
+TEST(CommonJS, unpaddedLeft)
 {
     bytes a = {0x00, 0x00, 0x00, 0xff, 0xaa};
     EXPECT_EQ(bytes({0xff, 0xaa}), unpadLeft(a));
@@ -85,7 +85,7 @@ TEST(common_js, unpaddedLeft)
     EXPECT_EQ(bytes(), unpadLeft(c));
 }
 
-TEST(common_js, fromRaw)
+TEST(CommonJS, fromRaw)
 {
     // non ascii characters means empty string
     h256 a("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -96,7 +96,7 @@ TEST(common_js, fromRaw)
     EXPECT_EQ("AsciiCharacters", fromRaw(c));
 }
 
-TEST(common_js, jsToFixed)
+TEST(CommonJS, jsToFixed)
 {
     h256 a("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     EXPECT_EQ(
@@ -106,7 +106,7 @@ TEST(common_js, jsToFixed)
     EXPECT_EQ(h256(), jsToFixed<32>("NotAHexadecimalOrDecimal"));
 }
 
-TEST(common_js, jsToInt)
+TEST(CommonJS, jsToInt)
 {
     EXPECT_EQ(43832124, jsToInt("43832124"));
     EXPECT_EQ(1342356623, jsToInt("0x5002bc8f"));
@@ -121,7 +121,7 @@ TEST(common_js, jsToInt)
     EXPECT_EQ(u128(), jsToInt<16>("NotAHexadecimalOrDecimal"));
 }
 
-TEST(common_js, jsToU256)
+TEST(CommonJS, jsToU256)
 {
     EXPECT_EQ(u256("983298932490823474234"), jsToU256("983298932490823474234"));
     EXPECT_EQ(u256(), jsToU256("NotAHexadecimalOrDecimal"));

--- a/test/unittests/libdevcore/FixedHash.cpp
+++ b/test/unittests/libdevcore/FixedHash.cpp
@@ -1,148 +1,132 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file FixedHash.cpp
- * @author Lefterus <lefteris@ethdev.com>
- * @date 2015
- */
 
-#include <boost/test/unit_test.hpp>
 #include <libdevcore/FixedHash.h>
 #include <libdevcore/SHA3.h>
-#include <test/tools/libtesteth/TestOutputHelper.h>
+
+#include <gtest/gtest.h>
 
 using namespace std;
 using namespace dev;
 
-namespace dev
+TEST(FixedHash, Comparisons)
 {
-namespace test
-{
+    FixedHash<4> h1(sha3("abcd"));
+    FixedHash<4> h2(sha3("abcd"));
+    FixedHash<4> h3(sha3("aadd"));
+    FixedHash<4> h4(0xBAADF00D);
+    FixedHash<4> h5(0xAAAAAAAA);
+    FixedHash<4> h6(0xBAADF00D);
 
-BOOST_FIXTURE_TEST_SUITE(FixedHashTests, TestOutputHelperFixture)
+    EXPECT_EQ(h1, h2);
+    EXPECT_NE(h2, h3);
 
-BOOST_AUTO_TEST_CASE(FixedHashComparisons)
-{
-	FixedHash<4> h1(sha3("abcd"));
-	FixedHash<4> h2(sha3("abcd"));
-	FixedHash<4> h3(sha3("aadd"));
-	FixedHash<4> h4(0xBAADF00D);
-	FixedHash<4> h5(0xAAAAAAAA);
-	FixedHash<4> h6(0xBAADF00D);
-
-	BOOST_CHECK(h1 == h2);
-	BOOST_CHECK(h2 != h3);
-
-	BOOST_CHECK(h4 > h5);
-	BOOST_CHECK(h5 < h4);
-	BOOST_CHECK(h6 <= h4);
-	BOOST_CHECK(h6 >= h4);
+    EXPECT_GT(h4, h5);
+    EXPECT_LT(h5, h4);
+    EXPECT_LE(h6, h4);
+    EXPECT_GE(h6, h4);
 }
 
-BOOST_AUTO_TEST_CASE(FixedHashXOR)
+TEST(FixedHash, XOR)
 {
-	FixedHash<2> h1("0xAAAA");
-	FixedHash<2> h2("0xBBBB");
+    FixedHash<2> h1("0xAAAA");
+    FixedHash<2> h2("0xBBBB");
 
-	BOOST_CHECK((h1 ^ h2) == FixedHash<2>("0x1111"));
-	h1 ^= h2;
-	BOOST_CHECK(h1 == FixedHash<2>("0x1111"));
+    EXPECT_EQ((h1 ^ h2), FixedHash<2>("0x1111"));
+    h1 ^= h2;
+    EXPECT_EQ(h1, FixedHash<2>("0x1111"));
 }
 
-BOOST_AUTO_TEST_CASE(FixedHashOR)
+TEST(FixedHash, OR)
 {
-	FixedHash<4> h1("0xD3ADB33F");
-	FixedHash<4> h2("0xBAADF00D");
-	FixedHash<4> res("0xFBADF33F");
+    FixedHash<4> h1("0xD3ADB33F");
+    FixedHash<4> h2("0xBAADF00D");
+    FixedHash<4> res("0xFBADF33F");
 
-	BOOST_CHECK((h1 | h2) == res);
-	h1 |= h2;
-	BOOST_CHECK(h1 == res);
+    EXPECT_EQ((h1 | h2), res);
+    h1 |= h2;
+    EXPECT_EQ(h1, res);
 }
 
-BOOST_AUTO_TEST_CASE(FixedHashAND)
+TEST(FixedHash, AND)
 {
-	FixedHash<4> h1("0xD3ADB33F");
-	FixedHash<4> h2("0xBAADF00D");
-	FixedHash<4> h3("0x92aDB00D");
+    FixedHash<4> h1("0xD3ADB33F");
+    FixedHash<4> h2("0xBAADF00D");
+    FixedHash<4> h3("0x92aDB00D");
 
-	BOOST_CHECK((h1 & h2) == h3);
-	h1 &= h2;
-	BOOST_CHECK(h1 = h3);
+    EXPECT_EQ((h1 & h2), h3);
+    h1 &= h2;
+    EXPECT_EQ(h1, h3);
 }
 
-BOOST_AUTO_TEST_CASE(FixedHashInvert)
+TEST(FixedHash, Invert)
 {
-	FixedHash<4> h1("0xD3ADB33F");
-	FixedHash<4> h2("0x2C524CC0");
+    FixedHash<4> h1("0xD3ADB33F");
+    FixedHash<4> h2("0x2C524CC0");
 
-	BOOST_CHECK(~h1  == h2);
+    EXPECT_EQ(~h1, h2);
 }
 
-BOOST_AUTO_TEST_CASE(FixedHashContains)
+TEST(FixedHash, Contains)
 {
-	FixedHash<4> h1("0xD3ADB331");
-	FixedHash<4> h2("0x0000B331");
-	FixedHash<4> h3("0x0000000C");
+    FixedHash<4> h1("0xD3ADB331");
+    FixedHash<4> h2("0x0000B331");
+    FixedHash<4> h3("0x0000000C");
 
-	BOOST_CHECK(h1.contains(h2));
-	BOOST_CHECK(!h1.contains(h3));
+    EXPECT_TRUE(h1.contains(h2));
+    EXPECT_FALSE(h1.contains(h3));
 }
 
 void incrementSingleIteration(unsigned seed)
 {
-	unsigned next = seed + 1;
+    unsigned next = seed + 1;
 
-	FixedHash<4> h1(seed);
-	FixedHash<4> h2 = h1;
-	FixedHash<4> h3(next);
+    FixedHash<4> h1(seed);
+    FixedHash<4> h2 = h1;
+    FixedHash<4> h3(next);
 
-	FixedHash<32> hh1(seed);
-	FixedHash<32> hh2 = hh1;
-	FixedHash<32> hh3(next);
+    FixedHash<32> hh1(seed);
+    FixedHash<32> hh2 = hh1;
+    FixedHash<32> hh3(next);
 
-	BOOST_CHECK_EQUAL(++h2, h3);
-	BOOST_CHECK_EQUAL(++hh2, hh3);
+    EXPECT_EQ(++h2, h3);
+    EXPECT_EQ(++hh2, hh3);
 
-	BOOST_CHECK(h2 > h1);
-	BOOST_CHECK(hh2 > hh1);
+    EXPECT_GT(h2, h1);
+    EXPECT_GT(hh2, hh1);
 
-	unsigned reverse1 = ((FixedHash<4>::Arith)h2).convert_to<unsigned>();
-	unsigned reverse2 = ((FixedHash<32>::Arith)hh2).convert_to<unsigned>();
+    unsigned reverse1 = ((FixedHash<4>::Arith)h2).convert_to<unsigned>();
+    unsigned reverse2 = ((FixedHash<32>::Arith)hh2).convert_to<unsigned>();
 
-	BOOST_CHECK_EQUAL(next, reverse1);
-	BOOST_CHECK_EQUAL(next, reverse2);
+    EXPECT_EQ(next, reverse1);
+    EXPECT_EQ(next, reverse2);
 }
 
-BOOST_AUTO_TEST_CASE(FixedHashIncrement)
+TEST(FixedHash, Increment)
 {
-	incrementSingleIteration(0);
-	incrementSingleIteration(1);
-	incrementSingleIteration(0xBAD);
-	incrementSingleIteration(0xBEEF);
-	incrementSingleIteration(0xFFFF);
-	incrementSingleIteration(0xFEDCBA);
-	incrementSingleIteration(0x7FFFFFFF);
+    incrementSingleIteration(0);
+    incrementSingleIteration(1);
+    incrementSingleIteration(0xBAD);
+    incrementSingleIteration(0xBEEF);
+    incrementSingleIteration(0xFFFF);
+    incrementSingleIteration(0xFEDCBA);
+    incrementSingleIteration(0x7FFFFFFF);
 
-	FixedHash<4> h(0xFFFFFFFF);
-	FixedHash<4> zero;
-	BOOST_CHECK_EQUAL(++h, zero);
-}
-
-BOOST_AUTO_TEST_SUITE_END()
-
-}
+    FixedHash<4> h(0xFFFFFFFF);
+    FixedHash<4> zero;
+    EXPECT_EQ(++h, zero);
 }

--- a/test/unittests/libdevcore/FixedHash.cpp
+++ b/test/unittests/libdevcore/FixedHash.cpp
@@ -23,7 +23,7 @@
 using namespace std;
 using namespace dev;
 
-TEST(FixedHash, Comparisons)
+TEST(FixedHash, comparisons)
 {
     FixedHash<4> h1(sha3("abcd"));
     FixedHash<4> h2(sha3("abcd"));
@@ -73,7 +73,7 @@ TEST(FixedHash, AND)
     EXPECT_EQ(h1, h3);
 }
 
-TEST(FixedHash, Invert)
+TEST(FixedHash, invert)
 {
     FixedHash<4> h1("0xD3ADB33F");
     FixedHash<4> h2("0x2C524CC0");
@@ -81,7 +81,7 @@ TEST(FixedHash, Invert)
     EXPECT_EQ(~h1, h2);
 }
 
-TEST(FixedHash, Contains)
+TEST(FixedHash, contains)
 {
     FixedHash<4> h1("0xD3ADB331");
     FixedHash<4> h2("0x0000B331");
@@ -116,7 +116,7 @@ void incrementSingleIteration(unsigned seed)
     EXPECT_EQ(next, reverse2);
 }
 
-TEST(FixedHash, Increment)
+TEST(FixedHash, increment)
 {
     incrementSingleIteration(0);
     incrementSingleIteration(1);

--- a/test/unittests/libdevcore/RLP.cpp
+++ b/test/unittests/libdevcore/RLP.cpp
@@ -10,7 +10,7 @@
 using namespace dev;
 using namespace std;
 
-TEST(rlp, EmptyArrayList)
+TEST(RLP, emptyArrayList)
 {
     try
     {
@@ -28,7 +28,7 @@ TEST(rlp, EmptyArrayList)
     }
 }
 
-TEST(rlp, ActualSize)
+TEST(RLP, actualSize)
 {
     EXPECT_EQ(RLP{}.actualSize(), 0);
 

--- a/test/unittests/libdevcore/RangeMask.cpp
+++ b/test/unittests/libdevcore/RangeMask.cpp
@@ -1,18 +1,18 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 /** @file RangeMask.cpp
  * @author Christian <c@ethdev.com>
@@ -20,131 +20,119 @@
  */
 
 #include <libdevcore/RangeMask.h>
-#include <test/tools/libtesteth/TestOutputHelper.h>
-#include <boost/test/unit_test.hpp>
+
+#include <gtest/gtest.h>
 
 using namespace std;
 using namespace dev;
-using namespace boost::unit_test;
 
-namespace dev
+TEST(RangeMask, constructor)
 {
-namespace test
-{
-
-BOOST_FIXTURE_TEST_SUITE(RangeMaskTest, TestOutputHelperFixture)
-
-BOOST_AUTO_TEST_CASE(constructor)
-{
-	using RM = RangeMask;
-	using Range = pair<unsigned, unsigned>;
-	for (RM r: {RM(), RM(1, 10), RM(Range(2, 10))})
-	{
-		BOOST_CHECK(r.empty());
-		BOOST_CHECK(!r.contains(0));
-		BOOST_CHECK(!r.contains(1));
-		BOOST_CHECK_EQUAL(0, r.size());
-	}
-	BOOST_CHECK(RM().full());
-	BOOST_CHECK(!RM(1, 10).full());
-	BOOST_CHECK(!RM(Range(2, 10)).full());
+    using RM = RangeMask;
+    using Range = pair<unsigned, unsigned>;
+    for (RM r : {RM(), RM(1, 10), RM(Range(2, 10))})
+    {
+        EXPECT_TRUE(r.empty());
+        EXPECT_FALSE(r.contains(0));
+        EXPECT_FALSE(r.contains(1));
+        EXPECT_EQ(0, r.size());
+    }
+    EXPECT_TRUE(RM().full());
+    EXPECT_FALSE(RM(1, 10).full());
+    EXPECT_FALSE(RM(Range(2, 10)).full());
 }
 
-BOOST_AUTO_TEST_CASE(simple_unions)
+TEST(RangeMask, simple_unions)
 {
-	using RM = RangeMask;
-	using Range = pair<unsigned, unsigned>;
-	RM m(Range(0, 2000));
-	m.unionWith(Range(1, 2));
-	BOOST_CHECK_EQUAL(m.size(), 1);
-	m.unionWith(Range(50, 250));
-	BOOST_CHECK_EQUAL(m.size(), 201);
-	m.unionWith(Range(10, 16));
-	BOOST_CHECK_EQUAL(m.size(), 207);
-	BOOST_CHECK(m.contains(1));
-	BOOST_CHECK(m.contains(11));
-	BOOST_CHECK(m.contains(51));
-	BOOST_CHECK(m.contains(200));
-	BOOST_CHECK(!m.contains(2));
-	BOOST_CHECK(!m.contains(7));
-	BOOST_CHECK(!m.contains(17));
-	BOOST_CHECK(!m.contains(258));
+    using RM = RangeMask;
+    using Range = pair<unsigned, unsigned>;
+    RM m(Range(0, 2000));
+    m.unionWith(Range(1, 2));
+    EXPECT_EQ(m.size(), 1);
+    m.unionWith(Range(50, 250));
+    EXPECT_EQ(m.size(), 201);
+    m.unionWith(Range(10, 16));
+    EXPECT_EQ(m.size(), 207);
+    EXPECT_TRUE(m.contains(1));
+    EXPECT_TRUE(m.contains(11));
+    EXPECT_TRUE(m.contains(51));
+    EXPECT_TRUE(m.contains(200));
+    EXPECT_FALSE(m.contains(2));
+    EXPECT_FALSE(m.contains(7));
+    EXPECT_FALSE(m.contains(17));
+    EXPECT_FALSE(m.contains(258));
 }
 
-BOOST_AUTO_TEST_CASE(empty_union)
+TEST(RangeMask, empty_union)
 {
-	using RM = RangeMask;
-	using Range = pair<unsigned, unsigned>;
-	RM m(Range(0, 2000));
-	m.unionWith(Range(3, 6));
-	BOOST_CHECK_EQUAL(m.size(), 3);
-	m.unionWith(Range(50, 50));
-	BOOST_CHECK_EQUAL(m.size(), 3);
-	m.unionWith(Range(0, 0));
-	BOOST_CHECK_EQUAL(m.size(), 3);
-	m.unionWith(Range(1, 1));
-	BOOST_CHECK_EQUAL(m.size(), 3);
-	m.unionWith(Range(2, 2));
-	BOOST_CHECK_EQUAL(m.size(), 3);
-	m.unionWith(Range(3, 3));
-	BOOST_CHECK_EQUAL(m.size(), 3);
+    using RM = RangeMask;
+    using Range = pair<unsigned, unsigned>;
+    RM m(Range(0, 2000));
+    m.unionWith(Range(3, 6));
+    EXPECT_EQ(m.size(), 3);
+    m.unionWith(Range(50, 50));
+    EXPECT_EQ(m.size(), 3);
+    m.unionWith(Range(0, 0));
+    EXPECT_EQ(m.size(), 3);
+    m.unionWith(Range(1, 1));
+    EXPECT_EQ(m.size(), 3);
+    m.unionWith(Range(2, 2));
+    EXPECT_EQ(m.size(), 3);
+    m.unionWith(Range(3, 3));
+    EXPECT_EQ(m.size(), 3);
 }
 
-BOOST_AUTO_TEST_CASE(overlapping_unions)
+TEST(RangeMask, overlapping_unions)
 {
-	using RM = RangeMask;
-	using Range = pair<unsigned, unsigned>;
-	RM m(Range(0, 2000));
-	m.unionWith(Range(10, 20));
-	BOOST_CHECK_EQUAL(10, m.size());
-	m.unionWith(Range(30, 40));
-	BOOST_CHECK_EQUAL(20, m.size());
-	m.unionWith(Range(15, 30));
-	BOOST_CHECK_EQUAL(40 - 10, m.size());
-	m.unionWith(Range(50, 60));
-	m.unionWith(Range(45, 55));
-	// [40, 45) still missing here
-	BOOST_CHECK_EQUAL(60 - 10 - 5, m.size());
-	m.unionWith(Range(15, 56));
-	BOOST_CHECK_EQUAL(60 - 10, m.size());
-	m.unionWith(Range(15, 65));
-	BOOST_CHECK_EQUAL(65 - 10, m.size());
-	m.unionWith(Range(5, 70));
-	BOOST_CHECK_EQUAL(70 - 5, m.size());
+    using RM = RangeMask;
+    using Range = pair<unsigned, unsigned>;
+    RM m(Range(0, 2000));
+    m.unionWith(Range(10, 20));
+    EXPECT_EQ(10, m.size());
+    m.unionWith(Range(30, 40));
+    EXPECT_EQ(20, m.size());
+    m.unionWith(Range(15, 30));
+    EXPECT_EQ(40 - 10, m.size());
+    m.unionWith(Range(50, 60));
+    m.unionWith(Range(45, 55));
+    // [40, 45) still missing here
+    EXPECT_EQ(60 - 10 - 5, m.size());
+    m.unionWith(Range(15, 56));
+    EXPECT_EQ(60 - 10, m.size());
+    m.unionWith(Range(15, 65));
+    EXPECT_EQ(65 - 10, m.size());
+    m.unionWith(Range(5, 70));
+    EXPECT_EQ(70 - 5, m.size());
 }
 
-BOOST_AUTO_TEST_CASE(complement)
+TEST(RangeMask, complement)
 {
-	using RM = RangeMask;
-	using Range = pair<unsigned, unsigned>;
-	RM m(Range(0, 2000));
-	m.unionWith(7).unionWith(9);
-	m = ~m;
-	m.unionWith(7).unionWith(9);
-	m = ~m;
-	BOOST_CHECK(m.empty());
+    using RM = RangeMask;
+    using Range = pair<unsigned, unsigned>;
+    RM m(Range(0, 2000));
+    m.unionWith(7).unionWith(9);
+    m = ~m;
+    m.unionWith(7).unionWith(9);
+    m = ~m;
+    EXPECT_TRUE(m.empty());
 
-	m += Range(0, 10);
-	m += Range(1000, 2000);
-	m.invert();
-	BOOST_CHECK_EQUAL(m.size(), 1000 - 10);
+    m += Range(0, 10);
+    m += Range(1000, 2000);
+    m.invert();
+    EXPECT_EQ(m.size(), 1000 - 10);
 }
 
-BOOST_AUTO_TEST_CASE(iterator)
+TEST(RangeMask, iterator)
 {
-	using RM = RangeMask;
-	using Range = pair<unsigned, unsigned>;
-	RM m(Range(0, 2000));
-	m.unionWith(Range(7, 9));
-	m.unionWith(11);
-	m.unionWith(Range(200, 205));
+    using RM = RangeMask;
+    using Range = pair<unsigned, unsigned>;
+    RM m(Range(0, 2000));
+    m.unionWith(Range(7, 9));
+    m.unionWith(11);
+    m.unionWith(Range(200, 205));
 
-	vector<unsigned> elements;
-	copy(m.begin(), m.end(), back_inserter(elements));
-	BOOST_CHECK(elements == (vector<unsigned>{7, 8, 11, 200, 201, 202, 203, 204}));
+    vector<unsigned> elements;
+    copy(m.begin(), m.end(), back_inserter(elements));
+    EXPECT_TRUE(elements == (vector<unsigned>{7, 8, 11, 200, 201, 202, 203, 204}));
 }
 
-BOOST_AUTO_TEST_SUITE_END()
-
-}
-}

--- a/test/unittests/libdevcore/RangeMask.cpp
+++ b/test/unittests/libdevcore/RangeMask.cpp
@@ -42,7 +42,7 @@ TEST(RangeMask, constructor)
     EXPECT_FALSE(RM(Range(2, 10)).full());
 }
 
-TEST(RangeMask, simple_unions)
+TEST(RangeMask, simpleUnions)
 {
     using RM = RangeMask;
     using Range = pair<unsigned, unsigned>;
@@ -63,7 +63,7 @@ TEST(RangeMask, simple_unions)
     EXPECT_FALSE(m.contains(258));
 }
 
-TEST(RangeMask, empty_union)
+TEST(RangeMask, emptyUnion)
 {
     using RM = RangeMask;
     using Range = pair<unsigned, unsigned>;
@@ -82,7 +82,7 @@ TEST(RangeMask, empty_union)
     EXPECT_EQ(m.size(), 3);
 }
 
-TEST(RangeMask, overlapping_unions)
+TEST(RangeMask, overlappingUnions)
 {
     using RM = RangeMask;
     using Range = pair<unsigned, unsigned>;

--- a/test/unittests/libdevcore/core.cpp
+++ b/test/unittests/libdevcore/core.cpp
@@ -1,75 +1,67 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file core.cpp
- * @author Dimitry Khokhlov <winsvega@mail.ru>
- * @date 2014
- * CORE test functions.
- */
 
-#include <boost/test/unit_test.hpp>
 #include <libdevcore/CommonIO.h>
-#include <libdevcore/Log.h>
-#include <test/tools/libtesteth/TestOutputHelper.h>
+#include <libdevcore/FixedHash.h>
 
-using namespace dev::test;
+#include <gtest/gtest.h>
 
-BOOST_FIXTURE_TEST_SUITE(CoreLibTests, TestOutputHelperFixture)
-
-BOOST_AUTO_TEST_CASE(toHex)
+TEST(core, toHex)
 {
-	dev::bytes b = dev::fromHex("f0e1d2c3b4a59687");
-	BOOST_CHECK_EQUAL(dev::toHex(b), "f0e1d2c3b4a59687");
-	BOOST_CHECK_EQUAL(dev::toHexPrefixed(b), "0xf0e1d2c3b4a59687");
+    dev::bytes b = dev::fromHex("f0e1d2c3b4a59687");
+    EXPECT_EQ(dev::toHex(b), "f0e1d2c3b4a59687");
+    EXPECT_EQ(dev::toHexPrefixed(b), "0xf0e1d2c3b4a59687");
 
-	dev::h256 h("705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
-	BOOST_CHECK_EQUAL(dev::toHex(h), "705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
-	BOOST_CHECK_EQUAL(dev::toHexPrefixed(h), "0x705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
+    dev::h256 h("705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
+    EXPECT_EQ(dev::toHex(h), "705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
+    EXPECT_EQ(dev::toHexPrefixed(h),
+        "0x705a1849c02140e7197fbde82987a9eb623f97e32fc479a3cd8e4b3b52dcc4b2");
 }
 
-BOOST_AUTO_TEST_CASE(toCompactHex)
+TEST(core, toCompactHex)
 {
-	dev::u256 i("0x123456789abcdef");
-	BOOST_CHECK_EQUAL(dev::toCompactHex(i), "0123456789abcdef");
-	BOOST_CHECK_EQUAL(dev::toCompactHexPrefixed(i), "0x0123456789abcdef");
+    dev::u256 i("0x123456789abcdef");
+    EXPECT_EQ(dev::toCompactHex(i), "0123456789abcdef");
+    EXPECT_EQ(dev::toCompactHexPrefixed(i), "0x0123456789abcdef");
 }
 
-BOOST_AUTO_TEST_CASE(byteRef)
-{	
-	cnote << "bytesRef copyTo and toString...";
-	dev::bytes originalSequence = dev::fromHex("0102030405060708091011121314151617181920212223242526272829303132");
-	dev::bytesRef out(&originalSequence.at(0), 32);
-	dev::h256 hash32("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
-	hash32.ref().copyTo(out);
-
-	BOOST_CHECK_MESSAGE(out.size() == 32, "Error wrong result size when h256::ref().copyTo(dev::bytesRef out)");
-	BOOST_CHECK_MESSAGE(out.toBytes() == originalSequence, "Error when h256::ref().copyTo(dev::bytesRef out)");
-}
-
-BOOST_AUTO_TEST_CASE(isHex)
+TEST(core, byteRef)
 {
-	BOOST_CHECK(dev::isHex("0x"));
-	BOOST_CHECK(dev::isHex("0xA"));
-	BOOST_CHECK(dev::isHex("0xAB"));
-	BOOST_CHECK(dev::isHex("0x0AA"));
-	BOOST_CHECK(!dev::isHex("0x0Ag"));
-	BOOST_CHECK(!dev::isHex("0Ag"));
-	BOOST_CHECK(!dev::isHex(" "));
-	BOOST_CHECK(dev::isHex("aa"));
-	BOOST_CHECK(dev::isHex("003"));
+    dev::bytes originalSequence =
+        dev::fromHex("0102030405060708091011121314151617181920212223242526272829303132");
+    dev::bytesRef out(&originalSequence.at(0), 32);
+    dev::h256 hash32("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    hash32.ref().copyTo(out);
+
+    EXPECT_EQ(out.size(), 32)
+        << "Error wrong result size when h256::ref().copyTo(dev::bytesRef out)";
+    EXPECT_EQ(out.toBytes(), originalSequence)
+        << "Error when h256::ref().copyTo(dev::bytesRef out)";
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+TEST(core, isHex)
+{
+    EXPECT_TRUE(dev::isHex("0x"));
+    EXPECT_TRUE(dev::isHex("0xA"));
+    EXPECT_TRUE(dev::isHex("0xAB"));
+    EXPECT_TRUE(dev::isHex("0x0AA"));
+    EXPECT_FALSE(dev::isHex("0x0Ag"));
+    EXPECT_FALSE(dev::isHex("0Ag"));
+    EXPECT_FALSE(dev::isHex(" "));
+    EXPECT_TRUE(dev::isHex("aa"));
+    EXPECT_TRUE(dev::isHex("003"));
+}

--- a/test/unittests/libdevcore/rlp.cpp
+++ b/test/unittests/libdevcore/rlp.cpp
@@ -38,174 +38,174 @@ namespace js = json_spirit;
 
 namespace dev
 {
-    namespace test
+namespace test
+{
+void buildRLP(js::mValue const& _v, RLPStream& _rlp);
+void checkRLPAgainstJson(js::mValue const& v, RLP& u);
+enum class RlpType
+{
+    Valid,
+    Invalid,
+    Test
+};
+
+void doRlpTests(json_spirit::mValue const& _input)
+{
+    string testname;
+    for (auto& i : _input.get_obj())
     {
-        void buildRLP(js::mValue const& _v, RLPStream& _rlp);
-        void checkRLPAgainstJson(js::mValue const& v, RLP& u);
-        enum class RlpType
+        js::mObject const& o = i.second.get_obj();
+
+        cnote << "  " << i.first;
+        testname = "(" + i.first + ") ";
+
+        BOOST_REQUIRE_MESSAGE(o.count("out") > 0, testname + "out not set!");
+        BOOST_REQUIRE_MESSAGE(!o.at("out").is_null(), testname + "out is set to null!");
+
+        // Check Encode
+        BOOST_REQUIRE_MESSAGE(o.count("in") > 0, testname + "in not set!");
+        RlpType rlpType = RlpType::Test;
+        if (o.at("in").type() == js::str_type)
         {
-            Valid,
-            Invalid,
-            Test
-        };
-
-        void doRlpTests(json_spirit::mValue const& _input)
-        {
-            string testname;
-            for (auto& i: _input.get_obj())
-            {
-                js::mObject const& o = i.second.get_obj();
-
-                cnote << "  " << i.first;
-                testname = "(" + i.first + ") ";
-
-                BOOST_REQUIRE_MESSAGE(o.count("out") > 0, testname + "out not set!");
-                BOOST_REQUIRE_MESSAGE(!o.at("out").is_null(), testname + "out is set to null!");
-
-                //Check Encode
-                BOOST_REQUIRE_MESSAGE(o.count("in") > 0, testname + "in not set!");
-                RlpType rlpType = RlpType::Test;
-                if (o.at("in").type() == js::str_type)
-                {
-                    if (o.at("in").get_str() == "INVALID")
-                        rlpType = RlpType::Invalid;
-                    else if (o.at("in").get_str() == "VALID")
-                        rlpType = RlpType::Valid;
-                }
-
-                if (rlpType == RlpType::Test)
-                {
-                    RLPStream s;
-                    dev::test::buildRLP(o.at("in"), s);
-                    string computedText = toHex(s.out());
-
-                    string expectedText(o.at("out").get_str());
-                    transform(expectedText.begin(), expectedText.end(), expectedText.begin(), ::tolower );
-
-                    stringstream msg;
-                    msg << "Encoding Failed: expected: " << expectedText << std::endl;
-                    msg << " But Computed: " << computedText;
-                    BOOST_CHECK_MESSAGE(expectedText == computedText, testname + msg.str());
-                }
-
-                //Check Decode
-                // Uses the same test cases as encoding but in reverse.
-                // We read into the string of hex values, convert to bytes,
-                // and then compare the output structure to the json of the
-                // input object.
-                bool was_exception = false;
-                js::mValue const& inputData = o.at("in");
-                try
-                {
-                    bytes payloadToDecode = fromHex(o.at("out").get_str());
-                    RLP payload(payloadToDecode);
-
-                    //attempt to read all the contents of RLP
-                    ostringstream() << payload;
-
-                    if (rlpType == RlpType::Test)
-                        dev::test::checkRLPAgainstJson(inputData, payload);
-                }
-                catch (Exception const& _e)
-                {
-                    cnote << "Exception: " << diagnostic_information(_e);
-                    was_exception = true;
-                }
-                catch (std::exception const& _e)
-                {
-                    cnote << "rlp exception: " << _e.what();
-                    was_exception = true;
-                }
-
-                //Expect exception as input is INVALID
-                if (rlpType == RlpType::Invalid && was_exception)
-                    continue;
-
-                //Check that there was an exception as input is INVALID
-                if (rlpType == RlpType::Invalid && !was_exception)
-                    BOOST_ERROR(testname + "Expected RLP Exception as rlp should be invalid!");
-
-                //input is VALID check that there was no exceptions
-                if (was_exception)
-                    BOOST_ERROR(testname + "Unexpected RLP Exception!");
-            }
+            if (o.at("in").get_str() == "INVALID")
+                rlpType = RlpType::Invalid;
+            else if (o.at("in").get_str() == "VALID")
+                rlpType = RlpType::Valid;
         }
 
-        void buildRLP(js::mValue const& _v, RLPStream& _rlp)
+        if (rlpType == RlpType::Test)
         {
-            if (_v.type() == js::array_type)
-            {
-                RLPStream s;
-                for (auto& i: _v.get_array())
-                    buildRLP(i, s);
-                _rlp.appendList(s.out());
-            }
-            else if (_v.type() == js::int_type)
-                _rlp.append(_v.get_uint64());
-            else if (_v.type() == js::str_type)
-            {
-                auto s = _v.get_str();
-                if (s.size() && s[0] == '#')
-                    _rlp.append(bigint(s.substr(1)));
-                else
-                    _rlp.append(s);
-            }
+            RLPStream s;
+            dev::test::buildRLP(o.at("in"), s);
+            string computedText = toHex(s.out());
+
+            string expectedText(o.at("out").get_str());
+            transform(expectedText.begin(), expectedText.end(), expectedText.begin(), ::tolower);
+
+            stringstream msg;
+            msg << "Encoding Failed: expected: " << expectedText << std::endl;
+            msg << " But Computed: " << computedText;
+            BOOST_CHECK_MESSAGE(expectedText == computedText, testname + msg.str());
         }
 
-        void checkRLPAgainstJson(js::mValue const& v, RLP& u)
+        // Check Decode
+        // Uses the same test cases as encoding but in reverse.
+        // We read into the string of hex values, convert to bytes,
+        // and then compare the output structure to the json of the
+        // input object.
+        bool was_exception = false;
+        js::mValue const& inputData = o.at("in");
+        try
         {
-            if ( v.type() == js::str_type )
-            {
-                const string& expectedText = v.get_str();
-                if ( !expectedText.empty() && expectedText.front() == '#' )
-                {
-                    // Deal with bigint instead of a raw string
-                    string bigIntStr = expectedText.substr(1,expectedText.length()-1);
-                    stringstream bintStream(bigIntStr);
-                    bigint val;
-                    bintStream >> val;
-                    BOOST_CHECK( !u.isList() );
-                    BOOST_CHECK( !u.isNull() );
-                    BOOST_CHECK( u == val );
-                }
-                else
-                {
-                    BOOST_CHECK( !u.isList() );
-                    BOOST_CHECK( !u.isNull() );
-                    BOOST_CHECK( u.isData() );
-                    BOOST_CHECK( u.size() == expectedText.length() );
-                    BOOST_CHECK( u == expectedText );
-                }
-            }
-            else if ( v.type() == js::int_type )
-            {
-                const int expectedValue = v.get_int();
-                BOOST_CHECK( u.isInt() );
-                BOOST_CHECK( !u.isList() );
-                BOOST_CHECK( !u.isNull() );
-                BOOST_CHECK( u == expectedValue );
-            }
-            else if ( v.type() == js::array_type )
-            {
-                BOOST_CHECK( u.isList() );
-                BOOST_CHECK( !u.isInt() );
-                BOOST_CHECK( !u.isData() );
-                js::mArray const& arr = v.get_array();
-                BOOST_CHECK( u.itemCount() == arr.size() );
-                unsigned i;
-                for( i = 0; i < arr.size(); i++ )
-                {
-                    RLP item = u[i];
-                    checkRLPAgainstJson(arr[i], item);
-                }
-            }
-            else
-            {
-                BOOST_ERROR("Invalid Javascript object!");
-            }
+            bytes payloadToDecode = fromHex(o.at("out").get_str());
+            RLP payload(payloadToDecode);
+
+            // attempt to read all the contents of RLP
+            ostringstream() << payload;
+
+            if (rlpType == RlpType::Test)
+                dev::test::checkRLPAgainstJson(inputData, payload);
         }
+        catch (Exception const& _e)
+        {
+            cnote << "Exception: " << diagnostic_information(_e);
+            was_exception = true;
+        }
+        catch (std::exception const& _e)
+        {
+            cnote << "rlp exception: " << _e.what();
+            was_exception = true;
+        }
+
+        // Expect exception as input is INVALID
+        if (rlpType == RlpType::Invalid && was_exception)
+            continue;
+
+        // Check that there was an exception as input is INVALID
+        if (rlpType == RlpType::Invalid && !was_exception)
+            BOOST_ERROR(testname + "Expected RLP Exception as rlp should be invalid!");
+
+        // input is VALID check that there was no exceptions
+        if (was_exception)
+            BOOST_ERROR(testname + "Unexpected RLP Exception!");
     }
 }
+
+void buildRLP(js::mValue const& _v, RLPStream& _rlp)
+{
+    if (_v.type() == js::array_type)
+    {
+        RLPStream s;
+        for (auto& i : _v.get_array())
+            buildRLP(i, s);
+        _rlp.appendList(s.out());
+    }
+    else if (_v.type() == js::int_type)
+        _rlp.append(_v.get_uint64());
+    else if (_v.type() == js::str_type)
+    {
+        auto s = _v.get_str();
+        if (s.size() && s[0] == '#')
+            _rlp.append(bigint(s.substr(1)));
+        else
+            _rlp.append(s);
+    }
+}
+
+void checkRLPAgainstJson(js::mValue const& v, RLP& u)
+{
+    if (v.type() == js::str_type)
+    {
+        const string& expectedText = v.get_str();
+        if (!expectedText.empty() && expectedText.front() == '#')
+        {
+            // Deal with bigint instead of a raw string
+            string bigIntStr = expectedText.substr(1, expectedText.length() - 1);
+            stringstream bintStream(bigIntStr);
+            bigint val;
+            bintStream >> val;
+            BOOST_CHECK(!u.isList());
+            BOOST_CHECK(!u.isNull());
+            BOOST_CHECK(u == val);
+        }
+        else
+        {
+            BOOST_CHECK(!u.isList());
+            BOOST_CHECK(!u.isNull());
+            BOOST_CHECK(u.isData());
+            BOOST_CHECK(u.size() == expectedText.length());
+            BOOST_CHECK(u == expectedText);
+        }
+    }
+    else if (v.type() == js::int_type)
+    {
+        const int expectedValue = v.get_int();
+        BOOST_CHECK(u.isInt());
+        BOOST_CHECK(!u.isList());
+        BOOST_CHECK(!u.isNull());
+        BOOST_CHECK(u == expectedValue);
+    }
+    else if (v.type() == js::array_type)
+    {
+        BOOST_CHECK(u.isList());
+        BOOST_CHECK(!u.isInt());
+        BOOST_CHECK(!u.isData());
+        js::mArray const& arr = v.get_array();
+        BOOST_CHECK(u.itemCount() == arr.size());
+        unsigned i;
+        for (i = 0; i < arr.size(); i++)
+        {
+            RLP item = u[i];
+            checkRLPAgainstJson(arr[i], item);
+        }
+    }
+    else
+    {
+        BOOST_ERROR("Invalid Javascript object!");
+    }
+}
+}  // namespace test
+}  // namespace dev
 
 void runRlpTest(string _name, fs::path const& _path)
 {
@@ -216,9 +216,12 @@ void runRlpTest(string _name, fs::path const& _path)
         cnote << "TEST " << _name << ":";
         json_spirit::mValue v;
         string const s = asString(dev::contents(testPath / fs::path(_name + ".json")));
-        BOOST_REQUIRE_MESSAGE(s.length() > 0, "Contents of " << (testPath / fs::path(_name + ".json")).string() << " is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?");
+        BOOST_REQUIRE_MESSAGE(
+            s.length() > 0, "Contents of " << (testPath / fs::path(_name + ".json")).string()
+                                           << " is empty. Have you cloned the 'tests' repo branch "
+                                              "develop and set ETHEREUM_TEST_PATH to its path?");
         json_spirit::read_string(s, v);
-        //Listener::notifySuiteStarted(_name);
+        // Listener::notifySuiteStarted(_name);
         dev::test::doRlpTests(v);
     }
     catch (Exception const& _e)
@@ -273,22 +276,26 @@ BOOST_AUTO_TEST_CASE(rlpRandom)
     testPath /= fs::path("RLPTests/RandomRLPTests");
 
     vector<boost::filesystem::path> testFiles = test::getFiles(testPath, {".json"});
-    for (auto& path: testFiles)
+    for (auto& path : testFiles)
     {
         try
         {
             cnote << "Testing ..." << path.filename();
             json_spirit::mValue v;
             string s = asString(dev::contents(path.string()));
-            BOOST_REQUIRE_MESSAGE(s.length() > 0, "Content of " + path.string() + " is empty. Have you cloned the 'tests' repo branch develop and set ETHEREUM_TEST_PATH to its path?");
+            BOOST_REQUIRE_MESSAGE(
+                s.length() > 0, "Content of " + path.string() +
+                                    " is empty. Have you cloned the 'tests' repo branch develop "
+                                    "and set ETHEREUM_TEST_PATH to its path?");
             json_spirit::read_string(s, v);
-            //test::Listener::notifySuiteStarted(path.filename().string());
+            // test::Listener::notifySuiteStarted(path.filename().string());
             dev::test::doRlpTests(v);
         }
 
         catch (Exception const& _e)
         {
-            BOOST_ERROR(path.filename().string() + "Failed test with Exception: " << diagnostic_information(_e));
+            BOOST_ERROR(path.filename().string() + "Failed test with Exception: "
+                        << diagnostic_information(_e));
         }
         catch (std::exception const& _e)
         {

--- a/test/unittests/libdevcore/rlp.cpp
+++ b/test/unittests/libdevcore/rlp.cpp
@@ -1,244 +1,16 @@
-/*
-    This file is part of cpp-ethereum.
+/* Aleth: Ethereum C++ client, tools and libraries.
+ * Copyright 2018 Aleth Autors.
+ * Licensed under the GNU General Public License, Version 3. See the LICENSE file.
+ */
 
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/// @file
-/// RLP unit tests.
-
-#include <json_spirit/JsonSpiritHeaders.h>
-#include <libdevcore/Common.h>
-#include <libdevcore/CommonIO.h>
-#include <libdevcore/Log.h>
 #include <libdevcore/RLP.h>
-#include <test/tools/libtesteth/TestHelper.h>
-#include <test/tools/libtesteth/TestOutputHelper.h>
 
-#include <boost/filesystem.hpp>
-#include <boost/test/unit_test.hpp>
-#include <algorithm>
-#include <fstream>
-#include <sstream>
+#include <gtest/gtest.h>
 
-using namespace std;
 using namespace dev;
-namespace fs = boost::filesystem;
-namespace js = json_spirit;
+using namespace std;
 
-namespace dev
-{
-namespace test
-{
-void buildRLP(js::mValue const& _v, RLPStream& _rlp);
-void checkRLPAgainstJson(js::mValue const& v, RLP& u);
-enum class RlpType
-{
-    Valid,
-    Invalid,
-    Test
-};
-
-void doRlpTests(json_spirit::mValue const& _input)
-{
-    string testname;
-    for (auto& i : _input.get_obj())
-    {
-        js::mObject const& o = i.second.get_obj();
-
-        cnote << "  " << i.first;
-        testname = "(" + i.first + ") ";
-
-        BOOST_REQUIRE_MESSAGE(o.count("out") > 0, testname + "out not set!");
-        BOOST_REQUIRE_MESSAGE(!o.at("out").is_null(), testname + "out is set to null!");
-
-        // Check Encode
-        BOOST_REQUIRE_MESSAGE(o.count("in") > 0, testname + "in not set!");
-        RlpType rlpType = RlpType::Test;
-        if (o.at("in").type() == js::str_type)
-        {
-            if (o.at("in").get_str() == "INVALID")
-                rlpType = RlpType::Invalid;
-            else if (o.at("in").get_str() == "VALID")
-                rlpType = RlpType::Valid;
-        }
-
-        if (rlpType == RlpType::Test)
-        {
-            RLPStream s;
-            dev::test::buildRLP(o.at("in"), s);
-            string computedText = toHex(s.out());
-
-            string expectedText(o.at("out").get_str());
-            transform(expectedText.begin(), expectedText.end(), expectedText.begin(), ::tolower);
-
-            stringstream msg;
-            msg << "Encoding Failed: expected: " << expectedText << std::endl;
-            msg << " But Computed: " << computedText;
-            BOOST_CHECK_MESSAGE(expectedText == computedText, testname + msg.str());
-        }
-
-        // Check Decode
-        // Uses the same test cases as encoding but in reverse.
-        // We read into the string of hex values, convert to bytes,
-        // and then compare the output structure to the json of the
-        // input object.
-        bool was_exception = false;
-        js::mValue const& inputData = o.at("in");
-        try
-        {
-            bytes payloadToDecode = fromHex(o.at("out").get_str());
-            RLP payload(payloadToDecode);
-
-            // attempt to read all the contents of RLP
-            ostringstream() << payload;
-
-            if (rlpType == RlpType::Test)
-                dev::test::checkRLPAgainstJson(inputData, payload);
-        }
-        catch (Exception const& _e)
-        {
-            cnote << "Exception: " << diagnostic_information(_e);
-            was_exception = true;
-        }
-        catch (std::exception const& _e)
-        {
-            cnote << "rlp exception: " << _e.what();
-            was_exception = true;
-        }
-
-        // Expect exception as input is INVALID
-        if (rlpType == RlpType::Invalid && was_exception)
-            continue;
-
-        // Check that there was an exception as input is INVALID
-        if (rlpType == RlpType::Invalid && !was_exception)
-            BOOST_ERROR(testname + "Expected RLP Exception as rlp should be invalid!");
-
-        // input is VALID check that there was no exceptions
-        if (was_exception)
-            BOOST_ERROR(testname + "Unexpected RLP Exception!");
-    }
-}
-
-void buildRLP(js::mValue const& _v, RLPStream& _rlp)
-{
-    if (_v.type() == js::array_type)
-    {
-        RLPStream s;
-        for (auto& i : _v.get_array())
-            buildRLP(i, s);
-        _rlp.appendList(s.out());
-    }
-    else if (_v.type() == js::int_type)
-        _rlp.append(_v.get_uint64());
-    else if (_v.type() == js::str_type)
-    {
-        auto s = _v.get_str();
-        if (s.size() && s[0] == '#')
-            _rlp.append(bigint(s.substr(1)));
-        else
-            _rlp.append(s);
-    }
-}
-
-void checkRLPAgainstJson(js::mValue const& v, RLP& u)
-{
-    if (v.type() == js::str_type)
-    {
-        const string& expectedText = v.get_str();
-        if (!expectedText.empty() && expectedText.front() == '#')
-        {
-            // Deal with bigint instead of a raw string
-            string bigIntStr = expectedText.substr(1, expectedText.length() - 1);
-            stringstream bintStream(bigIntStr);
-            bigint val;
-            bintStream >> val;
-            BOOST_CHECK(!u.isList());
-            BOOST_CHECK(!u.isNull());
-            BOOST_CHECK(u == val);
-        }
-        else
-        {
-            BOOST_CHECK(!u.isList());
-            BOOST_CHECK(!u.isNull());
-            BOOST_CHECK(u.isData());
-            BOOST_CHECK(u.size() == expectedText.length());
-            BOOST_CHECK(u == expectedText);
-        }
-    }
-    else if (v.type() == js::int_type)
-    {
-        const int expectedValue = v.get_int();
-        BOOST_CHECK(u.isInt());
-        BOOST_CHECK(!u.isList());
-        BOOST_CHECK(!u.isNull());
-        BOOST_CHECK(u == expectedValue);
-    }
-    else if (v.type() == js::array_type)
-    {
-        BOOST_CHECK(u.isList());
-        BOOST_CHECK(!u.isInt());
-        BOOST_CHECK(!u.isData());
-        js::mArray const& arr = v.get_array();
-        BOOST_CHECK(u.itemCount() == arr.size());
-        unsigned i;
-        for (i = 0; i < arr.size(); i++)
-        {
-            RLP item = u[i];
-            checkRLPAgainstJson(arr[i], item);
-        }
-    }
-    else
-    {
-        BOOST_ERROR("Invalid Javascript object!");
-    }
-}
-}  // namespace test
-}  // namespace dev
-
-void runRlpTest(string _name, fs::path const& _path)
-{
-    fs::path const testPath = dev::test::getTestPath() / _path;
-
-    try
-    {
-        cnote << "TEST " << _name << ":";
-        json_spirit::mValue v;
-        string const s = asString(dev::contents(testPath / fs::path(_name + ".json")));
-        BOOST_REQUIRE_MESSAGE(
-            s.length() > 0, "Contents of " << (testPath / fs::path(_name + ".json")).string()
-                                           << " is empty. Have you cloned the 'tests' repo branch "
-                                              "develop and set ETHEREUM_TEST_PATH to its path?");
-        json_spirit::read_string(s, v);
-        // Listener::notifySuiteStarted(_name);
-        dev::test::doRlpTests(v);
-    }
-    catch (Exception const& _e)
-    {
-        BOOST_ERROR("Failed test with Exception: " << diagnostic_information(_e));
-    }
-    catch (std::exception const& _e)
-    {
-        BOOST_ERROR("Failed test with Exception: " << _e.what());
-    }
-}
-
-using namespace dev::test;
-
-BOOST_FIXTURE_TEST_SUITE(RlpTests, TestOutputHelperFixture)
-
-BOOST_AUTO_TEST_CASE(EmptyArrayList)
+TEST(rlp, EmptyArrayList)
 {
     try
     {
@@ -250,78 +22,28 @@ BOOST_AUTO_TEST_CASE(EmptyArrayList)
         RLP payload2(payloadToDecode);
         ostringstream() << payload2;
     }
-    catch (Exception const& _e)
-    {
-        BOOST_ERROR("(EmptyArrayList) Failed test with Exception: " << _e.what());
-    }
     catch (std::exception const& _e)
     {
-        BOOST_ERROR("(EmptyArrayList) Failed test with Exception: " << _e.what());
+        ADD_FAILURE() << "Exception: " << _e.what();
     }
 }
 
-BOOST_AUTO_TEST_CASE(invalidRLPtest)
+TEST(rlp, ActualSize)
 {
-    runRlpTest("invalidRLPTest", "/RLPTests");
-}
-
-BOOST_AUTO_TEST_CASE(rlptest)
-{
-    runRlpTest("rlptest", "/RLPTests");
-}
-
-BOOST_AUTO_TEST_CASE(rlpRandom)
-{
-    fs::path testPath = dev::test::getTestPath();
-    testPath /= fs::path("RLPTests/RandomRLPTests");
-
-    vector<boost::filesystem::path> testFiles = test::getFiles(testPath, {".json"});
-    for (auto& path : testFiles)
-    {
-        try
-        {
-            cnote << "Testing ..." << path.filename();
-            json_spirit::mValue v;
-            string s = asString(dev::contents(path.string()));
-            BOOST_REQUIRE_MESSAGE(
-                s.length() > 0, "Content of " + path.string() +
-                                    " is empty. Have you cloned the 'tests' repo branch develop "
-                                    "and set ETHEREUM_TEST_PATH to its path?");
-            json_spirit::read_string(s, v);
-            // test::Listener::notifySuiteStarted(path.filename().string());
-            dev::test::doRlpTests(v);
-        }
-
-        catch (Exception const& _e)
-        {
-            BOOST_ERROR(path.filename().string() + "Failed test with Exception: "
-                        << diagnostic_information(_e));
-        }
-        catch (std::exception const& _e)
-        {
-            BOOST_ERROR(path.filename().string() + "Failed test with Exception: " << _e.what());
-        }
-    }
-}
-
-BOOST_AUTO_TEST_CASE(rlpActualSize)
-{
-    BOOST_CHECK_EQUAL(RLP{}.actualSize(), 0);
+    EXPECT_EQ(RLP{}.actualSize(), 0);
 
     bytes b{0x79};
-    BOOST_CHECK_EQUAL(RLP{b}.actualSize(), 1);
+    EXPECT_EQ(RLP{b}.actualSize(), 1);
 
     b = {0x80};
-    BOOST_CHECK_EQUAL(RLP{b}.actualSize(), 1);
+    EXPECT_EQ(RLP{b}.actualSize(), 1);
 
     b = {0x81, 0xff};
-    BOOST_CHECK_EQUAL(RLP{b}.actualSize(), 2);
+    EXPECT_EQ(RLP{b}.actualSize(), 2);
 
     b = {0xc0};
-    BOOST_CHECK_EQUAL(RLP{b}.actualSize(), 1);
+    EXPECT_EQ(RLP{b}.actualSize(), 1);
 
     b = {0xc1, 0x00};
-    BOOST_CHECK_EQUAL(RLP{b}.actualSize(), 2);
+    EXPECT_EQ(RLP{b}.actualSize(), 2);
 }
-
-BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libdevcrypto/AES.cpp
+++ b/test/unittests/libdevcrypto/AES.cpp
@@ -1,81 +1,75 @@
 /*
-	This file is part of cpp-ethereum.
+    This file is part of cpp-ethereum.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <boost/test/unit_test.hpp>
-#include <libdevcore/Common.h>
-#include <libdevcrypto/Common.h>
 #include <libdevcore/SHA3.h>
-#include <libdevcore/Log.h>
 #include <libdevcrypto/AES.h>
-#include <test/tools/libtesteth/TestOutputHelper.h>
+
+#include <gtest/gtest.h>
 
 using namespace std;
 using namespace dev;
-using namespace dev::test;
 
-BOOST_AUTO_TEST_SUITE(Crypto)
-
-BOOST_FIXTURE_TEST_SUITE(AES, TestOutputHelperFixture)
-
-BOOST_AUTO_TEST_CASE(AesDecrypt)
+TEST(Aes, Decrypt)
 {
-	cnote << "AesDecrypt";
-	bytes seed = fromHex("2dbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc96fce7ffc621");
-	KeyPair kp(sha3Secure(aesDecrypt(&seed, "test")));
-	BOOST_CHECK(Address("07746f871de684297923f933279555dda418f8a2") == kp.address());
+    bytes seed = fromHex(
+        "2dbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
+        "d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc"
+        "96fce7ffc621");
+    KeyPair kp(sha3Secure(aesDecrypt(&seed, "test")));
+    EXPECT_EQ(Address("07746f871de684297923f933279555dda418f8a2"), kp.address());
 }
 
-BOOST_AUTO_TEST_CASE(AesDecryptWrongSeed)
+TEST(Aes, DecryptWrongSeed)
 {
-	cnote << "AesDecryptWrongSeed";
-	bytes seed = fromHex("badaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc96fce7ffc621");
-	KeyPair kp(sha3Secure(aesDecrypt(&seed, "test")));
-	BOOST_CHECK(Address("07746f871de684297923f933279555dda418f8a2") != kp.address());
+    bytes seed = fromHex(
+        "badaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
+        "d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc"
+        "96fce7ffc621");
+    KeyPair kp(sha3Secure(aesDecrypt(&seed, "test")));
+    EXPECT_NE(Address("07746f871de684297923f933279555dda418f8a2"), kp.address());
 }
 
-BOOST_AUTO_TEST_CASE(AesDecryptWrongPassword)
+TEST(Aes, DecryptWrongPassword)
 {
-	cnote << "AesDecryptWrongPassword";
-	bytes seed = fromHex("2dbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc96fce7ffc621");
-	KeyPair kp(sha3Secure(aesDecrypt(&seed, "badtest")));
-	BOOST_CHECK(Address("07746f871de684297923f933279555dda418f8a2") != kp.address());
+    bytes seed = fromHex(
+        "2dbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
+        "d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc"
+        "96fce7ffc621");
+    KeyPair kp(sha3Secure(aesDecrypt(&seed, "badtest")));
+    EXPECT_NE(Address("07746f871de684297923f933279555dda418f8a2"), kp.address());
 }
 
-BOOST_AUTO_TEST_CASE(AesDecryptFailInvalidSeed)
+TEST(Aes, DecryptFailInvalidSeed)
 {
-	cnote << "AesDecryptFailInvalidSeed";
-	bytes seed = fromHex("xdbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc96fce7ffc621");
-	BOOST_CHECK(bytes() == aesDecrypt(&seed, "test"));
+    bytes seed = fromHex(
+        "xdbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
+        "d87e2d597536c4641098b9a89836c94f58a2ab4c525c27c4cb848b3e22ea245b2bc5c8c7beaa900b0c479253fc"
+        "96fce7ffc621");
+    EXPECT_EQ(bytes(), aesDecrypt(&seed, "test"));
 }
 
-BOOST_AUTO_TEST_CASE(AesDecryptFailInvalidSeedSize)
+TEST(Aes, DecryptFailInvalidSeedSize)
 {
-	cnote << "AesDecryptFailInvalidSeedSize";
-	bytes seed = fromHex("000102030405060708090a0b0c0d0e0f");
-	BOOST_CHECK(bytes() == aesDecrypt(&seed, "test"));
+    bytes seed = fromHex("000102030405060708090a0b0c0d0e0f");
+    EXPECT_EQ(bytes(), aesDecrypt(&seed, "test"));
 }
 
-BOOST_AUTO_TEST_CASE(AesDecryptFailInvalidSeed2)
+TEST(Aes, DecryptFailInvalidSeed2)
 {
-	cnote << "AesDecryptFailInvalidSeed2";
-	bytes seed = fromHex("000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
-	BOOST_CHECK(bytes() == aesDecrypt(&seed, "test"));
+    bytes seed = fromHex("000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
+    EXPECT_EQ(bytes(), aesDecrypt(&seed, "test"));
 }
-
-BOOST_AUTO_TEST_SUITE_END()
-
-BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libdevcrypto/AES.cpp
+++ b/test/unittests/libdevcrypto/AES.cpp
@@ -23,7 +23,7 @@
 using namespace std;
 using namespace dev;
 
-TEST(Aes, Decrypt)
+TEST(AES, decrypt)
 {
     bytes seed = fromHex(
         "2dbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
@@ -33,7 +33,7 @@ TEST(Aes, Decrypt)
     EXPECT_EQ(Address("07746f871de684297923f933279555dda418f8a2"), kp.address());
 }
 
-TEST(Aes, DecryptWrongSeed)
+TEST(AES, decryptWrongSeed)
 {
     bytes seed = fromHex(
         "badaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
@@ -43,7 +43,7 @@ TEST(Aes, DecryptWrongSeed)
     EXPECT_NE(Address("07746f871de684297923f933279555dda418f8a2"), kp.address());
 }
 
-TEST(Aes, DecryptWrongPassword)
+TEST(AES, decryptWrongPassword)
 {
     bytes seed = fromHex(
         "2dbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
@@ -53,7 +53,7 @@ TEST(Aes, DecryptWrongPassword)
     EXPECT_NE(Address("07746f871de684297923f933279555dda418f8a2"), kp.address());
 }
 
-TEST(Aes, DecryptFailInvalidSeed)
+TEST(AES, decryptFailInvalidSeed)
 {
     bytes seed = fromHex(
         "xdbaead416c20cfd00c2fc9f1788ff9f965a2000799c96a624767cb0e1e90d2d7191efdd92349226742fdc73d1"
@@ -62,13 +62,13 @@ TEST(Aes, DecryptFailInvalidSeed)
     EXPECT_EQ(bytes(), aesDecrypt(&seed, "test"));
 }
 
-TEST(Aes, DecryptFailInvalidSeedSize)
+TEST(AES, decryptFailInvalidSeedSize)
 {
     bytes seed = fromHex("000102030405060708090a0b0c0d0e0f");
     EXPECT_EQ(bytes(), aesDecrypt(&seed, "test"));
 }
 
-TEST(Aes, DecryptFailInvalidSeed2)
+TEST(AES, decryptFailInvalidSeed2)
 {
     bytes seed = fromHex("000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
     EXPECT_EQ(bytes(), aesDecrypt(&seed, "test"));


### PR DESCRIPTION
This adds new executable aleth-unittests powered by GTest.
Two files were converted so far:
- libdevcore/CommonJS.cpp,
- libdevcore/core.cpp.