### PR TITLE
Validate PONGs

### DIFF
--- a/libdevcore/Assertions.h
+++ b/libdevcore/Assertions.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <boost/exception/info.hpp>
-#include <iosfwd>
+#include <iostream>
 
 namespace dev
 {

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -33,6 +33,11 @@ constexpr unsigned c_handleTimeoutsIntervalMs = 5000;
 
 }  // namespace
 
+constexpr std::chrono::seconds DiscoveryDatagram::c_timeToLive;
+constexpr std::chrono::milliseconds NodeTable::c_reqTimeout;
+constexpr std::chrono::milliseconds NodeTable::c_bucketRefresh;
+constexpr std::chrono::milliseconds NodeTable::c_evictionCheckInterval;
+
 inline bool operator==(
     std::weak_ptr<NodeEntry> const& _weak, std::shared_ptr<NodeEntry> const& _shared)
 {

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -630,7 +630,12 @@ void NodeTable::doHandleTimeouts()
         for (auto it = m_sentPings.begin(); it != m_sentPings.end();)
         {
             if (chrono::steady_clock::now() > it->second.first + DiscoveryDatagram::c_timeToLive)
+            {
+                if (auto node = nodeEntry(it->first))
+                    dropNode(node);
+
                 it = m_sentPings.erase(it);
+            }
             else
                 ++it;
         }

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -14,10 +14,6 @@
  You should have received a copy of the GNU General Public License
  along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
-/** @file NodeTable.cpp
- * @author Alex Leverington <nessence@gmail.com>
- * @date 2014
- */
 
 #include "NodeTable.h"
 using namespace std;
@@ -32,7 +28,17 @@ namespace
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(g_discoveryWarnLogger,
     boost::log::sources::severity_channel_logger_mt<>,
     (boost::log::keywords::severity = 0)(boost::log::keywords::channel = "discov"))
+
+const unsigned c_handleTimeoutsIntervalMs = 5000;
+
 }  // namespace
+
+std::chrono::seconds const DiscoveryDatagram::c_timeToLive{60};
+std::chrono::milliseconds const NodeTable::c_evictionCheckInterval{75};
+std::chrono::milliseconds const NodeTable::c_reqTimeout{300};
+std::chrono::milliseconds const NodeTable::c_bucketRefresh{7200};
+uint32_t const NodeTable::c_bondingTimeSeconds = 12 * 60 * 60;
+
 
 inline bool operator==(
     std::weak_ptr<NodeEntry> const& _weak, std::shared_ptr<NodeEntry> const& _shared)
@@ -60,6 +66,7 @@ NodeTable::NodeTable(
     {
         m_socket->connect();
         doDiscovery();
+        doHandleTimeouts();
     }
     catch (std::exception const& _e)
     {
@@ -85,7 +92,9 @@ void NodeTable::addNode(Node const& _node, NodeRelation _relation)
     if (_relation == Known)
     {
         auto nodeEntry = make_shared<NodeEntry>(m_hostNode.id, _node.id, _node.endpoint);
-        nodeEntry->pending = false;
+        // mark as validated
+        // TODO get last pong time as input, ping if needed
+        nodeEntry->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
         DEV_GUARDED(x_nodes) { m_allNodes[_node.id] = nodeEntry; }
         noteActiveNode(_node.id, _node.endpoint);
         return;
@@ -100,10 +109,10 @@ void NodeTable::addNode(Node const& _node, NodeRelation _relation)
             return;
     }
 
-    auto ret = make_shared<NodeEntry>(m_hostNode.id, _node.id, _node.endpoint);
-    DEV_GUARDED(x_nodes) { m_allNodes[_node.id] = ret; }
+    auto nodeEntry = make_shared<NodeEntry>(m_hostNode.id, _node.id, _node.endpoint);
+    DEV_GUARDED(x_nodes) { m_allNodes[_node.id] = nodeEntry; }
     LOG(m_logger) << "Pending node " << _node.id << "@" << _node.endpoint;
-    ping(_node.id, _node.endpoint);
+    ping(*nodeEntry);
 }
 
 list<NodeID> NodeTable::nodes() const
@@ -269,14 +278,21 @@ vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID _target)
     return ret;
 }
 
