### PR TITLE
Add allow-local networking command-line argument to aleth & aleth-bootnode

### DIFF
--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -118,8 +118,6 @@ int main(int argc, char** argv)
         listenIP = vm["listen-ip"].as<string>();
     if (vm.count("listen"))
         listenPort = vm["listen"].as<unsigned short>();
-    if (vm.count("allow-local-discovery"))
-        NodeIPEndpoint::test_allowLocal = true;
     setupLogging(loggingOptions);
     if (loggingOptions.verbosity > 0)
         cout << EthGrayBold << c_programName << ", a C++ Ethereum bootnode implementation" EthReset
@@ -127,6 +125,7 @@ int main(int argc, char** argv)
 
     auto netPrefs = publicIP.empty() ? NetworkConfig(listenIP, listenPort, upnp) :
                                        NetworkConfig(publicIP, listenIP, listenPort, upnp);
+    netPrefs.allowLocalDiscovery = vm.count("allow-local-discovery") != 0;
     auto netData = contents(getDataDir() / fs::path(c_networkConfigFileName));
 
     Host h(c_programName, netPrefs, &netData);

--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -59,8 +59,9 @@ int main(int argc, char** argv)
     addNetworkingOption("listen-ip", po::value<string>()->value_name("<ip>(:<port>)"),
         "Listen on the given IP for incoming connections (default: 0.0.0.0)");
     addNetworkingOption("listen", po::value<unsigned short>()->value_name("<port>"),
-        "Listen on the given port for incoming connections (default: 30303)\n");
-
+        "Listen on the given port for incoming connections (default: 30303)");
+    addNetworkingOption("allow-local-discovery",
+        "Include local addresses in the discovery process. Used for testing purposes.");
     po::options_description allowedOptions("Allowed options");
     allowedOptions.add(generalOptions).add(loggingProgramOptions).add(clientNetworking);
 
@@ -117,7 +118,8 @@ int main(int argc, char** argv)
         listenIP = vm["listen-ip"].as<string>();
     if (vm.count("listen"))
         listenPort = vm["listen"].as<unsigned short>();
-
+    if (vm.count("allow-local-discovery"))
+        NodeIPEndpoint::test_allowLocal = true;
     setupLogging(loggingOptions);
     if (loggingOptions.verbosity > 0)
         cout << EthGrayBold << c_programName << ", a C++ Ethereum bootnode implementation" EthReset

--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -40,6 +40,8 @@ int main(int argc, char** argv)
 {
     setDefaultOrCLocale();
 
+    bool allowLocalDiscovery = false;
+
     po::options_description generalOptions("GENERAL OPTIONS", c_lineWidth);
     auto addGeneralOption = generalOptions.add_options();
     addGeneralOption("help,h", "Show this help message and exit\n");
@@ -60,7 +62,7 @@ int main(int argc, char** argv)
         "Listen on the given IP for incoming connections (default: 0.0.0.0)");
     addNetworkingOption("listen", po::value<unsigned short>()->value_name("<port>"),
         "Listen on the given port for incoming connections (default: 30303)");
-    addNetworkingOption("allow-local-discovery",
+    addNetworkingOption("allow-local-discovery", po::bool_switch(&allowLocalDiscovery),
         "Include local addresses in the discovery process. Used for testing purposes.");
     po::options_description allowedOptions("Allowed options");
     allowedOptions.add(generalOptions).add(loggingProgramOptions).add(clientNetworking);
@@ -125,7 +127,7 @@ int main(int argc, char** argv)
 
     auto netPrefs = publicIP.empty() ? NetworkConfig(listenIP, listenPort, upnp) :
                                        NetworkConfig(publicIP, listenIP, listenPort, upnp);
-    netPrefs.allowLocalDiscovery = vm.count("allow-local-discovery") != 0;
+    netPrefs.allowLocalDiscovery = allowLocalDiscovery;
     auto netData = contents(getDataDir() / fs::path(c_networkConfigFileName));
 
     Host h(c_programName, netPrefs, &netData);

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -633,8 +633,6 @@ int main(int argc, char** argv)
             cerr << "Bad " << "--network-id" << " option: " << vm["network-id"].as<string>() << "\n";
             return -1;
         }
