### PR TITLE
Set Windows console codepage to UTF-8

### DIFF
--- a/aleth-key/main.cpp
+++ b/aleth-key/main.cpp
@@ -43,29 +43,6 @@ void version()
     exit(0);
 }
 
-/*
-The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
-If the user has an invalid environment setting then it is possible for the call
-to set locale to fail, so there are only two possible actions, the first is to
-throw a runtime exception and cause the program to quit (default behaviour),
-or the second is to modify the environment to something sensible (least
-surprising behaviour).
-
-The follow code produces the least surprising behaviour. It will use the user
-specified default locale if it is valid, and if not then it will modify the
-environment the process is running in to use a sensible default. This also means
-that users do not need to install language packs for their OS.
-*/
-void setDefaultOrCLocale()
-{
-#if __unix__
-    if (!std::setlocale(LC_ALL, ""))
-    {
-        setenv("LC_ALL", "C", 1);
-    }
-#endif
-}
-
 int main(int argc, char** argv)
 {
     setDefaultOrCLocale();

--- a/aleth-vm/main.cpp
+++ b/aleth-vm/main.cpp
@@ -63,29 +63,6 @@ void version()
     exit(0);
 }
 
-/*
-The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
-If the user has an invalid environment setting then it is possible for the call
-to set locale to fail, so there are only two possible actions, the first is to
-throw a runtime exception and cause the program to quit (default behaviour),
-or the second is to modify the environment to something sensible (least
-surprising behaviour).
-
-The follow code produces the least surprising behaviour. It will use the user
-specified default locale if it is valid, and if not then it will modify the
-environment the process is running in to use a sensible default. This also means
-that users do not need to install language packs for their OS.
-*/
-void setDefaultOrCLocale()
-{
-#if __unix__
-    if (!std::setlocale(LC_ALL, ""))
-    {
-        setenv("LC_ALL", "C", 1);
-    }
-#endif
-}
-
 enum class Mode
 {
     Trace,

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -180,6 +180,12 @@ int main(int argc, char** argv)
 {
     setDefaultOrCLocale();
 
+#if defined(_WIN32)
+    // Need to change the code page from the default OEM code page (437) so that
+    // UTF-8 characters are displayed correctly in the console
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     // Init secp256k1 context by calling one of the functions.
     toPublic({});
 

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -95,29 +95,6 @@ bool isFalse(std::string const& _m)
     return _m == "off" || _m == "no" || _m == "false" || _m == "0";
 }
 
-/*
-The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
-If the user has an invalid environment setting then it is possible for the call
-to set locale to fail, so there are only two possible actions, the first is to
-throw a runtime exception and cause the program to quit (default behaviour),
-or the second is to modify the environment to something sensible (least
-surprising behaviour).
-
-The follow code produces the least surprising behaviour. It will use the user
-specified default locale if it is valid, and if not then it will modify the
-environment the process is running in to use a sensible default. This also means
-that users do not need to install language packs for their OS.
-*/
-void setDefaultOrCLocale()
-{
-#if __unix__
-    if (!std::setlocale(LC_ALL, ""))
-    {
-        setenv("LC_ALL", "C", 1);
-    }
-#endif
-}
-
 void importPresale(KeyManager& _km, string const& _file, function<string()> _pass)
 {
     KeyPair k = _km.presaleSecret(contentsString(_file), [&](bool){ return _pass(); });
@@ -179,12 +156,6 @@ bool ExitHandler::s_shouldExit = false;
 int main(int argc, char** argv)
 {
     setDefaultOrCLocale();
-
-#if defined(_WIN32)
-    // Need to change the code page from the default OEM code page (437) so that
-    // UTF-8 characters are displayed correctly in the console
-    SetConsoleOutputCP(CP_UTF8);
-#endif
 
     // Init secp256k1 context by calling one of the functions.
     toPublic({});

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -19,6 +19,10 @@
 #include "Exceptions.h"
 #include "Log.h"
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include <aleth/buildinfo.h>
 
 using namespace std;
@@ -93,4 +97,32 @@ string inUnits(bigint const& _b, strings const& _units)
     return ret.str();
 }
 
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
+{
+#if __unix__
+    if (!std::setlocale(LC_ALL, ""))
+    {
+        setenv("LC_ALL", "C", 1);
+    }
+#endif
+
+#if defined(_WIN32)
+    // Change the code page from the default OEM code page (437) so that UTF-8 characters are
+    // displayed correctly in the console.
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+}
 }

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -302,4 +302,5 @@ enum class WithExisting: int
 /// Get the current time in seconds since the epoch in UTC
 int64_t utcTime();
 
+void setDefaultOrCLocale();
 }