-void NodeTable::ping(NodeID _toId, NodeIPEndpoint _toEndpoint) const
+void NodeTable::ping(NodeEntry const& _nodeEntry)
 {
-    NodeIPEndpoint src;
-    DEV_GUARDED(x_nodes) { src = m_hostNode.endpoint; }
-    PingNode p(src, _toEndpoint);
-    p.sign(m_secret);
-    LOG(m_logger) << p.typeName() << " to " << _toId << "@" << p.destination;
-    m_socket->send(p);
+    m_timers.schedule(0, [this, _nodeEntry](boost::system::error_code const& _ec) {
+        if (_ec || m_timers.isStopped())
+            return;
+
+        NodeIPEndpoint src;
+        DEV_GUARDED(x_nodes) { src = m_hostNode.endpoint; }
+        PingNode p(src, _nodeEntry.endpoint);
+        auto const pingHash = p.sign(m_secret);
+	    LOG(m_logger) << p.typeName() << " to " << _nodeEntry.id << "@" << p.destination;
+        m_socket->send(p);
+
+        m_sentPings[_nodeEntry.id] = std::make_pair(chrono::steady_clock::now(), pingHash);
+    });
 }
 
 void NodeTable::evict(NodeEntry const& _leastSeen, NodeEntry const& _new)
@@ -294,7 +310,7 @@ void NodeTable::evict(NodeEntry const& _leastSeen, NodeEntry const& _new)
 
     if (evicts == 1)
         doCheckEvictions();
-    ping(_leastSeen.id, _leastSeen.endpoint);
+    ping(_leastSeen);
 }
 
 void NodeTable::noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint)
@@ -304,7 +320,8 @@ void NodeTable::noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _en
         return;
 
     shared_ptr<NodeEntry> newNode = nodeEntry(_pubk);