-    if (vm.count("allow-local-discovery"))
-        NodeIPEndpoint::test_allowLocal = true;
     if (vm.count("private"))
         try
         {
@@ -768,6 +766,7 @@ int main(int argc, char** argv)
 
     auto netPrefs = publicIP.empty() ? NetworkConfig(listenIP, listenPort, upnp) : NetworkConfig(publicIP, listenIP ,listenPort, upnp);
     netPrefs.discovery = (privateChain.empty() && !disableDiscovery) || enableDiscovery;
+    netPrefs.allowLocalDiscovery = vm.count("allow-local-discovery") != 0;
     netPrefs.pin = vm.count("pin") != 0;
 
     auto nodesState = contents(getDataDir() / fs::path("network.rlp"));

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -287,6 +287,8 @@ int main(int argc, char** argv)
         "Connect to the given remote port (default: 30303)");
     addNetworkingOption("network-id", po::value<unsigned>()->value_name("<n>"),
         "Only connect to other hosts with this network id");
+    addNetworkingOption("allow-local-discovery",
+        "Include local addresses in the discovery process. Used for testing purposes.");
 #if ETH_MINIUPNPC
     addNetworkingOption(
         "upnp", po::value<string>()->value_name("<on/off>"), "Use UPnP for NAT (default: on)");
@@ -631,6 +633,8 @@ int main(int argc, char** argv)
             cerr << "Bad " << "--network-id" << " option: " << vm["network-id"].as<string>() << "\n";
             return -1;
         }
+    if (vm.count("allow-local-discovery"))
+        NodeIPEndpoint::test_allowLocal = true;
     if (vm.count("private"))
         try
         {

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -161,6 +161,7 @@ int main(int argc, char** argv)
     bool bootstrap = true;
     bool disableDiscovery = false;
     bool enableDiscovery = false;
+    bool allowLocalDiscovery = false;
     static const unsigned NoNetworkID = (unsigned)-1;
     unsigned networkID = NoNetworkID;
 
@@ -287,7 +288,7 @@ int main(int argc, char** argv)
         "Connect to the given remote port (default: 30303)");
     addNetworkingOption("network-id", po::value<unsigned>()->value_name("<n>"),
         "Only connect to other hosts with this network id");
-    addNetworkingOption("allow-local-discovery",
+    addNetworkingOption("allow-local-discovery", po::bool_switch(&allowLocalDiscovery),
         "Include local addresses in the discovery process. Used for testing purposes.");
 #if ETH_MINIUPNPC
     addNetworkingOption(
@@ -766,7 +767,7 @@ int main(int argc, char** argv)
 
     auto netPrefs = publicIP.empty() ? NetworkConfig(listenIP, listenPort, upnp) : NetworkConfig(publicIP, listenIP ,listenPort, upnp);
     netPrefs.discovery = (privateChain.empty() && !disableDiscovery) || enableDiscovery;
-    netPrefs.allowLocalDiscovery = vm.count("allow-local-discovery") != 0;
+    netPrefs.allowLocalDiscovery = allowLocalDiscovery;
     netPrefs.pin = vm.count("pin") != 0;
 
     auto nodesState = contents(getDataDir() / fs::path("network.rlp"));

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -33,8 +33,6 @@ static_assert(dev::p2p::c_protocolVersion == 4, "Replace v3 compatbility with v4
 const dev::p2p::NodeIPEndpoint dev::p2p::UnspecifiedNodeIPEndpoint = NodeIPEndpoint(bi::address(), 0, 0);
 const dev::p2p::Node dev::p2p::UnspecifiedNode = dev::p2p::Node(NodeID(), UnspecifiedNodeIPEndpoint);
 
-bool dev::p2p::NodeIPEndpoint::test_allowLocal = false;
-
 bool p2p::isPublicAddress(std::string const& _addressToCheck)
 {
     return _addressToCheck.empty() ? false : isPublicAddress(bi::address::from_string(_addressToCheck));
@@ -43,6 +41,12 @@ bool p2p::isPublicAddress(std::string const& _addressToCheck)
 bool p2p::isPublicAddress(bi::address const& _addressToCheck)
 {
     return !(isPrivateAddress(_addressToCheck) || isLocalHostAddress(_addressToCheck));
+}
+
+bool p2p::isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck)
+{
+    return _allowLocalDiscovery ? !_addressToCheck.is_unspecified() :
+                                  isPublicAddress(_addressToCheck);
 }
 
 // Helper function to determine if an address falls within one of the reserved ranges

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -43,12 +43,6 @@ bool p2p::isPublicAddress(bi::address const& _addressToCheck)
     return !(isPrivateAddress(_addressToCheck) || isLocalHostAddress(_addressToCheck));
 }
 
-bool p2p::isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck)
-{
-    return _allowLocalDiscovery ? !_addressToCheck.is_unspecified() :
-                                  isPublicAddress(_addressToCheck);
-}
-
 // Helper function to determine if an address falls within one of the reserved ranges
 // For V4:
 // Class A "10.*", Class B "172.[16->31].*", Class C "192.168.*"

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -43,6 +43,17 @@ bool p2p::isPublicAddress(bi::address const& _addressToCheck)
     return !(isPrivateAddress(_addressToCheck) || isLocalHostAddress(_addressToCheck));
 }
 
