### PR TITLE
Fix redundant ping when adding node to node table in response to ping packet

### DIFF
--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -1,22 +1,18 @@
 /*
- This file is part of cpp-ethereum.
+ This file is part of aleth.
 
- cpp-ethereum is free software: you can redistribute it and/or modify
+ aleth is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- cpp-ethereum is distributed in the hope that it will be useful,
+ aleth is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
- */
-/** @file NodeTable.h
- * @author Alex Leverington <nessence@gmail.com>
- * @date 2014
+ along with aleth.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #pragma once
@@ -154,8 +150,8 @@ public:
     /// Called by implementation which provided handler to process NodeEntryAdded/NodeEntryDropped events. Events are coalesced by type whereby old events are ignored.
     void processEvents();
 
-    /// Add node. Node will be pinged.
-    void addNode(Node const& _node, NodeRelation _relation = NodeRelation::Unknown);
+    /// Add node and optionally ping it
+    void addNode(Node const& _node, NodeRelation _relation = NodeRelation::Unknown, bool _ping = true);
 
     /// Returns list of node ids active in node table.
     std::list<NodeID> nodes() const;


### PR DESCRIPTION
Fix #5386 

This removes the redundant ping which occurs when Aleth adds a node to the node table in response to receiving a ping from the node. There are numerous conditions when Aleth will still ping a node after adding it to the node table, including when it is supplied as a part of the `--peerset` command line argument.

I've verified that these changes address the redundant ping and that Aleth still initiates a full sync on the ropsten testnet.

Console output prior to these changes (note that aleth-bootnode sends a ping and a pong to ##16ff0f98… immediately after receiving a ping from it and adding it to its node table. The ping is redundant and results in the other node sending back an unnecessary pong): 
```
C:\Users\nilse\Documents\Code\aleth\build\aleth-bootnode\Debug>aleth-bootnode -v 4
aleth-bootnode, a C++ Ethereum bootnode implementation
INFO  12-07 20:37:37 main net    Id: ##51bb204f…
INFO  12-07 20:37:37 p2p  info   UPnP device not found.
TRACE 12-07 20:37:37 p2p  net    Listening on local port 30303 (public: 0.0.0.0:0)
DEBUG 12-07 20:37:37 p2p  net    p2p.started id: ##51bb204f…
Node ID: enode://51bb204f454971eaa0360c33fb33e9afdd63a6a7020d0d0c00bb709c4a506d1f74e3220050521e57195f04cfee6e71bccec31c18b78b5c8b6676a2fb33cec50e@0.0.0.0:0
DEBUG 12-07 20:37:44 p2p  discov performing random discovery
DEBUG 12-07 20:37:44 p2p  discov Terminating discover after 0 rounds.
DEBUG 12-07 20:37:45 p2p  discov Received Ping from ##16ff0f98…@127.0.0.1:30305
DEBUG 12-07 20:37:45 p2p  discov addNode pending for ##16ff0f98…@127.0.0.1 UDP 30305 TCP 30305
DEBUG 12-07 20:37:45 p2p  discov Sending Ping to ##16ff0f98…@127.0.0.1 UDP 30305 TCP 30305
DEBUG 12-07 20:37:45 p2p  discov Sending Pong to ##16ff0f98…@127.0.0.1:30305
DEBUG 12-07 20:37:45 p2p  discov Received Pong from ##16ff0f98…@127.0.0.1:30305
```

Console output with these changes (note that aleth-bootnode a ping from the aleth node and adds it to its node table but only responds with a pong):
```
C:\Users\nilse\Documents\Code\aleth\build\aleth-bootnode\Debug>aleth-bootnode -v 4
aleth-bootnode, a C++ Ethereum bootnode implementation
INFO  12-09 15:44:10 main net    Id: ##40b94b84…
INFO  12-09 15:44:10 p2p  info   UPnP device not found.
TRACE 12-09 15:44:10 p2p  net    Listening on local port 30303 (public: 0.0.0.0:0)
DEBUG 12-09 15:44:10 p2p  net    p2p.started id: ##40b94b84…
Node ID: enode://40b94b8427c7f3ef7ec4c4a2d92ef47051e488910ecf66ef72a512a5fb034a29c6a3154d482cfb635c3813cac6822ac5ff09a27b3691aa6e08e152eb8177a5f0@0.0.0.0:0
DEBUG 12-09 15:44:17 p2p  discov performing random discovery
DEBUG 12-09 15:44:17 p2p  discov Terminating discover after 0 rounds.
DEBUG 12-09 15:44:24 p2p  discov performing random discovery
DEBUG 12-09 15:44:24 p2p  discov Terminating discover after 0 rounds.
DEBUG 12-09 15:44:27 p2p  discov Received Ping from ##6111c300…@127.0.0.1:30305
DEBUG 12-09 15:44:27 p2p  discov addNode pending for ##6111c300…@127.0.0.1 UDP 30305 TCP 30305
DEBUG 12-09 15:44:27 p2p  discov Sending Pong to ##6111c300…@127.0.0.1:30305
TRACE 12-09 15:44:27 p2p  net    p2p.connect.ingress receiving auth from 127.0.0.1:59810
```