-    if (newNode && !newNode->pending)
+    if (newNode && RLPXDatagramFace::secondsSinceEpoch() <
+                       newNode->lastPongReceivedTime + c_bondingTimeSeconds)
     {
         LOG(m_logger) << "Active node " << _pubk << '@' << _endpoint;
         newNode->endpoint.setAddress(_endpoint.address());
@@ -399,46 +416,60 @@ void NodeTable::onPacketReceived(
         {
             case Pong::type:
             {
-                auto in = dynamic_cast<Pong const&>(*packet);
-                // whenever a pong is received, check if it's in m_evictions
-                bool found = false;
-                NodeID leastSeenID;
+                auto pong = dynamic_cast<Pong const&>(*packet);
+                auto const sourceId = pong.sourceid;
+
+                // validate pong
+                auto const sentPing = m_sentPings.find(sourceId);
+                if (sentPing == m_sentPings.end())
+                {
+                    LOG(m_logger) << "Unsolicited PONG from " << _from.address().to_string() << ":"
+                                  << _from.port();
+                    return;
+                }
+
+                if (pong.echo != sentPing->second.second)
+                {
+                    LOG(m_logger) << "Invalid PONG from " << _from.address().to_string() << ":"
+                                  << _from.port();
+                    return;
+                }
+
+                m_sentPings.erase(sentPing);
+                auto const sourceNodeEntry = nodeEntry(sourceId);
+                assert(sourceNodeEntry.get());
+                sourceNodeEntry->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
+
+                // Whenever a pong is received, check if it's in m_evictions.
+                // Don't evict it if valid PONG received.
                 EvictionTimeout evictionEntry;
+                NodeID replacementNodeID;
                 DEV_GUARDED(x_evictions)
-                { 
-                    auto e = m_evictions.find(in.sourceid);
-                    if (e != m_evictions.end())
+                {
+                    auto e = m_evictions.find(sourceId);
+                    if (e != m_evictions.end() &&
+                        e->second.evictedTimePoint + c_reqTimeout >=
+                        std::chrono::steady_clock::now())
                     {
-                        if (e->second.evictedTimePoint + c_reqTimeout >=
-                            std::chrono::steady_clock::now())
-                        {
-                            found = true;
-                            leastSeenID = e->first;
-                            evictionEntry = e->second;
-                            m_evictions.erase(e);
-                        }
+                        replacementNodeID = e->second.newNodeID;
+                        m_evictions.erase(e);
                     }
                 }
-
-                if (found)
-                {
-                    if (auto n = nodeEntry(evictionEntry.newNodeID))
+                // if we don't want to evict, we don't need to remember replacement anymore
+                if (replacementNodeID)
+                    if (auto n = nodeEntry(replacementNodeID))
                         dropNode(n);
-                }
-
-                auto n = nodeEntry(found ? leastSeenID : in.sourceid);
-                if (n && n->pending)
-                    n->pending = false;
 
                 // update our endpoint address and UDP port
                 DEV_GUARDED(x_nodes)
                 {
                     if ((!m_hostNode.endpoint || !m_hostNode.endpoint.isAllowed()) &&
-                        isPublicAddress(in.destination.address()))
-                        m_hostNode.endpoint.setAddress(in.destination.address());
-                    m_hostNode.endpoint.setUdpPort(in.destination.udpPort());
+                        isPublicAddress(pong.destination.address()))
+                        m_hostNode.endpoint.setAddress(pong.destination.address());
+                    m_hostNode.endpoint.setUdpPort(pong.destination.udpPort());
                 }
 
+                LOG(m_logger) << "PONG from " << sourceId << " " << _from;
                 break;
             }
 
@@ -550,6 +581,7 @@ void NodeTable::doCheckEvictions()
                             active.push_back(itNewNode->second);
                     }
                 }
+
             // remove evicted nodes from m_evictions
             drop.unique();
             for (auto const& n : drop)
@@ -586,6 +618,24 @@ void NodeTable::doDiscovery()
         crypto::Nonce::get().ref().copyTo(randNodeId.ref().cropped(0, h256::size));
         crypto::Nonce::get().ref().copyTo(randNodeId.ref().cropped(h256::size, h256::size));
         doDiscover(randNodeId);
+    });
+}
+
+void NodeTable::doHandleTimeouts()
+{
+    m_timers.schedule(c_handleTimeoutsIntervalMs, [this](boost::system::error_code const& _ec) {
+        if ((_ec && _ec.value() == boost::asio::error::operation_aborted) || m_timers.isStopped())
+            return;
+
+        for (auto it = m_sentPings.begin(); it != m_sentPings.end();)
+        {
+            if (chrono::steady_clock::now() > it->second.first + DiscoveryDatagram::c_timeToLive)
+                it = m_sentPings.erase(it);
+            else
+                ++it;
+        }
+
+        doHandleTimeouts();
     });
 }
 

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -177,26 +177,26 @@ public:
 protected:
     /// Constants for Kademlia, derived from address space.
 
-    static unsigned const s_addressByteSize = h256::size;					///< Size of address type in bytes.
-    static unsigned const s_bits = 8 * s_addressByteSize;					///< Denoted by n in [Kademlia].
-    static unsigned const s_bins = s_bits - 1;  ///< Size of m_buckets (excludes root, which is us).
-    static unsigned const s_maxSteps = boost::static_log2<s_bits>::value;	///< Max iterations of discovery. (discover)
+    static constexpr unsigned s_addressByteSize = h256::size;					///< Size of address type in bytes.
+    static constexpr unsigned s_bits = 8 * s_addressByteSize;					///< Denoted by n in [Kademlia].
+    static constexpr unsigned s_bins = s_bits - 1;  ///< Size of m_buckets (excludes root, which is us).
+    static constexpr unsigned s_maxSteps = boost::static_log2<s_bits>::value;	///< Max iterations of discovery. (discover)
 
     /// Chosen constants
 