+bool p2p::isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck)
+{
+    return _allowLocalDiscovery ? !_addressToCheck.is_unspecified() :
+                                  isPublicAddress(_addressToCheck);
+}
+
+bool p2p::isAllowedEndpoint(bool _allowLocalDiscovery, NodeIPEndpoint const& _endpointToCheck)
+{
+    return isAllowedAddress(_allowLocalDiscovery, _endpointToCheck.address());
+}
+
 // Helper function to determine if an address falls within one of the reserved ranges
 // For V4:
 // Class A "10.*", Class B "172.[16->31].*", Class C "192.168.*"

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -68,7 +68,6 @@ bool isLocalHostAddress(bi::address const& _addressToCheck);
 bool isLocalHostAddress(std::string const& _addressToCheck);
 bool isPublicAddress(bi::address const& _addressToCheck);
 bool isPublicAddress(std::string const& _addressToCheck);
-bool isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck);
 
 class UPnP;
 class Host;

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -179,8 +179,9 @@ public:
         StreamList,
         StreamInline
     };
-    
-    /// Setting true causes isAllowed to return true for all addresses. (Used by test fixtures)
+
+    /// Setting true causes isAllowed to return true for all addresses. (Used by test fixtures and
+    /// configurable via an aleth/aleth-bootnode command line argument)
     static bool test_allowLocal;
 
     NodeIPEndpoint() = default;
@@ -284,6 +285,7 @@ public:
 
 class DeadlineOps
 {
+    // Boost deadline timer wrapper which provides thread-safety
     class DeadlineOp
     {
     public:

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -68,6 +68,7 @@ bool isLocalHostAddress(bi::address const& _addressToCheck);
 bool isLocalHostAddress(std::string const& _addressToCheck);
 bool isPublicAddress(bi::address const& _addressToCheck);
 bool isPublicAddress(std::string const& _addressToCheck);
+bool isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck);
 
 class UPnP;
 class Host;
@@ -180,10 +181,6 @@ public:
         StreamInline
     };
 
-    /// Setting true causes isAllowed to return true for all addresses. (Used by test fixtures and
-    /// configurable via an aleth/aleth-bootnode command line argument)
-    static bool test_allowLocal;
-
     NodeIPEndpoint() = default;
     NodeIPEndpoint(bi::address _addr, uint16_t _udp, uint16_t _tcp)
       : m_address(_addr), m_udpPort(_udp), m_tcpPort(_tcp)
@@ -194,12 +191,6 @@ public:
     operator bi::tcp::endpoint() const { return bi::tcp::endpoint(m_address, m_tcpPort); }
 
     operator bool() const { return !m_address.is_unspecified() && m_udpPort > 0 && m_tcpPort > 0; }
