### PR TITLE
Clean-up Discovery implementation

### DIFF
--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -154,8 +154,8 @@ public:
     /// Called by implementation which provided handler to process NodeEntryAdded/NodeEntryDropped events. Events are coalesced by type whereby old events are ignored.
     void processEvents();
 
-    /// Add node. Node will be pinged and empty shared_ptr is returned if node has never been seen or NodeID is empty.
-    std::shared_ptr<NodeEntry> addNode(Node const& _node, NodeRelation _relation = NodeRelation::Unknown);
+    /// Add node. Node will be pinged.
+    void addNode(Node const& _node, NodeRelation _relation = NodeRelation::Unknown);
 
     /// Returns list of node ids active in node table.
     std::list<NodeID> nodes() const;
@@ -275,9 +275,6 @@ private:
     Mutex x_evictions;												///< LOCK x_evictions first if both x_nodes and x_evictions locks are required.
     std::unordered_map<NodeID, EvictionTimeout> m_evictions;		///< Eviction timeouts.
     
-    Mutex x_pubkDiscoverPings;										///< LOCK x_nodes first if both x_nodes and x_pubkDiscoverPings locks are required.
-    std::unordered_map<bi::address, TimePoint> m_pubkDiscoverPings;	///< List of pending pings where node entry wasn't created due to unkown pubk.
-
     Mutex x_findNodeTimeout;
     std::list<NodeIdTimePoint> m_findNodeTimeout;					///< Timeouts for FindNode requests.
 

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -120,7 +120,7 @@ inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable)
  * @todo optimize knowledge at opposite edges; eg, s_bitsPerStep lookups. (Can be done via pointers to NodeBucket)
  * @todo ^ s_bitsPerStep = 8; // Denoted by b in [Kademlia]. Bits by which address space is divided.
  */
-class NodeTable: UDPSocketEvents, public std::enable_shared_from_this<NodeTable>
+class NodeTable : UDPSocketEvents
 {
     friend std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable);
     using NodeSocket = UDPSocket<NodeTable, 1280>;
@@ -161,13 +161,17 @@ public:
     std::list<NodeID> nodes() const;
 
     /// Returns node count.
-    unsigned count() const { return m_nodes.size(); }
+    unsigned count() const { return m_allNodes.size(); }
 
     /// Returns snapshot of table.
     std::list<NodeEntry> snapshot() const;
 
     /// Returns true if node id is in node table.
-    bool haveNode(NodeID const& _id) { Guard l(x_nodes); return m_nodes.count(_id) > 0; }
+    bool haveNode(NodeID const& _id)
+    {
+        Guard l(x_nodes);
+        return m_allNodes.count(_id) > 0;
+    }
 
     /// Returns the Node to the corresponding node id or the empty Node if that id is not found.
     Node node(NodeID const& _id);
@@ -182,7 +186,7 @@ private:
 
     static unsigned const s_addressByteSize = h256::size;					///< Size of address type in bytes.
     static unsigned const s_bits = 8 * s_addressByteSize;					///< Denoted by n in [Kademlia].
-    static unsigned const s_bins = s_bits - 1;								///< Size of m_state (excludes root, which is us).
+    static unsigned const s_bins = s_bits - 1;  ///< Size of m_buckets (excludes root, which is us).
     static unsigned const s_maxSteps = boost::static_log2<s_bits>::value;	///< Max iterations of discovery. (discover)
 
     /// Chosen constants
@@ -210,7 +214,10 @@ private:
     void ping(NodeEntry* _n) const;
 
     /// Returns center node entry which describes this node and used with dist() to calculate xor metric for node table nodes.
-    NodeEntry center() const { return NodeEntry(m_node.id, m_node.publicKey(), m_node.endpoint); }
+    NodeEntry center() const
+    {
+        return NodeEntry(m_hostNode.id, m_hostNode.publicKey(), m_hostNode.endpoint);
+    }
 
     /// Used by asynchronous operations to return NodeEntry which is active and managed by node table.
     std::shared_ptr<NodeEntry> nodeEntry(NodeID _id);
@@ -239,10 +246,11 @@ private:
     /// General Network Events
 
     /// Called by m_socket when packet is received.
-    void onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packet);
+    void onPacketReceived(
+        UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packet) override;
 
     /// Called by m_socket when socket is disconnected.
-    void onDisconnected(UDPSocketFace*) {}
+    void onSocketDisconnected(UDPSocketFace*) override {}
 
     /// Tasks
 
@@ -254,14 +262,15 @@ private:
 
     std::unique_ptr<NodeTableEventHandler> m_nodeEventHandler;		///< Event handler for node events.
 