-    static unsigned const s_bucketSize = 16;			///< Denoted by k in [Kademlia]. Number of nodes stored in each bucket.
-    static unsigned const s_alpha = 3;				///< Denoted by \alpha in [Kademlia]. Number of concurrent FindNode requests.
+    static constexpr unsigned s_bucketSize = 16;			///< Denoted by k in [Kademlia]. Number of nodes stored in each bucket.
+    static constexpr unsigned s_alpha = 3;				///< Denoted by \alpha in [Kademlia]. Number of concurrent FindNode requests.
 
     /// Intervals
 
     /// Interval at which eviction timeouts are checked.
-    static std::chrono::milliseconds const c_evictionCheckInterval;
+    static constexpr std::chrono::milliseconds c_evictionCheckInterval{75};
     /// How long to wait for requests (evict, find iterations).
-    static std::chrono::milliseconds const c_reqTimeout;
+    static constexpr std::chrono::milliseconds c_reqTimeout{300};
     /// Refresh interval prevents bucket from becoming stale. [Kademlia]
-    static std::chrono::milliseconds const c_bucketRefresh;
+    static constexpr std::chrono::milliseconds c_bucketRefresh{7200};
     // Period during which we consider last PONG results to be valid before sending new PONG
-    static uint32_t const c_bondingTimeSeconds;
+    static constexpr uint32_t c_bondingTimeSeconds{12 * 60 * 60};
 
     struct NodeBucket
     {
@@ -298,7 +298,7 @@ inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable)
 
 struct DiscoveryDatagram: public RLPXDatagramFace
 {
-    static std::chrono::seconds const c_timeToLive;
+    static constexpr std::chrono::seconds c_timeToLive{60};
 
     /// Constructor used for sending.
     DiscoveryDatagram(bi::udp::endpoint const& _to)

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -173,12 +173,8 @@ public:
     /// Returns the Node to the corresponding node id or the empty Node if that id is not found.
     Node node(NodeID const& _id);
 
-#if defined(BOOST_AUTO_TEST_SUITE) || defined(_MSC_VER) // MSVC includes access specifier in symbol name
+// protected only for derived classes in tests
 protected:
-#else
-private:
-#endif
-
     /// Constants for Kademlia, derived from address space.
 
     static unsigned const s_addressByteSize = h256::size;					///< Size of address type in bytes.

--- a/libp2p/UDP.cpp
+++ b/libp2p/UDP.cpp
@@ -47,9 +47,10 @@ h256 RLPXDatagramFace::sign(Secret const& _k)
     rlpx.copyTo(rlpxPayload);
     
     bytesConstRef signedRLPx(&data[h256::size], data.size() - h256::size);
-    dev::sha3(signedRLPx).ref().copyTo(rlpxHash);
+    h256 hash(dev::sha3(signedRLPx));
+    hash.ref().copyTo(rlpxHash);
 
-    return sighash;
+    return hash;
 }
 
 Public RLPXDatagramFace::authenticate(bytesConstRef _sig, bytesConstRef _rlp)

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeReplacesNodeInFullBucketWhenEndpointChanged)
     BOOST_CHECK_EQUAL(mostRecentNodeEntry->endpoint, newEndpoint);
 }
 
-BOOST_AUTO_TEST_CASE(unsolicitedPong)
+BOOST_AUTO_TEST_CASE(unexpectedPong)
 {
     // NodeTable receiving PONG
     TestNodeTableHost nodeTableHost(0);

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -83,16 +83,6 @@ struct TestNodeTable: public NodeTable
         return ret;
     }
 
-    void pingTestNodes(std::vector<std::pair<KeyPair,unsigned>> const& _testNodes)
-    {
-        bi::address ourIp = bi::address::from_string("127.0.0.1");
-        for (auto& n: _testNodes)
-        {
-            ping(n.first.pub(), NodeIPEndpoint(ourIp, n.second, n.second));
-            this_thread::sleep_for(chrono::milliseconds(2));
-        }
-    }
-
     void populateTestNodes(
         std::vector<std::pair<Public, unsigned>> const& _testNodes, size_t _count = 0)
     {
@@ -108,7 +98,7 @@ struct TestNodeTable: public NodeTable
                     Guard ln(x_nodes);
                     shared_ptr<NodeEntry> node(new NodeEntry(
                         m_hostNode.id, n.first, NodeIPEndpoint(ourIp, n.second, n.second)));
-                    node->pending = false;
+                    node->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
                     m_allNodes[node->id] = node;
                 }
                 noteActiveNode(n.first, bi::udp::endpoint(ourIp, n.second));