-
-    bool isAllowed() const
-    {
-        return NodeIPEndpoint::test_allowLocal ? !m_address.is_unspecified() :
-                                                 isPublicAddress(m_address);
-    }
 
     bool operator==(NodeIPEndpoint const& _cmp) const {
         return m_address == _cmp.m_address && m_udpPort == _cmp.m_udpPort &&

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -68,6 +68,8 @@ bool isLocalHostAddress(bi::address const& _addressToCheck);
 bool isLocalHostAddress(std::string const& _addressToCheck);
 bool isPublicAddress(bi::address const& _addressToCheck);
 bool isPublicAddress(std::string const& _addressToCheck);
+bool isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck);
+bool isAllowedEndpoint(bool _allowLocalDiscovery, NodeIPEndpoint const& _endpointToCheck);
 
 class UPnP;
 class Host;

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -855,18 +855,19 @@ bytes Host::saveNetwork() const
         if (!p.endpoint.address().is_v4())
             continue;
 
-        // Only save peers which have connected within 2 days, with properly-advertised port and public IP address
+        // Only save peers which have connected within 2 days, with properly-advertised port and
+        // public IP address
         if (chrono::system_clock::now() - p.m_lastConnected < chrono::seconds(3600 * 48) &&
             !!p.endpoint && p.id != id() &&
-            (p.peerType == PeerType::Required ||
-                isAllowedAddress(m_netConfig.allowLocalDiscovery, p.endpoint.address())))
+            (p.peerType == PeerType::Required || isAllowedAddress(p.endpoint.address())))
         {
             network.appendList(11);
             p.endpoint.streamRLP(network, NodeIPEndpoint::StreamInline);
             network << p.id << (p.peerType == PeerType::Required ? true : false)
-                << chrono::duration_cast<chrono::seconds>(p.m_lastConnected.time_since_epoch()).count()
-                << chrono::duration_cast<chrono::seconds>(p.m_lastAttempted.time_since_epoch()).count()
-                << p.m_failedAttempts.load() << (unsigned)p.m_lastDisconnect << p.m_score.load() << p.m_rating.load();
+                    << chrono::duration_cast<chrono::seconds>(p.m_lastConnected.time_since_epoch()).count()
+                    << chrono::duration_cast<chrono::seconds>(p.m_lastAttempted.time_since_epoch()).count()
+                    << p.m_failedAttempts.load() << (unsigned)p.m_lastDisconnect << p.m_score.load()
+                    << p.m_rating.load();
             count++;
         }
     }
