### PR TITLE
Make EthereumCapability thread-safe again

### DIFF
--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -411,13 +411,13 @@ EthereumCapability::EthereumCapability(shared_ptr<p2p::CapabilityHostFace> _host
 
 void EthereumCapability::onStarting()
 {
-    m_backgroundWork = true;
+    m_backgroundWorkEnabled = true;
     m_host->scheduleExecution(c_backroundWorkPeriodMs, [this]() { doBackgroundWork(); });
 }
 
 void EthereumCapability::onStopping()
 {
-    m_backgroundWork = false;
+    m_backgroundWorkEnabled = false;
 }
 
 bool EthereumCapability::ensureInitialised()
@@ -484,7 +484,7 @@ void EthereumCapability::doBackgroundWork()
         }
     }
 
-    if (m_backgroundWork)
+    if (m_backgroundWorkEnabled)
         m_host->scheduleExecution(c_backroundWorkPeriodMs, [this]() { doBackgroundWork(); });
 }
 

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -422,11 +422,11 @@ void EthereumCapability::onStopping()
 
 bool EthereumCapability::ensureInitialised()
 {
-    if (!m_latestBlockSent)
+    if (!m_latestBlockSent.load())
     {
         // First time - just initialise.
         m_latestBlockSent = m_chain.currentHash();
-        LOG(m_logger) << "Initialising: latest=" << m_latestBlockSent;
+        LOG(m_logger) << "Initialising: latest=" << m_latestBlockSent.load();
 
         Guard l(x_transactions);
         m_transactionsSent = m_tq.knownTransactions();
@@ -570,7 +570,7 @@ void EthereumCapability::maintainBlocks(h256 const& _currentHash)
         {
             // don't be sending more than 20 "new" blocks. if there are any more we were probably waaaay behind.
             LOG(m_logger) << "Sending a new block (current is " << _currentHash << ", was "
-                          << m_latestBlockSent << ")";
+                          << m_latestBlockSent.load() << ")";
 
             h256s blocks = get<0>(m_chain.treeRoute(m_latestBlockSent, _currentHash, false, false, true));
 

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -191,7 +191,7 @@ private:
 
     std::unordered_map<NodeID, EthereumPeer> m_peers;
 
-    std::atomic<bool> m_backgroundWork = {false};
+    std::atomic<bool> m_backgroundWorkEnabled = {false};
 
     std::mt19937_64 m_urng;  // Mersenne Twister psuedo-random number generator
 

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -127,7 +127,7 @@ public:
     BlockQueue& bq() { return m_bq; }
     BlockQueue const& bq() const { return m_bq; }
     SyncStatus status() const;
-    h256 latestBlockSent() const { return m_latestBlockSent; }
+
     static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
 
     static unsigned const c_oldProtocolVersion;

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -177,13 +177,12 @@ private:
 
     u256 m_networkId;
 
-    std::atomic<h256> m_latestBlockSent = {h256{}};
+    h256 m_latestBlockSent;
     h256Hash m_transactionsSent;
 
     std::atomic<bool> m_newTransactions = {false};
     std::atomic<bool> m_newBlocks = {false};
 
-    mutable Mutex x_transactions;
     std::shared_ptr<BlockChainSync> m_sync;
     std::atomic<time_t> m_lastTick = { 0 };
 

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -127,7 +127,7 @@ public:
     BlockQueue& bq() { return m_bq; }
     BlockQueue const& bq() const { return m_bq; }
     SyncStatus status() const;
-    h256 latestBlockSent() { return m_latestBlockSent; }
+    h256 latestBlockSent() const { return m_latestBlockSent; }
     static char const* stateName(SyncState _s) { return s_stateNames[static_cast<int>(_s)]; }
 
     static unsigned const c_oldProtocolVersion;
@@ -156,9 +156,6 @@ private:
     void maintainBlocks(h256 const& _currentBlock);
     void onTransactionImported(ImportResult _ir, h256 const& _h, h512 const& _nodeId);
 
-    ///	Check to see if the network peer-state initialisation has happened.
-    bool isInitialised() const { return (bool)m_latestBlockSent; }
-
     /// Initialises the network peer-state, doing the stuff that needs to be once-only. @returns true if it really was first.
     bool ensureInitialised();
 
@@ -180,11 +177,11 @@ private:
 
     u256 m_networkId;
 
-    h256 m_latestBlockSent;
+    std::atomic<h256> m_latestBlockSent = {h256{}};
     h256Hash m_transactionsSent;
 
-    bool m_newTransactions = false;
-    bool m_newBlocks = false;
+    std::atomic<bool> m_newTransactions = {false};
+    std::atomic<bool> m_newBlocks = {false};
 
     mutable Mutex x_transactions;
     std::shared_ptr<BlockChainSync> m_sync;

--- a/libp2p/CapabilityHost.cpp
+++ b/libp2p/CapabilityHost.cpp
@@ -109,6 +109,11 @@ public:
         m_host.forEachPeer(_capabilityName, _f);
     }
 
+    void scheduleExecution(int _delayMs, std::function<void()> _f) override
+    {
+        m_host.scheduleExecution(_delayMs, std::move(_f));
+    }
+
 private:
     Host& m_host;
 };

--- a/libp2p/CapabilityHost.h
+++ b/libp2p/CapabilityHost.h
@@ -85,6 +85,10 @@ public:
     /// Apply callback function to each of the connected peers with given capability.
     virtual void foreachPeer(std::string const& _capabilityName,
         std::function<bool(NodeID const& _nodeID)> _f) const = 0;
+
+    /// Schedule callback to be called from the network handling thread
+    /// after at least @a _delayMs milliseconds
+    virtual void scheduleExecution(int _delayMs, std::function<void()> _f) = 0;
 };
 
 class Host;

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -14,11 +14,6 @@
     You should have received a copy of the GNU General Public License
     along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file Host.h
- * @author Alex Leverington <nessence@gmail.com>
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
 
 #pragma once
 
@@ -250,6 +245,8 @@ public:
     /// Apply function to each session
     void forEachPeer(
         std::string const& _capabilityName, std::function<bool(NodeID const&)> _f) const;
+
+    void scheduleExecution(int _delayMs, std::function<void()> _f);
 
     std::shared_ptr<CapabilityHostFace> capabilityHost() const { return m_capabilityHost; }
 

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -352,7 +352,7 @@ private:
     std::map<CapDesc, std::shared_ptr<CapabilityFace>> m_capabilities;
 
     /// Deadline timers used for isolated network events. GC'd by run.
-    std::list<std::shared_ptr<boost::asio::deadline_timer>> m_timers;
+    std::list<std::unique_ptr<boost::asio::deadline_timer>> m_timers;
     Mutex x_timers;
 
     std::chrono::steady_clock::time_point m_lastPing;						///< Time we sent the last ping to all peers.


### PR DESCRIPTION
- Change background tasks of `EthereumCapability::doWork` to be performed from the networking thread instead of separate `Worker` thread
- Make `onTransactionImported` handler and `reset()` method code be run from the networking thread as well
- Make `atomic` some members of `EthereumCapability` that are still accessed from separate threads (like RPC handler thread)