### PR TITLE
Increase default gas limit to 8M

### DIFF
--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -235,7 +235,7 @@ u256 calculateEthashDifficulty(
 u256 calculateGasLimit(
     ChainOperationParams const& _chainParams, BlockHeader const& _bi, u256 const& _gasFloorTarget)
 {
-    u256 gasFloorTarget = _gasFloorTarget == Invalid256 ? 3141562 : _gasFloorTarget;
+    u256 gasFloorTarget = _gasFloorTarget == Invalid256 ? 8000000 : _gasFloorTarget;
     u256 gasLimit = _bi.gasLimit();
     u256 boundDivisor = _chainParams.gasLimitBoundDivisor;
     if (gasLimit < gasFloorTarget)


### PR DESCRIPTION
Geth and Parity already has 8M gas cap as a default .

ref)

https://github.com/paritytech/parity-ethereum/pull/9564
https://github.com/ethereum/go-ethereum/pull/17546/files#diff-21609b3ea13b7a6695113bee0fd055acR51

cc @chfast 