### PR TITLE
Fix test_mineBlocks returning too early with soltest

### DIFF
--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -122,7 +122,6 @@ void Client::init(p2p::Host& _extNet, fs::path const& _dbPath,
     bc().setOnBlockImport([=](BlockHeader const& _info) {
         if (auto h = m_host.lock())
             h->onBlockImported(_info);
-        m_onBlockImport(_info);
     });
 
     if (_forceAction == WithExisting::Rescue)

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -566,6 +566,7 @@ void Client::onChainChanged(ImportRoute const& _ir)
     if (!isMajorSyncing())
         resyncStateFromChain();
     noteChanged(changeds);
+    m_onChainChanged(_ir.deadBlocks, _ir.liveBlocks);
 }
 
 bool Client::remoteActive() const
@@ -926,7 +927,7 @@ ExecutionResult Client::call(Address const& _from, u256 _value, Address _dest, b
     }
     catch (...)
     {
-        // TODO: Some sort of notification of failure.
+        cwarn << boost::current_exception_diagnostic_information();
     }
     return ret;
 }

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -216,11 +216,6 @@ public:
     /// should be called after the constructor of the most derived class finishes.
     void startWorking() { Worker::startWorking(); };
 
-    /// Change the function that is called when a new block is imported
-    Handler<BlockHeader const&> setOnBlockImport(std::function<void(BlockHeader const&)> _handler)
-    {
-        return m_onBlockImport.add(_handler);
-    }
     /// Change the function that is called when a new block is sealed
     Handler<bytes const&> setOnBlockSealed(std::function<void(bytes const&)> _handler)
     {
@@ -375,8 +370,6 @@ protected:
 
     bytes m_extraData;
 
-    Signal<BlockHeader const&> m_onBlockImport;  ///< Called if we have imported a new block into
-                                                 ///< the DB
     Signal<bytes const&> m_onBlockSealed;        ///< Called if we have sealed a new block
 
     /// Called when blockchain was changed

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -226,6 +226,12 @@ public:
     {
         return m_onBlockSealed.add(_handler);
     }
+    /// Change the function that is called when blockchain was changed
+    Handler<h256s const&, h256s const&> setOnChainChanged(
+        std::function<void(h256s const&, h256s const&)> _handler)
+    {
+        return m_onChainChanged.add(_handler);
+    }
 
 
 protected:
@@ -372,6 +378,9 @@ protected:
     Signal<BlockHeader const&> m_onBlockImport;  ///< Called if we have imported a new block into
                                                  ///< the DB
     Signal<bytes const&> m_onBlockSealed;        ///< Called if we have sealed a new block
+
+    /// Called when blockchain was changed
+    Signal<h256s const&, h256s const&> m_onChainChanged;
 
     Logger m_logger{createLogger(VerbosityInfo, "client")};
     Logger m_loggerDetail{createLogger(VerbosityDebug, "client")};

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -53,9 +53,10 @@ void mine(Client& _c, int _numBlocks)
 
     int importedBlocks = 0;
     std::promise<void> allBlocksImported;
-    auto importHandler =
-        _c.setOnBlockImport([_numBlocks, &importedBlocks, &allBlocksImported](BlockHeader const&) {
-            if (++importedBlocks == _numBlocks)
+    auto chainChangedHandler = _c.setOnChainChanged(
+        [_numBlocks, &importedBlocks, &allBlocksImported](h256s const&, h256s const& _newBlocks) {
+            importedBlocks += _newBlocks.size();
+            if (importedBlocks == _numBlocks)
                 allBlocksImported.set_value();
         });
 


### PR DESCRIPTION
Fixes two problems:
- Blocks are first sealed, then imported into the chain. `test_mineBlocks` stopped sealing after all requested blocks are imported; it should better stop as soon as all requested blocks are sealed, otherwise as sealing continues in parallel with import, more blocks than requested can be sealed.
- `test_mineBlocks` returned after all requested blocks are imported into the chain. But it turns out, that at this moment `Client` class did not update the pending block yet, and `eth_call(..., "pending")` immediately after was accessing incorrect block. Now `test_mineBlocks` returns only after `Client` updates its stuff.