@@ -133,7 +123,7 @@ struct TestNodeTable: public NodeTable
                 Guard ln(x_nodes);
                 shared_ptr<NodeEntry> node(new NodeEntry(m_hostNode.id, testNode->first,
                     NodeIPEndpoint(ourIp, testNode->second, testNode->second)));
-                node->pending = false;
+                node->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
                 m_allNodes[node->id] = node;
                 distance = node->distance;
             }

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -97,7 +97,7 @@ struct TestNodeTable: public NodeTable
                 {
                     Guard ln(x_nodes);
                     shared_ptr<NodeEntry> node(new NodeEntry(
-                        m_hostNode.id, n.first, NodeIPEndpoint(ourIp, n.second, n.second)));
+                        m_hostNodeID, n.first, NodeIPEndpoint(ourIp, n.second, n.second)));
                     node->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
                     m_allNodes[node->id] = node;
                 }
@@ -121,7 +121,7 @@ struct TestNodeTable: public NodeTable
             // manually add node for test
             {
                 Guard ln(x_nodes);
-                shared_ptr<NodeEntry> node(new NodeEntry(m_hostNode.id, testNode->first,
+                shared_ptr<NodeEntry> node(new NodeEntry(m_hostNodeID, testNode->first,
                     NodeIPEndpoint(ourIp, testNode->second, testNode->second)));
                 node->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
                 m_allNodes[node->id] = node;
@@ -160,7 +160,8 @@ struct TestNodeTable: public NodeTable
 
     using NodeTable::m_allNodes;
     using NodeTable::m_buckets;
-    using NodeTable::m_hostNode;
+    using NodeTable::m_hostNodeID;
+    using NodeTable::m_hostNodeEndpoint;
     using NodeTable::m_sentPings;
     using NodeTable::m_socket;
     using NodeTable::noteActiveNode;
@@ -460,7 +461,7 @@ BOOST_AUTO_TEST_CASE(unexpectedPong)
     TestNodeTableHost nodeTableHost(0);
     nodeTableHost.start();
 
-    Pong pong(nodeTableHost.nodeTable->m_hostNode.endpoint);
+    Pong pong(nodeTableHost.nodeTable->m_hostNodeEndpoint);
     auto nodeKeyPair = KeyPair::create();
     pong.sign(nodeKeyPair.secret());
 
@@ -493,7 +494,7 @@ BOOST_AUTO_TEST_CASE(invalidPong)
     nodeTableHost.nodeTable->addNode(Node{nodePubKey, nodeEndpoint});
 
     // send PONG
-    Pong pong(nodeTableHost.nodeTable->m_hostNode.endpoint);
+    Pong pong(nodeTableHost.nodeTable->m_hostNodeEndpoint);
     pong.sign(nodeKeyPair.secret());
 
     nodeSocketHost.socket->send(pong);
@@ -530,7 +531,7 @@ BOOST_AUTO_TEST_CASE(validPong)
     auto ping = dynamic_cast<PingNode const&>(*pingDatagram);
 
     // send PONG
-    Pong pong(nodeTableHost.nodeTable->m_hostNode.endpoint);
+    Pong pong(nodeTableHost.nodeTable->m_hostNodeEndpoint);
     pong.echo = ping.echo;
     pong.sign(nodeKeyPair.secret());
     nodeSocketHost.socket->send(pong);


### PR DESCRIPTION
Addresses point 1 of https://github.com/ethereum/aleth/issues/4959
Saves info about every PING sent into `m_sentPings`; then validates each received PONG against the saved hash.

Next steps:
- more unit tests for timeouts and for evictions https://github.com/ethereum/aleth/pull/5390;
- Save last PONG time into `network.rlp` with each node (currently it trusts `network.rlp` to have valid nodes and doesn't re-PING them after aleth restart)