@@ -923,16 +924,14 @@ void Host::restoreNetwork(bytesConstRef _b)
             if (i.itemCount() == 4 || i.itemCount() == 11)
             {
                 Node n((NodeID)i[3], NodeIPEndpoint(i));
-                if (i.itemCount() == 4 &&
-                    isAllowedAddress(m_netConfig.allowLocalDiscovery, n.endpoint.address()))
+                if (i.itemCount() == 4 && isAllowedAddress(n.endpoint.address()))
                 {
                     addNodeToNodeTable(n);
                 }
                 else if (i.itemCount() == 11)
                 {
                     n.peerType = i[4].toInt<bool>() ? PeerType::Required : PeerType::Optional;
-                    if (!isAllowedAddress(m_netConfig.allowLocalDiscovery, n.endpoint.address()) &&
-                        n.peerType == PeerType::Optional)
+                    if (!isAllowedAddress(n.endpoint.address()) && n.peerType == PeerType::Optional)
                         continue;
                     shared_ptr<Peer> p = make_shared<Peer>(n);
                     p->m_lastConnected = chrono::system_clock::time_point(chrono::seconds(i[5].toInt<unsigned>()));
@@ -950,19 +949,20 @@ void Host::restoreNetwork(bytesConstRef _b)
             }
             else if (i.itemCount() == 3 || i.itemCount() == 10)
             {
-                Node n((NodeID)i[2], NodeIPEndpoint(bi::address_v4(i[0].toArray<byte, 4>()), i[1].toInt<uint16_t>(), i[1].toInt<uint16_t>()));
-                if (i.itemCount() == 3 &&
-                    isAllowedAddress(m_netConfig.allowLocalDiscovery, n.endpoint.address()))
+                Node n((NodeID)i[2], NodeIPEndpoint(bi::address_v4(i[0].toArray<byte, 4>()),
+                                         i[1].toInt<uint16_t>(), i[1].toInt<uint16_t>()));
+                if (i.itemCount() == 3 && isAllowedAddress(n.endpoint.address()))
                     addNodeToNodeTable(n);
                 else if (i.itemCount() == 10)
                 {
                     n.peerType = i[3].toInt<bool>() ? PeerType::Required : PeerType::Optional;
-                    if (!isAllowedAddress(m_netConfig.allowLocalDiscovery, n.endpoint.address()) &&
-                        n.peerType == PeerType::Optional)
+                    if (!isAllowedAddress(n.endpoint.address()) && n.peerType == PeerType::Optional)
                         continue;
                     shared_ptr<Peer> p = make_shared<Peer>(n);
-                    p->m_lastConnected = chrono::system_clock::time_point(chrono::seconds(i[4].toInt<unsigned>()));
-                    p->m_lastAttempted = chrono::system_clock::time_point(chrono::seconds(i[5].toInt<unsigned>()));
+                    p->m_lastConnected =
+                        chrono::system_clock::time_point(chrono::seconds(i[4].toInt<unsigned>()));
+                    p->m_lastAttempted =
+                        chrono::system_clock::time_point(chrono::seconds(i[5].toInt<unsigned>()));
                     p->m_failedAttempts = i[6].toInt<unsigned>();
                     p->m_lastDisconnect = (DisconnectReason)i[7].toInt<unsigned>();
                     p->m_score = (int)i[8].toInt<unsigned>();
@@ -1012,6 +1012,12 @@ bool Host::addNodeToNodeTable(Node const& _node, NodeTable::NodeRelation _relati
 
     nodeTable->addNode(_node, _relation);
     return true;
+}
+
+bool Host::isAllowedAddress(bi::address const& _addressToCheck) const
+{
+    return m_netConfig.allowLocalDiscovery ? !_addressToCheck.is_unspecified() :
+                                             isPublicAddress(_addressToCheck);
 }
 
 void Host::forEachPeer(

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -286,6 +286,10 @@ private:
     Node nodeFromNodeTable(Public const& _id) const;
     bool addNodeToNodeTable(Node const& _node, NodeTable::NodeRelation _relation = NodeTable::NodeRelation::Unknown);
 
+    /// Determines if a node with the supplied address should be included in or restored from the
+    /// serialized network configuration data
+    bool isAllowedAddress(bi::address const& _addressToCheck) const;
+
     bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
 
     std::atomic<bool> m_run{false};													///< Whether network is running.

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -286,9 +286,12 @@ private:
     Node nodeFromNodeTable(Public const& _id) const;
     bool addNodeToNodeTable(Node const& _node, NodeTable::NodeRelation _relation = NodeTable::NodeRelation::Unknown);
 
-    /// Determines if a node with the supplied address should be included in or restored from the
+    /// Determines if a node with the supplied endpoint should be included in or restored from the
     /// serialized network configuration data
-    bool isAllowedAddress(bi::address const& _addressToCheck) const;
+    bool isAllowedEndpoint(NodeIPEndpoint const& _endpointToCheck) const
+    {
+        return dev::p2p::isAllowedEndpoint(m_netConfig.allowLocalDiscovery, _endpointToCheck);
+    }
 
     bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
 

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -41,16 +41,37 @@ static const unsigned short c_defaultListenPort = 30303;
 
 struct NetworkConfig
 {
-	// Default Network Preferences
-	explicit NetworkConfig(unsigned short lp = c_defaultListenPort): listenPort(lp) {}
+    // Default Network Preferences
+    explicit NetworkConfig(unsigned short _listenPort = c_defaultListenPort)
+      : listenPort(_listenPort)
+    {}
 
-	// Network Preferences with specific Listen IP
-	NetworkConfig(std::string const& l, unsigned short lp = c_defaultListenPort, bool u = true): publicIPAddress(), listenIPAddress(l), listenPort(lp), traverseNAT(u) {}
+    // Network Preferences with specific Listen IP
+    NetworkConfig(std::string const& _listenAddress,
+        unsigned short _listenPort = c_defaultListenPort, bool _upnp = true,
+        bool _allowLocalDiscovery = false)
+      : publicIPAddress(),
+        listenIPAddress(_listenAddress),
+        listenPort(_listenPort),
+        traverseNAT(_upnp),
+        allowLocalDiscovery(_allowLocalDiscovery)
+    {}
 
-	// Network Preferences with intended Public IP
-	NetworkConfig(std::string const& publicIP, std::string const& l = std::string(), unsigned short lp = c_defaultListenPort, bool u = true): publicIPAddress(publicIP), listenIPAddress(l), listenPort(lp), traverseNAT(u) { if (!publicIPAddress.empty() && !isPublicAddress(publicIPAddress)) BOOST_THROW_EXCEPTION(InvalidPublicIPAddress()); }
+    // Network Preferences with intended Public IP
+    NetworkConfig(std::string const& _publicIP, std::string const& _listenAddress = std::string(),
+        unsigned short _listenPort = c_defaultListenPort, bool _upnp = true,
+        bool _allowLocalDiscovery = false)
+      : publicIPAddress(_publicIP),
+        listenIPAddress(_listenAddress),
+        listenPort(_listenPort),
+        traverseNAT(_upnp),
+        allowLocalDiscovery(_allowLocalDiscovery)
+    {
+        if (!publicIPAddress.empty() && !isPublicAddress(publicIPAddress))
+            BOOST_THROW_EXCEPTION(InvalidPublicIPAddress());
+    }
 
-	/// Addressing
+    /// Addressing
 
 	std::string publicIPAddress;
 	std::string listenIPAddress;
@@ -61,6 +82,7 @@ struct NetworkConfig
 
 	bool traverseNAT = true;
 	bool discovery = true;		// Discovery is activated with network.
+	bool allowLocalDiscovery = false; // Include nodes with local IP addresses in the discovery process.
 	bool pin = false;			// Only accept or connect to trusted peers.
 };
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -46,14 +46,15 @@ inline bool operator==(
 
 NodeEntry::NodeEntry(NodeID const& _src, Public const& _pubk, NodeIPEndpoint const& _gw): Node(_pubk, _gw), distance(NodeTable::distance(_src, _pubk)) {}
 
-NodeTable::NodeTable(
-    ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint, bool _enabled)
+NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint,
+    bool _enabled, bool _allowLocalDiscovery)
   : m_hostNodeID(_alias.pub()),
     m_hostNodeEndpoint(_endpoint),
     m_secret(_alias.secret()),
     m_socket(make_shared<NodeSocket>(
         _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)m_hostNodeEndpoint)),
     m_requestTimeToLive(DiscoveryDatagram::c_timeToLive),        
+    m_allowLocalDiscovery(_allowLocalDiscovery),
     m_timers(_io)
 {
     for (unsigned i = 0; i < s_bins; i++)
@@ -274,7 +275,8 @@ vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID _target)
     vector<shared_ptr<NodeEntry>> ret;
     for (auto& nodes: found)
         for (auto const& n: nodes.second)
-            if (ret.size() < s_bucketSize && !!n->endpoint && n->endpoint.isAllowed())
+            if (ret.size() < s_bucketSize && !!n->endpoint &&
+                isAllowedAddress(m_allowLocalDiscovery, n->endpoint.address()))
                 ret.push_back(n);
     return ret;
 }
@@ -309,7 +311,8 @@ void NodeTable::evict(NodeEntry const& _leastSeen, NodeEntry const& _new)
 void NodeTable::noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint)
 {
     if (_pubk == m_hostNodeID ||
-        !NodeIPEndpoint(_endpoint.address(), _endpoint.port(), _endpoint.port()).isAllowed())
+        !isAllowedAddress(m_allowLocalDiscovery,
+            NodeIPEndpoint(_endpoint.address(), _endpoint.port(), _endpoint.port()).address()))
         return;
 
     shared_ptr<NodeEntry> newNode = nodeEntry(_pubk);
@@ -444,7 +447,8 @@ void NodeTable::onPacketReceived(
                 // update our endpoint address and UDP port
                 DEV_GUARDED(x_nodes)
                 {
-                    if ((!m_hostNodeEndpoint || !m_hostNodeEndpoint.isAllowed()) &&
+                    if ((!m_hostNodeEndpoint || !isAllowedAddress(m_allowLocalDiscovery,
+                                                    m_hostNodeEndpoint.address())) &&
                         isPublicAddress(pong.destination.address()))
                         m_hostNodeEndpoint.setAddress(pong.destination.address());
                     m_hostNodeEndpoint.setUdpPort(pong.destination.udpPort());

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -140,7 +140,8 @@ public:
     enum DiscoverType { Random = 0 };
     
     /// Constructor requiring host for I/O, credentials, and IP Address and port to listen on.
-    NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint, bool _enabled = true);
+    NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint,
+        bool _enabled = true, bool _allowLocalDiscovery = false);
     ~NodeTable();
 
     /// Returns distance based on xor metric two node ids. Used by NodeEntry and NodeTable.
@@ -287,6 +288,8 @@ protected:
     std::chrono::seconds m_requestTimeToLive;
 
     mutable Logger m_logger{createLogger(VerbosityDebug, "discov")};
+
+    bool m_allowLocalDiscovery;                                     ///< Allow nodes with local addresses to be included in the discovery process
 
     DeadlineOps m_timers; ///< this should be the last member - it must be destroyed first
 };

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -263,8 +263,11 @@ protected:
         return RLPXDatagramFace::futureFromEpoch(m_requestTimeToLive);
     }
 
