### PR TITLE
Improve new block propagation

### DIFF
--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -145,10 +145,11 @@ public:
 private:
     static char const* const s_stateNames[static_cast<int>(SyncState::Size)];
 
-    std::tuple<std::vector<NodeID>, std::vector<NodeID>> randomSelection(unsigned _percent = 25,
-        std::function<bool(EthereumPeer const&)> const& _allow = [](EthereumPeer const&) {
-            return true;
-        });
+    std::vector<NodeID> selectPeers(
+        std::function<bool(EthereumPeer const&)> const& _predicate) const;
+
+    std::pair<std::vector<NodeID>, std::vector<NodeID>> randomPartitionPeers(
+        std::vector<NodeID> const& _peers, std::size_t _number) const;
 
     void doBackgroundWork();
 
@@ -193,7 +194,7 @@ private:
 
     std::atomic<bool> m_backgroundWorkEnabled = {false};
 
-    std::mt19937_64 m_urng;  // Mersenne Twister psuedo-random number generator
+    mutable std::mt19937_64 m_urng;  // Mersenne Twister psuedo-random number generator
 
     Logger m_logger{createLogger(VerbosityDebug, "ethcap")};
     /// Logger for messages about impolite behaivour of peers.


### PR DESCRIPTION
Addresses points 1 and 2 of https://github.com/ethereum/aleth/issues/5277

Now we send new blocks with `NewBlock` message to `sqrt(peers)` peers, but at least 4 peers, or all of them if they are fewer than 4.

To the rest of the peers that don't have a block yet we send its hash with `NewBlockHashes` message.

Relevant go-ethereum code:
https://github.com/ethereum/go-ethereum/blob/edc39aaedf526bfb7757a445c1f9dd42f45dc8d4/eth/handler.go#L694-L732
https://github.com/ethereum/go-ethereum/blob/edc39aaedf526bfb7757a445c1f9dd42f45dc8d4/eth/fetcher/fetcher.go#L635-L682