### PR TITLE
Store binaryenVersion in test outputs

### DIFF
--- a/cmake/ProjectBinaryen.cmake
+++ b/cmake/ProjectBinaryen.cmake
@@ -35,13 +35,15 @@ set(binaryen_other_libraries
     ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}support${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 
+set(BINARYEN_VERSION 1.37.35)
+
 ExternalProject_Add(binaryen
     PREFIX ${prefix}
-    DOWNLOAD_NAME binaryen-1.37.35.tar.gz
+    DOWNLOAD_NAME binaryen-${BINARYEN_VERSION}.tar.gz
     DOWNLOAD_DIR ${prefix}/downloads
     SOURCE_DIR ${source_dir}
     BINARY_DIR ${binary_dir}
-    URL https://github.com/WebAssembly/binaryen/archive/1.37.35.tar.gz
+    URL https://github.com/WebAssembly/binaryen/archive/${BINARYEN_VERSION}.tar.gz
     URL_HASH SHA256=19439e41dc576446eaae0c4a8e07d4cd4c40aea7dfb0a6475b925686852f8006
     CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,8 @@ target_include_directories(testeth PRIVATE ${UTILS_INCLUDE_DIR})
 target_link_libraries(testeth PRIVATE ethereum ethashseal web3jsonrpc devcrypto devcore aleth-buildinfo cryptopp-static yaml-cpp::yaml-cpp binaryen::binaryen libjson-rpc-cpp::client)
 install(TARGETS testeth DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+set_property(SOURCE tools/libtesteth/TestHelper.cpp PROPERTY COMPILE_DEFINITIONS BINARYEN_VERSION=${BINARYEN_VERSION})
+
 include(EthUtils)
 
 eth_add_test(ClientBase

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -637,11 +637,10 @@ string prepareLLLCVersionString()
     return "Error getting LLLC Version";
 }
 
+#define STR(X) #X
 string prepareBinaryenVersionString()
 {
-    // NOTE: keep this in-sync with cmake/ProjectBinaryen.cmake
-    // FIXME: there is no internal API to retrieve this...
-    return "1.37.35";
+    return STR(BINARYEN_VERSION);
 }
 
 void copyFile(fs::path const& _source, fs::path const& _destination)

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -637,6 +637,13 @@ string prepareLLLCVersionString()
     return "Error getting LLLC Version";
 }
 
+string prepareBinaryenVersionString()
+{
+    // NOTE: keep this in-sync with cmake/ProjectBinaryen.cmake
+    // FIXME: there is no internal API to retrieve this...
+    return "1.37.35";
+}
+
 void copyFile(fs::path const& _source, fs::path const& _destination)
 {
     fs::ifstream src(_source, ios::binary);

--- a/test/tools/libtesteth/TestHelper.h
+++ b/test/tools/libtesteth/TestHelper.h
@@ -73,6 +73,7 @@ protected:
 // helping functions
 std::string prepareVersionString();
 std::string prepareLLLCVersionString();
+std::string prepareBinaryenVersionString();
 std::vector<boost::filesystem::path> getFiles(boost::filesystem::path const& _dirPath, std::set<std::string> _extentionMask, std::string const& _particularFile = {});
 std::string netIdToString(eth::Network _netId);
 eth::Network stringToNetId(std::string const& _netname);

--- a/test/tools/libtesteth/TestSuite.cpp
+++ b/test/tools/libtesteth/TestSuite.cpp
@@ -98,6 +98,7 @@ void addClientInfo(json_spirit::mValue& _v, fs::path const& _testSource, h256 co
 
 		clientinfo["filledwith"] = test::prepareVersionString();
 		clientinfo["lllcversion"] = test::prepareLLLCVersionString();
+		clientinfo["binaryenVersion"] = test::prepareBinaryenVersionString();
 		clientinfo["source"] = _testSource.string();
 		clientinfo["sourceHash"] = toString(_testSourceHash);
 		clientinfo["comment"] = comment;


### PR DESCRIPTION
Will create a PR next which moves binaryen into an external binary (just like lllc).