--- a/rlp/main.cpp
+++ b/rlp/main.cpp
@@ -44,29 +44,6 @@ void version()
     exit(0);
 }
 
-/*
-The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
-If the user has an invalid environment setting then it is possible for the call
-to set locale to fail, so there are only two possible actions, the first is to
-throw a runtime exception and cause the program to quit (default behaviour),
-or the second is to modify the environment to something sensible (least
-surprising behaviour).
-
-The follow code produces the least surprising behaviour. It will use the user
-specified default locale if it is valid, and if not then it will modify the
-environment the process is running in to use a sensible default. This also means
-that users do not need to install language packs for their OS.
-*/
-void setDefaultOrCLocale()
-{
-#if __unix__
-    if (!std::setlocale(LC_ALL, ""))
-    {
-        setenv("LC_ALL", "C", 1);
-    }
-#endif
-}
-
 enum class Mode {
     AssembleArchive,
     ListArchive,

--- a/test/tools/libtesteth/boostTest.cpp
+++ b/test/tools/libtesteth/boostTest.cpp
@@ -99,29 +99,6 @@ void travisOut(std::atomic_bool* _stopTravisOut)
     }
 }
 
-/*
-The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
-If the user has an invalid environment setting then it is possible for the call
-to set locale to fail, so there are only two possible actions, the first is to
-throw a runtime exception and cause the program to quit (default behaviour),
-or the second is to modify the environment to something sensible (least
-surprising behaviour).
-
-The follow code produces the least surprising behaviour. It will use the user
-specified default locale if it is valid, and if not then it will modify the
-environment the process is running in to use a sensible default. This also means
-that users do not need to install language packs for their OS.
-*/
-void setDefaultOrCLocale()
-{
-#if __unix__
-    if (!std::setlocale(LC_ALL, ""))
-    {
-        setenv("LC_ALL", "C", 1);
-    }
-#endif
-}
-
 // Custom Boost Unit Test Main
 int main(int argc, const char* argv[])
 {


### PR DESCRIPTION
Fix #5366 

Set the Windows console codepage to UTF-8 (it's OEM 437 by default, even on Windows 10) so that UTF-8 characters (e.g. trailing ellipsis in abridged node ids) can be logged correctly.

Here's the console output with the fix:

C:\Users\nilse\Documents\Code\aleth\build\aleth\Debug>aleth --ropsten
aleth, a C++ Ethereum client
INFO  11-25 21:58:03 main net    **Id: ##d66b9492…**
aleth 1.5.0-alpha.6-59+commit.064b04d2.dirty
INFO  11-25 21:58:06 p2p  info   UPnP device not found.
Node ID: enode://d66b9492a713c2793ab2e965d434eb5d9ab45aa0fc30d92a35086951fb3c37db1d99027f0066d2a1bce4a5c5d2836eb9a39c56f63abda3aac94c32f3f65345ed@0.0.0.0:0
INFO  11-25 21:58:06 main rpc    JSON-RPC socket path: \\.\pipe\\geth.ipc
JSONRPC Admin Session Key: 52vzmdF6/+c=