-    /// Determines if a node with the supplied address is allowed to participate in discovery.
-    bool isAllowedAddress(bi::address const& _addressToCheck) const;
+    /// Determines if a node with the supplied endpoint is allowed to participate in discovery.
+    bool isAllowedEndpoint(NodeIPEndpoint const& _endpointToCheck) const
+    {
+        return dev::p2p::isAllowedEndpoint(m_allowLocalDiscovery, _endpointToCheck);
+    }
 
     std::unique_ptr<NodeTableEventHandler> m_nodeEventHandler;		///< Event handler for node events.
 

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -256,13 +256,15 @@ protected:
 
     void doHandleTimeouts();
 
-    // Useful ony for tests.
+    // Useful only for tests.
     void setRequestTimeToLive(std::chrono::seconds const& _time) { m_requestTimeToLive = _time; }
     uint32_t nextRequestExpirationTime() const
     {
         return RLPXDatagramFace::futureFromEpoch(m_requestTimeToLive);
     }
 
+    /// Determines if a node with the supplied address is allowed to participate in discovery.
+    bool isAllowedAddress(bi::address const& _addressToCheck) const;
 
     std::unique_ptr<NodeTableEventHandler> m_nodeEventHandler;		///< Event handler for node events.
 

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -35,12 +35,6 @@ using namespace dev;
 using namespace dev::test;
 using namespace dev::p2p;
 
