### PR TITLE
Create aleth-bootnode executable and remove "mode" argument from Aleth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ add_subdirectory(libwebthree)
 add_subdirectory(libweb3jsonrpc)
 
 add_subdirectory(aleth)
+add_subdirectory(aleth-bootnode)
 
 if (TOOLS)
     add_subdirectory(aleth-key)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,12 @@ add_subdirectory(libwebthree)
 add_subdirectory(libweb3jsonrpc)
 
 add_subdirectory(aleth)
-add_subdirectory(aleth-bootnode)
 
 if (TOOLS)
     add_subdirectory(aleth-key)
     add_subdirectory(aleth-vm)
     add_subdirectory(rlp)
+    add_subdirectory(aleth-bootnode)
 endif()
 
 if (TESTS)

--- a/aleth-bootnode/CMakeLists.txt
+++ b/aleth-bootnode/CMakeLists.txt
@@ -6,7 +6,7 @@ set(
 add_executable(aleth-bootnode ${sources})
 target_link_libraries(
     aleth-bootnode
-    PRIVATE devcore Boost::program_options p2p
+    PRIVATE p2p devcore Boost::program_options
 )
 
 install(TARGETS aleth-bootnode DESTINATION bin)

--- a/aleth-bootnode/CMakeLists.txt
+++ b/aleth-bootnode/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(
+    sources
+    main.cpp
+)
+
+add_executable(aleth-bootnode ${sources})
+target_link_libraries(
+    aleth-bootnode
+    PRIVATE devcore Boost::program_options p2p
+)
+
+install(TARGETS aleth-bootnode DESTINATION bin)

--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -1,0 +1,154 @@
+/*
+    This file is part of aleth.
+
+    aleth is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    aleth is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with aleth.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libdevcore/FileSystem.h>
+#include <libdevcore/LoggingProgramOptions.h>
+#include <libp2p/Host.h>
+#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <iostream>
+#include <thread>
+
+namespace po = boost::program_options;
+namespace fs = boost::filesystem;
+
+using namespace dev;
+using namespace dev::p2p;
+using namespace std;
+
+int main(int argc, char** argv)
+{
+    setDefaultOrCLocale();
+
+    string const ProgramName = "aleth-bootnode";
+    string const NetworkConfigFileName = ProgramName + "-network.rlp";
+
+    /// Networking params.
+    string listenIP;
+    unsigned short listenPort = c_defaultIPPort;
+    string publicIP;
+    bool upnp = true;
+
+    po::options_description generalOptions("GENERAL OPTIONS", lineWidth());
+    auto addGeneralOption = generalOptions.add_options();
+    addGeneralOption("help,h", "Show this help message and exit\n");
+
+    LoggingOptions loggingOptions;
+    po::options_description loggingProgramOptions(
+        createLoggingProgramOptions(lineWidth(), loggingOptions));
+
+    po::options_description clientNetworking("NETWORKING", lineWidth());
+    auto addNetworkingOption = clientNetworking.add_options();
+#if ETH_MINIUPNPC
+    addNetworkingOption(
+        "upnp", po::value<string>()->value_name("<on/off>"), "Use UPnP for NAT (default: on)");
+#endif
+    addNetworkingOption("public-ip", po::value<string>()->value_name("<ip>"),
+        "Force advertised public IP to the given IP (default: auto)");
+    addNetworkingOption("listen-ip", po::value<string>()->value_name("<ip>(:<port>)"),
+        "Listen on the given IP for incoming connections (default: 0.0.0.0)");
+    addNetworkingOption("listen", po::value<unsigned short>()->value_name("<port>"),
+        "Listen on the given port for incoming connections (default: 30303)\n");
+
+    po::options_description allowedOptions("Allowed options");
+    allowedOptions.add(generalOptions).add(loggingProgramOptions).add(clientNetworking);
+
+    po::variables_map vm;
+    try
+    {
+        po::parsed_options parsed = po::parse_command_line(argc, argv, allowedOptions);
+        po::store(parsed, vm);
+        po::notify(vm);
+    }
+    catch (po::error const& e)
+    {
+        cout << e.what() << "\n";
+        return -1;
+    }
+
+    if (vm.count("help"))
+    {
+        cout << "NAME:\n"
+             << "   " << ProgramName << "\n"
+             << "USAGE:\n"
+             << "   " << ProgramName << " [options]\n\n";
+        cout << generalOptions << clientNetworking << loggingProgramOptions;
+        return 0;
+    }
+
+    /// Networking params.
+    string listenIP;
+    unsigned short listenPort = c_defaultIPPort;
+    string publicIP;
+    bool upnp = true;
+
+#if ETH_MINIUPNPC
+    if (vm.count("upnp"))
+    {
+        string m = vm["upnp"].as<string>();
+        if (isTrue(m))
+            upnp = true;
+        else if (isFalse(m))
+            upnp = false;
+        else
+        {
+            cerr << "Bad "
+                 << "--upnp"
+                 << " option: " << m << "\n";
+            return -1;
+        }
+    }
+#endif
+
+    if (vm.count("public-ip"))
+        publicIP = vm["public-ip"].as<string>();
+    if (vm.count("listen-ip"))
+        listenIP = vm["listen-ip"].as<string>();
+    if (vm.count("listen"))
+        listenPort = vm["listen"].as<unsigned short>();
+
+    setupLogging(loggingOptions);
+    if (loggingOptions.verbosity > 0)
+        cout << EthGrayBold << ProgramName << ", a C++ Ethereum bootnode implementation" EthReset
+             << "\n";
+
+    auto netPrefs = publicIP.empty() ? NetworkConfig(listenIP, listenPort, upnp) :
+                                       NetworkConfig(publicIP, listenIP, listenPort, upnp);
+    auto netData = contents(getDataDir() / fs::path(NetworkConfigFileName));
+
+    // TODO: Compose client version
+    Host h(ProgramName, netPrefs, &netData);
+    h.start();
+
+    cout << "Node ID: " << h.enode() << endl;
+
+    ExitHandler exitHandler;
+    signal(SIGTERM, &ExitHandler::exitHandler);
+    signal(SIGABRT, &ExitHandler::exitHandler);
+    signal(SIGINT, &ExitHandler::exitHandler);
+
+    while (!exitHandler.shouldExit())
+        this_thread::sleep_for(chrono::milliseconds(1000));
+
+    h.stop();
+
+    netData = h.saveNetwork();
+    if (!netData.empty())
+        writeFile(getDataDir() / fs::path(NetworkConfigFileName), &netData);
+
+    return 0;
+}

--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -127,8 +127,7 @@ int main(int argc, char** argv)
                                        NetworkConfig(publicIP, listenIP, listenPort, upnp);
     auto netData = contents(getDataDir() / fs::path(c_networkConfigFileName));
 
-    // Pass in empty client version since it's not used in the discovery process
-    Host h("", netPrefs, &netData);
+    Host h(c_programName, netPrefs, &netData);
     h.start();
 
     cout << "Node ID: " << h.enode() << endl;

--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -30,28 +30,25 @@ using namespace dev;
 using namespace dev::p2p;
 using namespace std;
 
+namespace
+{
+string const c_programName = "aleth-bootnode";
+string const c_networkConfigFileName = c_programName + "-network.rlp";
+}  // namespace
+
 int main(int argc, char** argv)
 {
     setDefaultOrCLocale();
 
-    string const ProgramName = "aleth-bootnode";
-    string const NetworkConfigFileName = ProgramName + "-network.rlp";
-
-    /// Networking params.
-    string listenIP;
-    unsigned short listenPort = c_defaultIPPort;
-    string publicIP;
-    bool upnp = true;
-
-    po::options_description generalOptions("GENERAL OPTIONS", lineWidth());
+    po::options_description generalOptions("GENERAL OPTIONS", c_lineWidth);
     auto addGeneralOption = generalOptions.add_options();
     addGeneralOption("help,h", "Show this help message and exit\n");
 
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
-        createLoggingProgramOptions(lineWidth(), loggingOptions));
+        createLoggingProgramOptions(c_lineWidth, loggingOptions));
 
-    po::options_description clientNetworking("NETWORKING", lineWidth());
+    po::options_description clientNetworking("NETWORKING", c_lineWidth);
     auto addNetworkingOption = clientNetworking.add_options();
 #if ETH_MINIUPNPC
     addNetworkingOption(
@@ -83,9 +80,9 @@ int main(int argc, char** argv)
     if (vm.count("help"))
     {
         cout << "NAME:\n"
-             << "   " << ProgramName << "\n"
+             << "   " << c_programName << "\n"
              << "USAGE:\n"
-             << "   " << ProgramName << " [options]\n\n";
+             << "   " << c_programName << " [options]\n\n";
         cout << generalOptions << clientNetworking << loggingProgramOptions;
         return 0;
     }
@@ -123,15 +120,15 @@ int main(int argc, char** argv)
 
     setupLogging(loggingOptions);
     if (loggingOptions.verbosity > 0)
-        cout << EthGrayBold << ProgramName << ", a C++ Ethereum bootnode implementation" EthReset
+        cout << EthGrayBold << c_programName << ", a C++ Ethereum bootnode implementation" EthReset
              << "\n";
 
     auto netPrefs = publicIP.empty() ? NetworkConfig(listenIP, listenPort, upnp) :
                                        NetworkConfig(publicIP, listenIP, listenPort, upnp);
-    auto netData = contents(getDataDir() / fs::path(NetworkConfigFileName));
+    auto netData = contents(getDataDir() / fs::path(c_networkConfigFileName));
 
-    // TODO: Compose client version
-    Host h(ProgramName, netPrefs, &netData);
+    // Pass in empty client version since it's not used in the discovery process
+    Host h("", netPrefs, &netData);
     h.start();
 
     cout << "Node ID: " << h.enode() << endl;
@@ -148,7 +145,7 @@ int main(int argc, char** argv)
 
     netData = h.saveNetwork();
     if (!netData.empty())
-        writeFile(getDataDir() / fs::path(NetworkConfigFileName), &netData);
+        writeFile(getDataDir() / fs::path(c_networkConfigFileName), &netData);
 
     return 0;
 }

--- a/aleth-vm/main.cpp
+++ b/aleth-vm/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
     Ethash::init();
     NoProof::init();
 
-    po::options_description transactionOptions("Transaction options", lineWidth());
+    po::options_description transactionOptions("Transaction options", c_lineWidth);
     string const gasLimitDescription =
         "<n> Block gas limit (default: " + to_string(maxBlockGasLimit()) + ").";
     auto addTransactionOption = transactionOptions.add_options();
@@ -126,20 +126,20 @@ int main(int argc, char** argv)
     addTransactionOption("code", po::value<string>(),
         "<d> Contract code <d>. Makes transaction a call to this contract");
 
-    po::options_description networkOptions("Network options", lineWidth());
+    po::options_description networkOptions("Network options", c_lineWidth);
     networkOptions.add_options()("network", po::value<string>(),
         "Main|Ropsten|Homestead|Frontier|Byzantium|Constantinople\n");
 
-    po::options_description optionsForTrace("Options for trace", lineWidth());
+    po::options_description optionsForTrace("Options for trace", c_lineWidth);
     auto addTraceOption = optionsForTrace.add_options();
     addTraceOption("flat", "Minimal whitespace in the JSON.");
     addTraceOption("mnemonics", "Show instruction mnemonics in the trace (non-standard).\n");
 
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
-        createLoggingProgramOptions(lineWidth(), loggingOptions));
+        createLoggingProgramOptions(c_lineWidth, loggingOptions));
 
-    po::options_description generalOptions("General options", lineWidth());
+    po::options_description generalOptions("General options", c_lineWidth);
     auto addGeneralOption = generalOptions.add_options();
     addGeneralOption("version,v", "Show the version and exit.");
     addGeneralOption("help,h", "Show this help message and exit.");
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
 
     po::options_description allowedOptions(
         "Usage ethvm <options> [trace|stats|output|test] (<file>|-)");
-    allowedOptions.add(vmProgramOptions(lineWidth()))
+    allowedOptions.add(vmProgramOptions(c_lineWidth))
         .add(networkOptions)
         .add(optionsForTrace)
         .add(loggingProgramOptions)

--- a/aleth-vm/main.cpp
+++ b/aleth-vm/main.cpp
@@ -46,8 +46,6 @@ namespace po = boost::program_options;
 
 namespace
 {
-unsigned const c_lineWidth = 160;
-
 int64_t maxBlockGasLimit()
 {
     static int64_t limit =
@@ -109,7 +107,7 @@ int main(int argc, char** argv)
     Ethash::init();
     NoProof::init();
 
-    po::options_description transactionOptions("Transaction options", c_lineWidth);
+    po::options_description transactionOptions("Transaction options", lineWidth());
     string const gasLimitDescription =
         "<n> Block gas limit (default: " + to_string(maxBlockGasLimit()) + ").";
     auto addTransactionOption = transactionOptions.add_options();
@@ -128,20 +126,20 @@ int main(int argc, char** argv)
     addTransactionOption("code", po::value<string>(),
         "<d> Contract code <d>. Makes transaction a call to this contract");
 
-    po::options_description networkOptions("Network options", c_lineWidth);
+    po::options_description networkOptions("Network options", lineWidth());
     networkOptions.add_options()("network", po::value<string>(),
         "Main|Ropsten|Homestead|Frontier|Byzantium|Constantinople\n");
 
-    po::options_description optionsForTrace("Options for trace", c_lineWidth);
+    po::options_description optionsForTrace("Options for trace", lineWidth());
     auto addTraceOption = optionsForTrace.add_options();
     addTraceOption("flat", "Minimal whitespace in the JSON.");
     addTraceOption("mnemonics", "Show instruction mnemonics in the trace (non-standard).\n");
 
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
-        createLoggingProgramOptions(c_lineWidth, loggingOptions));
+        createLoggingProgramOptions(lineWidth(), loggingOptions));
 
-    po::options_description generalOptions("General options", c_lineWidth);
+    po::options_description generalOptions("General options", lineWidth());
     auto addGeneralOption = generalOptions.add_options();
     addGeneralOption("version,v", "Show the version and exit.");
     addGeneralOption("help,h", "Show this help message and exit.");
@@ -161,7 +159,7 @@ int main(int argc, char** argv)
 
     po::options_description allowedOptions(
         "Usage ethvm <options> [trace|stats|output|test] (<file>|-)");
-    allowedOptions.add(vmProgramOptions(c_lineWidth))
+    allowedOptions.add(vmProgramOptions(lineWidth()))
         .add(networkOptions)
         .add(optionsForTrace)
         .add(loggingProgramOptions)

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -214,7 +214,7 @@ int main(int argc, char** argv)
     fs::path configPath;
     string configJSON;
 
-    po::options_description clientDefaultMode("CLIENT MODE (default)", lineWidth());
+    po::options_description clientDefaultMode("CLIENT MODE (default)", c_lineWidth);
     auto addClientOption = clientDefaultMode.add_options();
     addClientOption("mainnet", "Use the main network protocol");
     addClientOption("ropsten", "Use the Ropsten testnet");
@@ -243,7 +243,7 @@ int main(int argc, char** argv)
     addClientOption("password", po::value<string>()->value_name("<password>"),
         "Give a password for a private key\n");
 
-    po::options_description clientTransacting("CLIENT TRANSACTING", lineWidth());
+    po::options_description clientTransacting("CLIENT TRANSACTING", c_lineWidth);
     auto addTransactingOption = clientTransacting.add_options();
     addTransactingOption("ask", po::value<u256>()->value_name("<wei>"),
         ("Set the minimum ask gas price under which no transaction will be mined (default: " +
@@ -256,7 +256,7 @@ int main(int argc, char** argv)
     addTransactingOption("unsafe-transactions",
         "Allow all transactions to proceed without verification; EXTREMELY UNSAFE\n");
 
-    po::options_description clientMining("CLIENT MINING", lineWidth());
+    po::options_description clientMining("CLIENT MINING", c_lineWidth);
     auto addMininigOption = clientMining.add_options();
     addMininigOption("address,a", po::value<Address>()->value_name("<addr>"),
         "Set the author (mining payout) address (default: auto)");
@@ -264,7 +264,7 @@ int main(int argc, char** argv)
         "Enable mining; optionally for a specified number of blocks (default: off)");
     addMininigOption("extra-data", po::value<string>(), "Set extra data for the sealed blocks\n");
 
-    po::options_description clientNetworking("CLIENT NETWORKING", lineWidth());
+    po::options_description clientNetworking("CLIENT NETWORKING", c_lineWidth);
     auto addNetworkingOption = clientNetworking.add_options();
     addNetworkingOption("bootstrap,b",
         "Connect to the default Ethereum peer servers (default unless --no-discovery used)");
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
     addNetworkingOption("pin", "Only accept or connect to trusted peers\n");
 
     std::string snapshotPath;
-    po::options_description importExportMode("IMPORT/EXPORT MODES", lineWidth());
+    po::options_description importExportMode("IMPORT/EXPORT MODES", c_lineWidth);
     auto addImportExportOption = importExportMode.add_options();
     addImportExportOption(
         "import,I", po::value<string>()->value_name("<file>"), "Import blocks from file");
@@ -334,18 +334,18 @@ int main(int argc, char** argv)
 
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
-        createLoggingProgramOptions(lineWidth(), loggingOptions));
+        createLoggingProgramOptions(c_lineWidth, loggingOptions));
 
-    po::options_description generalOptions("GENERAL OPTIONS", lineWidth());
+    po::options_description generalOptions("GENERAL OPTIONS", c_lineWidth);
     auto addGeneralOption = generalOptions.add_options();
     addGeneralOption("data-dir,d", po::value<string>()->value_name("<path>"),
         ("Load configuration files and keystore from path (default: " + getDataDir().string() + ")").c_str());
     addGeneralOption("version,V", "Show the version and exit");
     addGeneralOption("help,h", "Show this help message and exit\n");
 
-    po::options_description vmOptions = vmProgramOptions(lineWidth());
-    po::options_description dbOptions = db::databaseProgramOptions(lineWidth());
-    po::options_description minerOptions = MinerCLI::createProgramOptions(lineWidth());
+    po::options_description vmOptions = vmProgramOptions(c_lineWidth);
+    po::options_description dbOptions = db::databaseProgramOptions(c_lineWidth);
+    po::options_description minerOptions = MinerCLI::createProgramOptions(c_lineWidth);
 
     po::options_description allowedOptions("Allowed options");
     allowedOptions.add(clientDefaultMode)
@@ -767,13 +767,12 @@ int main(int argc, char** argv)
     netPrefs.pin = vm.count("pin") != 0;
 
     auto nodesState = contents(getDataDir() / fs::path("network.rlp"));
-    auto caps = set<string>{"eth"};
 
     if (testingMode)
         chainParams.allowFutureBlocks = true;
 
     dev::WebThreeDirect web3(WebThreeDirect::composeClientVersion("aleth"), db::databasePath(),
-        snapshotPath, chainParams, withExisting, caps, netPrefs, &nodesState, testingMode);
+        snapshotPath, chainParams, withExisting, netPrefs, &nodesState, testingMode);
 
     if (!extraData.empty())
         web3.ethereum()->setExtraData(extraData);
@@ -933,12 +932,12 @@ int main(int argc, char** argv)
     web3.setPeerStretch(peerStretch);
     std::shared_ptr<eth::TrivialGasPricer> gasPricer =
         make_shared<eth::TrivialGasPricer>(askPrice, bidPrice);
-    eth::Client* c = web3.ethereum();
-    c->setGasPricer(gasPricer);
-    c->setSealer(miner.minerType());
-    c->setAuthor(author);
+    Client& c = *(web3.ethereum());
+    c.setGasPricer(gasPricer);
+    c.setSealer(miner.minerType());
+    c.setAuthor(author);
     if (networkID != NoNetworkID)
-        c->setNetworkId(networkID);
+        c.setNetworkId(networkID);
 
     auto renderFullAddress = [&](Address const& _a) -> std::string
     {
@@ -1041,18 +1040,12 @@ int main(int argc, char** argv)
     signal(SIGTERM, &ExitHandler::exitHandler);
     signal(SIGINT, &ExitHandler::exitHandler);
 
-    if (c)
-    {
-        unsigned n = c->blockChain().details().number;
-        if (mining)
-            c->startSealing();
+    unsigned n = c.blockChain().details().number;
+    if (mining)
+        c.startSealing();
 
-        while (!exitHandler.shouldExit())
-            stopSealingAfterXBlocks(c, n, mining);
-    }
-    else
-        while (!exitHandler.shouldExit())
-            this_thread::sleep_for(chrono::milliseconds(1000));
+    while (!exitHandler.shouldExit())
+        stopSealingAfterXBlocks(&c, n, mining);
 
     if (jsonrpcIpcServer.get())
         jsonrpcIpcServer->StopListening();

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -125,4 +125,24 @@ void setDefaultOrCLocale()
     SetConsoleOutputCP(CP_UTF8);
 #endif
 }
+
+static unsigned const c_lineWidth = 160;
+
+unsigned lineWidth()
+{
+    return c_lineWidth;
 }
+
+bool ExitHandler::s_shouldExit = false;
+
+bool isTrue(std::string const& _m)
+{
+    return _m == "on" || _m == "yes" || _m == "true" || _m == "1";
+}
+
+bool isFalse(std::string const& _m)
+{
+    return _m == "off" || _m == "no" || _m == "false" || _m == "0";
+}
+
+}  // namespace dev

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -126,13 +126,6 @@ void setDefaultOrCLocale()
 #endif
 }
 
-static unsigned const c_lineWidth = 160;
-
-unsigned lineWidth()
-{
-    return c_lineWidth;
-}
-
 bool ExitHandler::s_shouldExit = false;
 
 bool isTrue(std::string const& _m)

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -303,4 +303,19 @@ enum class WithExisting: int
 int64_t utcTime();
 
 void setDefaultOrCLocale();
-}
+
+unsigned lineWidth();
+
+class ExitHandler
+{
+public:
+    static void exitHandler(int) { s_shouldExit = true; }
+    bool shouldExit() const { return s_shouldExit; }
+
+private:
+    static bool s_shouldExit;
+};
+
+bool isTrue(std::string const& _m);
+bool isFalse(std::string const& _m);
+}  // namespace dev

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -304,7 +304,7 @@ int64_t utcTime();
 
 void setDefaultOrCLocale();
 
-unsigned lineWidth();
+static constexpr unsigned c_lineWidth = 160;
 
 class ExitHandler
 {

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -536,7 +536,7 @@ void Host::addNode(NodeID const& _node, NodeIPEndpoint const& _endpoint)
 
     if (_node == id())
     {
-        cnetdetails << "Ingoring the request to connect to self " << _node;
+        cnetdetails << "Ignoring the request to connect to self " << _node;
         return;
     }
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -103,8 +103,8 @@ void NodeTable::addNode(Node const& _node, NodeRelation _relation)
 
     auto ret = make_shared<NodeEntry>(m_hostNode.id, _node.id, _node.endpoint);
     DEV_GUARDED(x_nodes) { m_allNodes[_node.id] = ret; }
-    LOG(m_logger) << "addNode pending for node " << _node.id << "@" << _node.endpoint;
-    ping(_node.endpoint);
+    LOG(m_logger) << "addNode pending for " << _node.id << "@" << _node.endpoint;
+    ping(_node.id, _node.endpoint);
 }
 
 list<NodeID> NodeTable::nodes() const
@@ -178,6 +178,7 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
             p.sign(m_secret);
             DEV_GUARDED(x_findNodeTimeout)
                 m_findNodeTimeout.push_back(make_pair(r->id, chrono::steady_clock::now()));
+            LOG(m_logger) << "Sending " << p.typeName() << " to " << _node << "@" << r->endpoint.address() << ":" << r->endpoint.udpPort();
             m_socketPointer->send(p);
         }
     
@@ -269,19 +270,14 @@ vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID _target)
     return ret;
 }
 
-void NodeTable::ping(NodeIPEndpoint _to) const
+void NodeTable::ping(NodeID _toId, NodeIPEndpoint _toEndpoint) const
 {
     NodeIPEndpoint src;
     DEV_GUARDED(x_nodes) { src = m_hostNode.endpoint; }
-    PingNode p(src, _to);
+    PingNode p(src, _toEndpoint);
     p.sign(m_secret);
+    LOG(m_logger) << "Sending " << p.typeName() << " to " << _toId << "@" << p.destination.address() << ":" << p.destination.udpPort();
     m_socketPointer->send(p);
-}
-
-void NodeTable::ping(NodeEntry* _n) const
-{
-    if (_n)
-        ping(_n->endpoint);
 }
 
 void NodeTable::evict(shared_ptr<NodeEntry> _leastSeen, shared_ptr<NodeEntry> _new)
@@ -299,7 +295,8 @@ void NodeTable::evict(shared_ptr<NodeEntry> _leastSeen, shared_ptr<NodeEntry> _n
 
     if (evicts == 1)
         doCheckEvictions();
-    ping(_leastSeen.get());
+    if (_leastSeen)
+        ping(_leastSeen->id, _leastSeen->endpoint);
 }
 
 void NodeTable::noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint)
@@ -482,7 +479,7 @@ void NodeTable::onPacketReceived(
                 for (unsigned offset = 0; offset < nearest.size(); offset += nlimit)
                 {
                     Neighbours out(_from, nearest, offset, nlimit);
-                    LOG(m_logger) << "Sending " << packet->typeName() << " to " << out.sourceid << "@" << _from.address() << ":" << _from.port();
+                    LOG(m_logger) << "Sending " << out.typeName() << " to " << in.sourceid << "@" << _from.address() << ":" << _from.port();
                     out.sign(m_secret);
                     if (out.data.size() > 1280)
                         cnetlog << "Sending truncated datagram, size: " << out.data.size();
@@ -499,7 +496,7 @@ void NodeTable::onPacketReceived(
                 addNode(Node(in.sourceid, in.source));
                 
                 Pong p(in.source);
-                LOG(m_logger) << "Sending " << packet->typeName() << " to " << in.sourceid << "@" << _from.address() << ":" << _from.port();
+                LOG(m_logger) << "Sending " << p.typeName() << " to " << in.sourceid << "@" << _from.address() << ":" << _from.port();
                 p.echo = in.echo;
                 p.sign(m_secret);
                 m_socketPointer->send(p);

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -178,7 +178,7 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
             p.sign(m_secret);
             DEV_GUARDED(x_findNodeTimeout)
                 m_findNodeTimeout.push_back(make_pair(r->id, chrono::steady_clock::now()));
-            LOG(m_logger) << "Sending " << p.typeName() << " to " << _node << "@" << r->endpoint.address() << ":" << r->endpoint.udpPort();
+            LOG(m_logger) << "Sending " << p.typeName() << " to " << _node << "@" << r->endpoint;
             m_socketPointer->send(p);
         }
     
@@ -276,7 +276,7 @@ void NodeTable::ping(NodeID _toId, NodeIPEndpoint _toEndpoint) const
     DEV_GUARDED(x_nodes) { src = m_hostNode.endpoint; }
     PingNode p(src, _toEndpoint);
     p.sign(m_secret);
-    LOG(m_logger) << "Sending " << p.typeName() << " to " << _toId << "@" << p.destination.address() << ":" << p.destination.udpPort();
+    LOG(m_logger) << "Sending " << p.typeName() << " to " << _toId << "@" << p.destination;
     m_socketPointer->send(p);
 }
 
@@ -395,7 +395,7 @@ void NodeTable::onPacketReceived(
             return;
         }
 
-        LOG(m_logger) << "Received " << packet->typeName() << " from " << packet->sourceid << "@" << _from.address() << ":" << _from.port();
+        LOG(m_logger) << "Received " << packet->typeName() << " from " << packet->sourceid << "@" << _from;
         switch (packet->packetType())
         {
             case Pong::type:
@@ -479,7 +479,7 @@ void NodeTable::onPacketReceived(
                 for (unsigned offset = 0; offset < nearest.size(); offset += nlimit)
                 {
                     Neighbours out(_from, nearest, offset, nlimit);
-                    LOG(m_logger) << "Sending " << out.typeName() << " to " << in.sourceid << "@" << _from.address() << ":" << _from.port();
+                    LOG(m_logger) << "Sending " << out.typeName() << " to " << in.sourceid << "@" << _from;
                     out.sign(m_secret);
                     if (out.data.size() > 1280)
                         cnetlog << "Sending truncated datagram, size: " << out.data.size();
@@ -496,7 +496,7 @@ void NodeTable::onPacketReceived(
                 addNode(Node(in.sourceid, in.source));
                 
                 Pong p(in.source);
-                LOG(m_logger) << "Sending " << p.typeName() << " to " << in.sourceid << "@" << _from.address() << ":" << _from.port();
+                LOG(m_logger) << "Sending " << p.typeName() << " to " << in.sourceid << "@" << _from;
                 p.echo = in.echo;
                 p.sign(m_secret);
                 m_socketPointer->send(p);

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -32,6 +32,30 @@ namespace
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_discoveryWarnLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 0)(boost::log::keywords::channel = "discov"))
+
+struct DatagramTypeTableEntry
+{
+    char const* name;
+    uint8_t type;
+};
+
+DatagramTypeTableEntry datagramTypesTable[] = {
+    {"PING", PingNode::type},
+    {"PONG", Pong::type},
+    {"FINDNODE", FindNode::type},
+    {"NEIGHBORS", Neighbours::type}
+};
+
+string datagramNameFromType(uint8_t _t)
+{
+    for (auto const& entry : datagramTypesTable)
+    {
+        if (entry.type == _t)
+            return entry.name;
+    }
+    return "UNKNOWN";
+}
+
 }  // namespace
 
 inline bool operator==(
@@ -103,7 +127,7 @@ void NodeTable::addNode(Node const& _node, NodeRelation _relation)
 
     auto ret = make_shared<NodeEntry>(m_hostNode.id, _node.id, _node.endpoint);
     DEV_GUARDED(x_nodes) { m_allNodes[_node.id] = ret; }
-    LOG(m_logger) << "addNode pending for " << _node.endpoint;
+    LOG(m_logger) << "addNode pending for node " << _node.id << "@" << _node.endpoint;
     ping(_node.endpoint);
 }
 
@@ -398,6 +422,7 @@ void NodeTable::onPacketReceived(
             return;
         }
 
+        cnetdetails << "Received " << datagramNameFromType(packet->packetType()) << " from " << packet->sourceid << "@" << _from.address() << ":" << _from.port();
         switch (packet->packetType())
         {
             case Pong::type:
@@ -444,7 +469,6 @@ void NodeTable::onPacketReceived(
                     m_hostNode.endpoint.setUdpPort(in.destination.udpPort());
                 }
 
-                LOG(m_logger) << "PONG from " << in.sourceid << " " << _from;
                 break;
             }
                 
@@ -482,6 +506,7 @@ void NodeTable::onPacketReceived(
                 for (unsigned offset = 0; offset < nearest.size(); offset += nlimit)
                 {
                     Neighbours out(_from, nearest, offset, nlimit);
+                    cnetdetails << "Sending " << datagramNameFromType(out.packetType()) << " to " << out.sourceid << "@" << _from.address() << ":" << _from.port();
                     out.sign(m_secret);
                     if (out.data.size() > 1280)
                         cnetlog << "Sending truncated datagram, size: " << out.data.size();
@@ -498,6 +523,7 @@ void NodeTable::onPacketReceived(
                 addNode(Node(in.sourceid, in.source));
                 
                 Pong p(in.source);
+                cnetdetails << "Sending " << datagramNameFromType(p.packetType()) << " to " << in.sourceid << "@" << _from.address() << ":" << _from.port();
                 p.echo = in.echo;
                 p.sign(m_secret);
                 m_socketPointer->send(p);

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -280,7 +280,7 @@ void NodeTable::ping(NodeID _toId, NodeIPEndpoint _toEndpoint) const
     m_socketPointer->send(p);
 }
 
-void NodeTable::evict(shared_ptr<NodeEntry> _leastSeen, shared_ptr<NodeEntry> _new)
+void NodeTable::evict(NodeEntry const& _leastSeen, NodeEntry const& _new)
 {
     if (!m_socketPointer->isOpen())
         return;
@@ -288,15 +288,14 @@ void NodeTable::evict(shared_ptr<NodeEntry> _leastSeen, shared_ptr<NodeEntry> _n
     unsigned evicts = 0;
     DEV_GUARDED(x_evictions)
     {
-        EvictionTimeout evictTimeout{_new->id, chrono::steady_clock::now()};  
-        m_evictions.emplace(_leastSeen->id, evictTimeout);
+        EvictionTimeout evictTimeout{_new.id, chrono::steady_clock::now()};  
+        m_evictions.emplace(_leastSeen.id, evictTimeout);
         evicts = m_evictions.size();
     }
 
     if (evicts == 1)
         doCheckEvictions();
-    if (_leastSeen)
-        ping(_leastSeen->id, _leastSeen->endpoint);
+    ping(_leastSeen.id, _leastSeen.endpoint);
 }
 
 void NodeTable::noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint)
@@ -356,7 +355,7 @@ void NodeTable::noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _en
         }
 
         if (nodeToEvict)
-            evict(nodeToEvict, newNode);
+            evict(*nodeToEvict, *newNode);
     }
 }
 

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -335,13 +335,13 @@ struct PingNode: DiscoveryDatagram
     PingNode(bi::udp::endpoint const& _from, NodeID const& _fromid, h256 const& _echo): DiscoveryDatagram(_from, _fromid, _echo) {}
 
     static const uint8_t type = 1;
-    uint8_t packetType() const { return type; }
+    uint8_t packetType() const override { return type; }
 
     unsigned version = 0;
     NodeIPEndpoint source;
     NodeIPEndpoint destination;
 
-    void streamRLP(RLPStream& _s) const
+    void streamRLP(RLPStream& _s) const override
     {
         _s.appendList(4);
         _s << dev::p2p::c_protocolVersion;
@@ -349,7 +349,7 @@ struct PingNode: DiscoveryDatagram
         destination.streamRLP(_s);
         _s << ts;
     }
-    void interpretRLP(bytesConstRef _bytes)
+    void interpretRLP(bytesConstRef _bytes) override
     {
         RLP r(_bytes, RLP::AllowNonCanon|RLP::ThrowOnFail);
         version = r[0].toInt<unsigned>();
@@ -357,6 +357,8 @@ struct PingNode: DiscoveryDatagram
         destination.interpretRLP(r[2]);
         ts = r[3].toInt<uint32_t>();
     }
+
+    std::string typeName() const override { return "Ping"; }
 };
 
 /**
@@ -368,24 +370,26 @@ struct Pong: DiscoveryDatagram
     Pong(bi::udp::endpoint const& _from, NodeID const& _fromid, h256 const& _echo): DiscoveryDatagram(_from, _fromid, _echo) {}
 
     static const uint8_t type = 2;
-    uint8_t packetType() const { return type; }
+    uint8_t packetType() const override { return type; }
 
     NodeIPEndpoint destination;
 
-    void streamRLP(RLPStream& _s) const
+    void streamRLP(RLPStream& _s) const override
     {
         _s.appendList(3);
         destination.streamRLP(_s);
         _s << echo;
         _s << ts;
     }
-    void interpretRLP(bytesConstRef _bytes)
+    void interpretRLP(bytesConstRef _bytes) override
     {
         RLP r(_bytes, RLP::AllowNonCanon|RLP::ThrowOnFail);
         destination.interpretRLP(r[0]);
         echo = (h256)r[1];
         ts = r[2].toInt<uint32_t>();
     }
+
+    std::string typeName() const override { return "Pong"; }
 };
 
 /**
@@ -406,20 +410,22 @@ struct FindNode: DiscoveryDatagram
     FindNode(bi::udp::endpoint const& _from, NodeID const& _fromid, h256 const& _echo): DiscoveryDatagram(_from, _fromid, _echo) {}
 
     static const uint8_t type = 3;
-    uint8_t packetType() const { return type; }
+    uint8_t packetType() const override { return type; }
 
     h512 target;
 
-    void streamRLP(RLPStream& _s) const
+    void streamRLP(RLPStream& _s) const override
     {
         _s.appendList(2); _s << target << ts;
     }
-    void interpretRLP(bytesConstRef _bytes)
+    void interpretRLP(bytesConstRef _bytes) override
     {
         RLP r(_bytes, RLP::AllowNonCanon|RLP::ThrowOnFail);
         target = r[0].toHash<h512>();
         ts = r[1].toInt<uint32_t>();
     }
+
+    std::string typeName() const override { return "FindNode"; }
 };
 
 /**
@@ -446,11 +452,11 @@ struct Neighbours: DiscoveryDatagram
     };
 
     static const uint8_t type = 4;
-    uint8_t packetType() const { return type; }
+    uint8_t packetType() const override { return type; }
 
     std::vector<Neighbour> neighbours;
 
-    void streamRLP(RLPStream& _s) const
+    void streamRLP(RLPStream& _s) const override
     {
         _s.appendList(2);
         _s.appendList(neighbours.size());
@@ -458,13 +464,15 @@ struct Neighbours: DiscoveryDatagram
             n.streamRLP(_s);
         _s << ts;
     }
-    void interpretRLP(bytesConstRef _bytes)
+    void interpretRLP(bytesConstRef _bytes) override
     {
         RLP r(_bytes, RLP::AllowNonCanon|RLP::ThrowOnFail);
         for (auto const& n: r[0])
             neighbours.emplace_back(n);
         ts = r[1].toInt<uint32_t>();
     }
+
+    std::string typeName() const override { return "Neighbours"; }
 };
 
 }

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -207,11 +207,8 @@ private:
         std::list<std::weak_ptr<NodeEntry>> nodes;
     };
 
-    /// Used to ping endpoint.
-    void ping(NodeIPEndpoint _to) const;
-
-    /// Used ping known node. Used by node table when refreshing buckets and as part of eviction process (see evict).
-    void ping(NodeEntry* _n) const;
+    /// Used to ping endpoint. Used by node table when refreshing buckets and as part of eviction process (see evict).
+    void ping(NodeID _toId, NodeIPEndpoint _toEndpoint) const;
 
     /// Returns center node entry which describes this node and used with dist() to calculate xor metric for node table nodes.
     NodeEntry center() const
@@ -281,7 +278,7 @@ private:
     std::shared_ptr<NodeSocket> m_socket;							///< Shared pointer for our UDPSocket; ASIO requires shared_ptr.
     NodeSocket* m_socketPointer;									///< Set to m_socket.get(). Socket is created in constructor and disconnected in destructor to ensure access to pointer is safe.
 
-    Logger m_logger{createLogger(VerbosityDebug, "discov")};
+    mutable Logger m_logger{createLogger(VerbosityDebug, "discov")};
 
     DeadlineOps m_timers; ///< this should be the last member - it must be destroyed first
 };

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -227,7 +227,7 @@ private:
     std::vector<std::shared_ptr<NodeEntry>> nearestNodeEntries(NodeID _target);
 
     /// Asynchronously drops _leastSeen node if it doesn't reply and adds _new node, otherwise _new node is thrown away.
-    void evict(std::shared_ptr<NodeEntry> _leastSeen, std::shared_ptr<NodeEntry> _new);
+    void evict(NodeEntry const& _leastSeen, NodeEntry const& _new);
 
     /// Called whenever activity is received from a node in order to maintain node table.
     void noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint);

--- a/libp2p/UDP.h
+++ b/libp2p/UDP.h
@@ -74,6 +74,8 @@ struct RLPXDatagramFace: public UDPDatagram
 
     virtual void streamRLP(RLPStream&) const = 0;
     virtual void interpretRLP(bytesConstRef _bytes) = 0;
+
+    virtual std::string typeName() const = 0;
 };
 
 /**

--- a/libwebthree/WebThree.h
+++ b/libwebthree/WebThree.h
@@ -112,9 +112,7 @@ public:
     /// ethereum() may be safely static_cast()ed to a eth::Client*.
     WebThreeDirect(std::string const& _clientVersion, boost::filesystem::path const& _dbPath,
         boost::filesystem::path const& _snapshotPath, eth::ChainParams const& _params,
-        WithExisting _we = WithExisting::Trust,
-        std::set<std::string> const& _interfaces = {"eth", "shh", "bzz"},
-        p2p::NetworkConfig const& _n = p2p::NetworkConfig{},
+        WithExisting _we = WithExisting::Trust, p2p::NetworkConfig const& _n = p2p::NetworkConfig{},
         bytesConstRef _network = bytesConstRef(), bool _testing = false);
 
     /// Destructor.

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -51,7 +51,7 @@ public:
         auto nodesState = contents(dir / fs::path("network.rlp"));
         bool testingMode = true;
         m_web3.reset(new dev::WebThreeDirect(WebThreeDirect::composeClientVersion("eth"), dir, dir,
-            chainParams, WithExisting::Kill, {"eth"}, netPrefs, &nodesState, testingMode));
+            chainParams, WithExisting::Kill, netPrefs, &nodesState, testingMode));
     }
 
     dev::WebThreeDirect* getWeb3() { return m_web3.get(); }

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -88,7 +88,7 @@ struct TestNodeTable: public NodeTable
         bi::address ourIp = bi::address::from_string("127.0.0.1");
         for (auto& n: _testNodes)
         {
-            ping(NodeIPEndpoint(ourIp, n.second, n.second));
+            ping(n.first.pub(), NodeIPEndpoint(ourIp, n.second, n.second));
             this_thread::sleep_for(chrono::milliseconds(2));
         }
     }

--- a/test/unittests/libweb3jsonrpc/Client.cpp
+++ b/test/unittests/libweb3jsonrpc/Client.cpp
@@ -65,9 +65,9 @@ BOOST_AUTO_TEST_CASE(Personal)
     chainParams.allowFutureBlocks = true;
     chainParams.difficulty = chainParams.minimumDifficulty;
     chainParams.gasLimit = chainParams.maxGasLimit;
-    
+
     dev::WebThreeDirect web3(WebThreeDirect::composeClientVersion("eth"), getDataDir(), string(),
-        chainParams, WithExisting::Kill, set<string>{"eth"}, p2p::NetworkConfig(0));
+        chainParams, WithExisting::Kill, p2p::NetworkConfig(0));
     web3.stopNetwork();
     web3.ethereum()->stopSealing();
     

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -133,8 +133,8 @@ struct JsonRpcFixture : public TestOutputHelperFixture
         // so that tests can be run in parallel
         // TODO: better make it use ethemeral in-memory databases
         chainParams.extraData = h256::random().asBytes();
-        web3.reset(new WebThreeDirect("eth tests", "", "", chainParams, WithExisting::Kill, {"eth"},
-            nprefs, bytesConstRef(), true));
+        web3.reset(new WebThreeDirect(
+            "eth tests", "", "", chainParams, WithExisting::Kill, nprefs, bytesConstRef(), true));
 
         web3->setIdealPeerCount(5);
 


### PR DESCRIPTION
Fix #4855, #4703 

Create the aleth-bootnode executable which just starts the `Host `thread in discovery mode with no p2p functionality. This is the same approach that Geth's "bootnode" binary takes (please see #4703 for details).

Configuration options:
```

NAME:
   aleth-bootnode
USAGE:
   aleth-bootnode [options]

GENERAL OPTIONS:
  -h [ --help ]         Show this help message and exit

NETWORKING:
  --public-ip <ip>          Force advertised public IP to the given IP (default: auto)
  --listen-ip <ip>(:<port>) Listen on the given IP for incoming connections (default: 0.0.0.0)
  --listen <port>           Listen on the given port for incoming connections (default: 30303)

LOGGING OPTIONS:
  -v [ --log-verbosity ] <0 - 4>        Set the log verbosity from 0 to 4 (default: 2).
  --log-channels <channel_list>         Space-separated list of the log channels to show (default: show all channels).
  --log-exclude-channels <channel_list> Space-separated list of the log channels to hide.
```

I've also removed the "mode" argument from Aleth's command line since it doesn't provide any purpose.

Note that I still need to verify that the bootnode works correctly - in my tests yesterday (running aleth-bootnode and 2 aleth clients) I didn't see the bootnode or either of the clients send FINDNODE packets so I need to investigate and figure out why.

I also need to add `composeClientVersion `functionality before merging.