-    Node m_node;													///< This node. LOCK x_state if endpoint access or mutation is required. Do not modify id.
+    /// This node. LOCK x_state if endpoint access or mutation is required. Do not modify id.
+    Node m_hostNode;
     Secret m_secret;												///< This nodes secret key.
 
     mutable Mutex x_nodes;											///< LOCK x_state first if both locks are required. Mutable for thread-safe copy in nodes() const.
-    std::unordered_map<NodeID, std::shared_ptr<NodeEntry>> m_nodes;	///< Known Node Endpoints
+    std::unordered_map<NodeID, std::shared_ptr<NodeEntry>> m_allNodes;  ///< Known Node Endpoints
 
     mutable Mutex x_state;											///< LOCK x_state first if both x_nodes and x_state locks are required.
-    std::array<NodeBucket, s_bins> m_state;							///< State of p2p node network.
+    std::array<NodeBucket, s_bins> m_buckets;                       ///< State of p2p node network.
 
     Mutex x_evictions;												///< LOCK x_evictions first if both x_nodes and x_evictions locks are required.
     std::unordered_map<NodeID, EvictionTimeout> m_evictions;		///< Eviction timeouts.

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -91,8 +91,9 @@ struct UDPSocketFace
 struct UDPSocketEvents
 {
     virtual ~UDPSocketEvents() = default;
-    virtual void onDisconnected(UDPSocketFace*) {}
-    virtual void onReceived(UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packetData) = 0;
+    virtual void onSocketDisconnected(UDPSocketFace*) {}
+    virtual void onPacketReceived(
+        UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packetData) = 0;
 };
 
 /**
@@ -206,7 +207,7 @@ void UDPSocket<Handler, MaxDatagramSize>::doRead()
             cnetlog << "Receiving UDP message failed. " << _ec.value() << " : " << _ec.message();
 
         if (_len)
-            m_host.onReceived(this, m_recvEndpoint, bytesConstRef(m_recvData.data(), _len));
+            m_host.onPacketReceived(this, m_recvEndpoint, bytesConstRef(m_recvData.data(), _len));
         doRead();
     });
 }
@@ -271,7 +272,7 @@ void UDPSocket<Handler, MaxDatagramSize>::disconnectWithError(boost::system::err
     if (wasClosed)
         return;
 
-    m_host.onDisconnected(this);
+    m_host.onSocketDisconnected(this);
 }
 
 }

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -416,17 +416,18 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeReplacesNodeInFullBucketWhenEndpointChanged)
     auto leastRecentlySeenNodeId = nodes.front().lock()->id;
 
     // addNode will replace the node in the m_allNodes map, because it's the same id with enother
-    // andpoint
-    auto nodeWithNewEndpoint = nodeTable->addNode(
-        Node(leastRecentlySeenNodeId, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), 30000, 30000)),
-        NodeTable::Known);
+    // endpoint
+    NodeIPEndpoint newEndpoint{bi::address::from_string("127.0.0.1"), 30000, 30000};
+    nodeTable->addNode(Node(leastRecentlySeenNodeId, newEndpoint), NodeTable::Known);
 
     // the bucket is still max size
     BOOST_CHECK_EQUAL(nodes.size(), 16);
     // least recently seen node removed
     BOOST_CHECK_NE(nodes.front().lock()->id, leastRecentlySeenNodeId);
     // but added as most recently seen with new endpoint
-    BOOST_CHECK_EQUAL(nodes.back().lock(), nodeWithNewEndpoint);
+    auto mostRecentNodeEntry = nodes.back().lock();
+    BOOST_CHECK_EQUAL(mostRecentNodeEntry->id, leastRecentlySeenNodeId);
+    BOOST_CHECK_EQUAL(mostRecentNodeEntry->endpoint, newEndpoint);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -107,9 +107,9 @@ struct TestNodeTable: public NodeTable
                 {
                     Guard ln(x_nodes);
                     shared_ptr<NodeEntry> node(new NodeEntry(
-                        m_node.id, n.first, NodeIPEndpoint(ourIp, n.second, n.second)));
+                        m_hostNode.id, n.first, NodeIPEndpoint(ourIp, n.second, n.second)));
                     node->pending = false;
-                    m_nodes[node->id] = node;
+                    m_allNodes[node->id] = node;
                 }
                 noteActiveNode(n.first, bi::udp::endpoint(ourIp, n.second));
             }
@@ -131,16 +131,16 @@ struct TestNodeTable: public NodeTable
             // manually add node for test
             {
                 Guard ln(x_nodes);
-                shared_ptr<NodeEntry> node(new NodeEntry(m_node.id, testNode->first,
+                shared_ptr<NodeEntry> node(new NodeEntry(m_hostNode.id, testNode->first,
                     NodeIPEndpoint(ourIp, testNode->second, testNode->second)));
                 node->pending = false;
-                m_nodes[node->id] = node;
+                m_allNodes[node->id] = node;
                 distance = node->distance;
             }
             noteActiveNode(testNode->first, bi::udp::endpoint(ourIp, testNode->second));
 
             auto const bucketIndex = distance - 1;
-            if (m_state[bucketIndex].nodes.size() >= _bucketSize)
+            if (m_buckets[bucketIndex].nodes.size() >= _bucketSize)
                 return bucketIndex;
 
             ++testNode;
@@ -153,13 +153,14 @@ struct TestNodeTable: public NodeTable
     void reset()
     {
         Guard l(x_state);
-        for (auto& n: m_state) n.nodes.clear();
+        for (auto& n : m_buckets)
+            n.nodes.clear();
     }
 
+    using NodeTable::m_allNodes;
+    using NodeTable::m_buckets;
     using NodeTable::m_evictions;
-    using NodeTable::m_nodes;
     using NodeTable::m_socket;
-    using NodeTable::m_state;
     using NodeTable::noteActiveNode;
 };
 
@@ -201,8 +202,12 @@ public:
       : m_socket(new UDPSocket<TestUDPSocketHost, 1024>(m_io, *this, _port))
     {}
 
-    void onDisconnected(UDPSocketFace*) {};
-    void onReceived(UDPSocketFace*, bi::udp::endpoint const&, bytesConstRef _packet) { if (_packet.toString() == "AAAA") success = true; }
+    void onSocketDisconnected(UDPSocketFace*){};
+    void onPacketReceived(UDPSocketFace*, bi::udp::endpoint const&, bytesConstRef _packet)
+    {
+        if (_packet.toString() == "AAAA")
+            success = true;
+    }
 
     shared_ptr<UDPSocket<TestUDPSocketHost, 1024>> m_socket;
 
@@ -337,9 +342,9 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeAppendsNewNode)
     nodeTableHost.populate(1);
 
     auto nodeTable = nodeTableHost.nodeTable;
-    std::shared_ptr<NodeEntry> newNode = nodeTable->m_nodes.begin()->second;
+    std::shared_ptr<NodeEntry> newNode = nodeTable->m_allNodes.begin()->second;
 
-    auto const& nodeBucketArray = nodeTable->m_state;
+    auto const& nodeBucketArray = nodeTable->m_buckets;
     auto const& nodeBucket = nodeBucketArray[newNode->distance - 1];
     auto const& nodes = nodeBucket.nodes;
     BOOST_REQUIRE(!nodes.empty());
@@ -355,7 +360,7 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeUpdatesKnownNode)
     BOOST_REQUIRE(bucketIndex >= 0);
 
     auto nodeTable = nodeTableHost.nodeTable;
-    auto const& nodeBucketArray = nodeTable->m_state;
+    auto const& nodeBucketArray = nodeTable->m_buckets;
     auto const& nodes = nodeBucketArray[bucketIndex].nodes;
     auto knownNode = nodes.front().lock();
 
@@ -381,7 +386,7 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeEvictsTheNodeWhenBucketIsFull)
     } while (NodeTable::distance(nodeTableHost.m_alias.pub(), newNodeId) != bucketIndex + 1);
 
     auto nodeTable = nodeTableHost.nodeTable;
-    auto const& nodeBucketArray = nodeTable->m_state;
+    auto const& nodeBucketArray = nodeTable->m_buckets;
     auto const& nodes = nodeBucketArray[bucketIndex].nodes;
     auto leastRecentlySeenNode = nodes.front().lock();
 
@@ -406,11 +411,12 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeReplacesNodeInFullBucketWhenEndpointChanged)
     BOOST_REQUIRE(bucketIndex >= 0);
 
     auto nodeTable = nodeTableHost.nodeTable;
-    auto const& nodeBucketArray = nodeTable->m_state;
+    auto const& nodeBucketArray = nodeTable->m_buckets;
     auto const& nodes = nodeBucketArray[bucketIndex].nodes;
     auto leastRecentlySeenNodeId = nodes.front().lock()->id;
 
-    // addNode will replace the node in the m_nodes map, because it's the same id with enother andpoint
+    // addNode will replace the node in the m_allNodes map, because it's the same id with enother
+    // andpoint
     auto nodeWithNewEndpoint = nodeTable->addNode(
         Node(leastRecentlySeenNodeId, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), 30000, 30000)),
         NodeTable::Known);


### PR DESCRIPTION
1. Renaming some methods/data members.
2. Remove the feature to add a node by IP+port only and discover its public key by sending PING - this is not used anyway and complicates the code.