-struct P2PFixture: public TestOutputHelperFixture
-{
-    P2PFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = true; }
-    ~P2PFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = false; }
-};
-
 class TestCapability : public CapabilityFace, public Worker
 {
 public:
@@ -98,7 +92,7 @@ public:
     std::unordered_map<NodeID, int> m_testSums;
 };
 
-BOOST_FIXTURE_TEST_SUITE(p2pCapability, P2PFixture)
+BOOST_FIXTURE_TEST_SUITE(p2pCapability, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(capability)
 {
@@ -106,8 +100,8 @@ BOOST_AUTO_TEST_CASE(capability)
 
     int const step = 10;
     const char* const localhost = "127.0.0.1";
-    NetworkConfig prefs1(localhost, 0, false);
-    NetworkConfig prefs2(localhost, 0, false);
+    NetworkConfig prefs1(localhost, 0, false /* upnp */, true /* allow local discovery */);
+    NetworkConfig prefs2(localhost, 0, false /* upnp */, true /* allow local discovery */);
     Host host1("Test", prefs1);
     Host host2("Test", prefs2);
     auto thc1 = make_shared<TestCapability>(host1);

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -36,15 +36,9 @@ using namespace dev::p2p;
 namespace ba = boost::asio;
 namespace bi = ba::ip;
 
-struct NetFixture: public TestOutputHelperFixture
-{
-    NetFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = true; }
-    ~NetFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = false; }
-};
-
 BOOST_AUTO_TEST_SUITE(network)
 
-BOOST_FIXTURE_TEST_SUITE(net, NetFixture)
+BOOST_FIXTURE_TEST_SUITE(net, TestOutputHelperFixture)
 
 /**
  * Only used for testing. Not useful beyond tests.
@@ -65,7 +59,7 @@ protected:
 struct TestNodeTable: public NodeTable
 {
     /// Constructor
-    TestNodeTable(ba::io_service& _io, KeyPair _alias, bi::address const& _addr, uint16_t _port = 30311): NodeTable(_io, _alias, NodeIPEndpoint(_addr, _port, _port)) {}
+    TestNodeTable(ba::io_service& _io, KeyPair _alias, bi::address const& _addr, uint16_t _port = 30311): NodeTable(_io, _alias, NodeIPEndpoint(_addr, _port, _port), true /* discovery enabled */, true /* allow local discovery */) {}
 
     static std::vector<std::pair<Public, uint16_t>> createTestNodes(unsigned _count)
     {

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -33,12 +33,6 @@ using namespace dev;
 using namespace dev::test;
 using namespace dev::p2p;
 
-struct P2PPeerFixture: public TestOutputHelperFixture
-{
-    P2PPeerFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = true; }
-    ~P2PPeerFixture() { dev::p2p::NodeIPEndpoint::test_allowLocal = false; }
-};
-
 class TestCap : public CapabilityFace, public Worker
 {
 public:
@@ -58,16 +52,16 @@ public:
 };
 
 BOOST_AUTO_TEST_SUITE(libp2p)
-BOOST_FIXTURE_TEST_SUITE(p2p, P2PPeerFixture)
+BOOST_FIXTURE_TEST_SUITE(p2p, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
-    Host host1("Test", NetworkConfig("127.0.0.1", 0, false));
+    Host host1("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
     host1.start();
     auto host1port = host1.listenPort();
     BOOST_REQUIRE(host1port);
 
-    Host host2("Test", NetworkConfig("127.0.0.1", 0, false));
+    Host host2("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
     host2.start();
     auto host2port = host2.listenPort();
     BOOST_REQUIRE(host2port);
@@ -135,7 +129,7 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 
     for (unsigned i = 0; i < c_nodes; ++i)
     {
-        Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0, false));
+        Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
         h->setIdealPeerCount(10);		
         h->start(); // starting host is required so listenport is available
         while (!h->haveNetwork())
@@ -187,14 +181,14 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_FIXTURE_TEST_SUITE(p2pPeer, P2PPeerFixture)
+BOOST_FIXTURE_TEST_SUITE(p2pPeer, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(requirePeer)
 {
     unsigned const step = 10;
     const char* const localhost = "127.0.0.1";
-    NetworkConfig prefs1(localhost, 0, false);
-    NetworkConfig prefs2(localhost, 0, false);
+    NetworkConfig prefs1(localhost, 0, false /* upnp */, true /* allow local discovery */);
+    NetworkConfig prefs2(localhost, 0, false /* upnp */, true /* allow local discovery */);
     Host host1("Test", prefs1);
     Host host2("Test", prefs2);
     host1.start();


### PR DESCRIPTION
New networking arg is used to enable nodes from your local network to be added to the
node table. Useful for testing discovery running multiple nodes on ones local machine