### PR TITLE
[WIP] Only start p2p if capabilities have been registered

### DIFF
--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -133,8 +133,6 @@ int main(int argc, char** argv)
     Host h(c_programName, netPrefs, &netData);
     h.start();
 
-    cout << "Node ID: " << h.enode() << endl;
-
     ExitHandler exitHandler;
     signal(SIGTERM, &ExitHandler::exitHandler);
     signal(SIGABRT, &ExitHandler::exitHandler);

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -952,10 +952,7 @@ int main(int argc, char** argv)
         cout << "Mining Beneficiary: " << renderFullAddress(author) << "\n";
 
     if (bootstrap || !remoteHost.empty() || enableDiscovery || listenSet || !preferredNodes.empty())
-    {
         web3.startNetwork();
-        cout << "Node ID: " << web3.enode() << "\n";
-    }
     else
         cout << "Networking disabled. To start, use netstart or pass --bootstrap or a remote host.\n";
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -621,9 +621,9 @@ size_t Host::peerCount() const
     return retCount;
 }
 
-void Host::run(boost::system::error_code const&)
+void Host::run(boost::system::error_code const& _ec)
 {
-    if (!m_run)
+    if (!m_run || _ec)
         return;
 
     if (auto nodeTable = this->nodeTable()) // This again requires x_nodeTable, which is why an additional variable nodeTable is used.

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -780,7 +780,8 @@ void Host::startedWorking()
         int port = Network::tcp4Listen(m_tcp4Acceptor, m_netConfig);
         if (port > 0)
         {
-            m_listenPort = port;
+            // Port may have been changed if the specified port was already in use
+            m_netConfig.listenPort = m_listenPort = port;
             determinePublic();
             runAcceptor();
         }
@@ -799,7 +800,7 @@ void Host::startedWorking()
         m_netConfig.discovery, m_netConfig.allowLocalDiscovery);
 
     if (m_capabilities.size())
-        // Don't need to set event handler since there are no peers for Host to update when p2p
+        // Only set the event handler if there are capabilities since otherwise p2p
         // isn't running
         nodeTable->setEventHandler(new HostNodeTableHandler(*this));
     DEV_GUARDED(x_nodeTable)

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -139,11 +139,11 @@ void Host::stop()
 
 void Host::doneWorking()
 {
+    // reset ioservice (cancels all timers and allows manually polling network if there are
+    // capabilities. Also enables reuse of the ioservice)
+    m_ioService.reset();
     if (m_capabilities.size())
     {
-        // reset ioservice (cancels all timers and allows manually polling network, below)
-        m_ioService.reset();
-
         DEV_GUARDED(x_timers)
             m_timers.clear();
 
@@ -206,9 +206,6 @@ void Host::doneWorking()
         RecursiveGuard l(x_sessions);
         m_sessions.clear();
     }
-    else
-        // allows reusing ioservice in the future
-        m_ioService.reset();
 }
 
 bool Host::isRequiredPeer(NodeID const& _id) const

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -733,12 +733,10 @@ void Host::run(boost::system::error_code const&)
     m_timer->async_wait(runcb);
 }
 
+// Called after thread has been started to perform additional class-specific state
+// initialization (e.g. start capability threads, start TCP listener, and kick off timers) 
 void Host::startedWorking()
 {
-    // Called after thread has been started to perform additional class-specific state
-    // initialization (e.g. start capability threads, start TCP listener, and kick off timers)
-    asserts(!m_timer);
-
     // create deadline timer
     m_timer.reset(new io::deadline_timer(m_ioService));
     m_run = true;

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -90,9 +90,7 @@ Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkConfig co
     m_alias(_alias),
     m_lastPing(chrono::steady_clock::time_point::min()),
     m_capabilityHost(createCapabilityHost(*this))
-{
-    cnetnote << "Id: " << id();
-}
+{}
 
 Host::Host(string const& _clientVersion, NetworkConfig const& _n, bytesConstRef _restoreNetwork):
     Host(_clientVersion, networkAlias(_restoreNetwork), _n)
@@ -148,7 +146,7 @@ void Host::doneWorking()
 
         DEV_GUARDED(x_timers)
             m_timers.clear();
-        
+
         // shutdown acceptor
         m_tcp4Acceptor.cancel();
         if (m_tcp4Acceptor.is_open())
@@ -162,14 +160,14 @@ void Host::doneWorking()
             m_ioService.poll();
 
         // stop capabilities (eth: stops syncing or block/tx broadcast)
-        for (auto const& h: m_capabilities)
+        for (auto const& h : m_capabilities)
             h.second->onStopping();
 
         // disconnect pending handshake, before peers, as a handshake may create a peer
         for (unsigned n = 0;; n = 0)
         {
             DEV_GUARDED(x_connecting)
-                for (auto const& i: m_connecting)
+                for (auto const& i : m_connecting)
                     if (auto h = i.lock())
                     {
                         h->cancel();
@@ -179,12 +177,12 @@ void Host::doneWorking()
                 break;
             m_ioService.poll();
         }
-        
+
         // disconnect peers
         for (unsigned n = 0;; n = 0)
         {
             DEV_RECURSIVE_GUARDED(x_sessions)
-                for (auto i: m_sessions)
+                for (auto i : m_sessions)
                     if (auto p = i.second.lock())
                         if (p->isConnected())
                         {
@@ -785,7 +783,7 @@ void Host::startedWorking()
 
     if (m_capabilities.size())
     {
-        LOG(m_logger) << "p2p.started id: " << id();
+        LOG(m_logger) << "Capabilities detected, p2p started";
         run(boost::system::error_code());
     }
     else

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -796,7 +796,7 @@ void Host::startedWorking()
                            bi::address::from_string(m_netConfig.listenIPAddress) :
                            bi::address_v4(),
             m_netConfig.listenPort /* UDP */, m_netConfig.listenPort /* TCP */),
-        m_netConfig.discovery);
+        m_netConfig.discovery, m_netConfig.allowLocalDiscovery);
 
     if (m_capabilities.size())
         // Don't need to set event handler since there are no peers for Host to update when p2p

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -734,15 +734,9 @@ void Host::startedWorking()
     // initialization (e.g. start capability threads, start TCP listener, and kick off timers)
     asserts(!m_timer);
 
-    {
-        // prevent m_run from being set to true at same time as set to false by stop()
-        // don't release mutex until m_timer is set so in case stop() is called at same
-        // time, stop will wait on m_timer and graceful network shutdown.
-        Guard l(x_runTimer);
-        // create deadline timer
-        m_timer.reset(new io::deadline_timer(m_ioService));
-        m_run = true;
-    }
+    // create deadline timer
+    m_timer.reset(new io::deadline_timer(m_ioService));
+    m_run = true;
 
     if (m_capabilities.size())
     {

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -778,13 +778,14 @@ void Host::startedWorking()
                           << " TCP Listen port is invalid or unavailable.";
     }
 
-    auto nodeTable = make_shared<NodeTable>(
-        m_ioService,
-        m_alias,
-        NodeIPEndpoint(bi::address::from_string(listenAddress()), listenPort(), listenPort()),
-        m_netConfig.discovery,
-        m_netConfig.allowLocalDiscovery
-    );
+    auto nodeTable = make_shared<NodeTable>(m_ioService, m_alias,
+        // Use data from network configuration rather than Host's settings because p2p might not
+        // have been started
+        NodeIPEndpoint(!m_netConfig.listenIPAddress.empty() ?
+                           bi::address::from_string(m_netConfig.listenIPAddress) :
+                           bi::address_v4(),
+            m_netConfig.listenPort /* UDP */, m_netConfig.listenPort /* TCP */),
+        m_netConfig.discovery);
     nodeTable->setEventHandler(new HostNodeTableHandler(*this));
     DEV_GUARDED(x_nodeTable)
         m_nodeTable = nodeTable;

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -111,9 +111,11 @@ void Host::start()
     while (isWorking() && !haveNetwork())
         this_thread::sleep_for(chrono::milliseconds(10));
     
-    // network start failed!
     if (isWorking())
+    {
+        cout << "Node ID: " << enode() << endl;
         return;
+    }
 
     cwarn << "Network start failed!";
     doneWorking();

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -102,7 +102,6 @@ struct NodeInfo
  * @brief The Host class
  * Capabilities should be registered prior to startNetwork, since m_capabilities is not thread-safe.
  *
- * @todo determinePublic: ipv6, udp
  * @todo per-session keepalive/ping instead of broadcast; set ping-timeout via median-latency
  */
 class Host: public Worker
@@ -268,9 +267,6 @@ private:
     unsigned peerSlots(PeerSlotType _type) { return _type == Egress ? m_idealPeerCount : m_idealPeerCount * m_stretchPeers; }
     
     bool havePeerSession(NodeID const& _id) { return !!peerSession(_id); }
-
-    /// Determines and sets m_tcpPublic to publicly advertised address.
-    void determinePublic();
 
     void connect(std::shared_ptr<Peer> const& _p);
 

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -203,7 +203,7 @@ public:
     ReputationManager& repMan() { return m_repMan; }
 
     /// @returns if network is started and interactive.
-    bool haveNetwork() const { Guard l(x_runTimer); Guard ll(x_nodeTable); return m_run && !!m_nodeTable; }
+    bool haveNetwork() const { Guard ll(x_nodeTable); return m_run && !!m_nodeTable; }
     
     /// Validates and starts peer session, taking ownership of _io. Disconnects and returns false upon error.
     void startPeerSession(Public const& _id, RLP const& _hello, std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
@@ -310,7 +310,6 @@ private:
     bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.
 
     std::unique_ptr<io::deadline_timer> m_timer;					///< Timer which, when network is running, calls run() every c_timerInterval ms.
-    mutable std::mutex x_runTimer;	///< Start/stop mutex.
     static constexpr unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
 
     std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -174,10 +174,31 @@ public:
     size_t peerCount() const;
 
     /// Get the address we're listening on currently.
-    std::string listenAddress() const { return m_tcpPublic.address().is_unspecified() ? "0.0.0.0" : m_tcpPublic.address().to_string(); }
+    std::string listenAddress() const
+    {
+        if (!m_capabilities.empty())
+        {
+            return m_tcpPublic.address().is_unspecified() ? "0.0.0.0" :
+                                                            m_tcpPublic.address().to_string();
+        }
+        else
+        {
+            return m_nodeTable->listenAddress();
+        }
+    }
 
     /// Get the port we're listening on currently.
-    unsigned short listenPort() const { return std::max(0, m_listenPort.load()); }
+    unsigned short listenPort() const
+    {
+        if (!m_capabilities.empty())
+        {
+            return std::max(0, m_listenPort.load());
+        }
+        else
+        {
+            return m_nodeTable->listenPort();
+        }
+    }
 
     /// Serialise the set of known peers.
     bytes saveNetwork() const;

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -312,7 +312,6 @@ private:
     std::unique_ptr<io::deadline_timer> m_timer;					///< Timer which, when network is running, calls run() every c_timerInterval ms.
     mutable std::mutex x_runTimer;	///< Start/stop mutex.
     static constexpr unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
-    std::condition_variable m_timerReset;
 
     std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).
 

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -99,6 +99,10 @@ public:
 
 	/// Resolve "host:port" string as TCP endpoint. Returns unspecified endpoint on failure.
 	static bi::tcp::endpoint resolveHost(std::string const& _host);
+
+    /// Determine public address and port to listen on
+    /// @todo: ipv6, udp
+    static NodeIPEndpoint determinePublic(NetworkConfig const& _netConfig, unsigned short _listenPort);
 };
 
 }

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -1,24 +1,19 @@
 /*
-	This file is part of cpp-ethereum.
+	This file is part of aleth.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
+	aleth is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
 
-	cpp-ethereum is distributed in the hope that it will be useful,
+	aleth is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+	along with aleth.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file Network.h
- * @author Alex Leverington <nessence@gmail.com>
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
 
 #pragma once
 
@@ -37,7 +32,7 @@ namespace dev
 namespace p2p
 {
 
-static const unsigned short c_defaultListenPort = 30303;
+static constexpr unsigned short c_defaultListenPort = 30303;
 
 struct NetworkConfig
 {

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -49,10 +49,10 @@ NodeEntry::NodeEntry(NodeID const& _src, Public const& _pubk, NodeIPEndpoint con
 NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint,
     bool _enabled, bool _allowLocalDiscovery)
   : m_hostNodeID(_alias.pub()),
-    m_hostNodeEndpoint(_endpoint),
+    m_nodeEndpoint(_endpoint),
     m_secret(_alias.secret()),
     m_socket(make_shared<NodeSocket>(
-        _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)m_hostNodeEndpoint)),
+        _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)m_nodeEndpoint)),
     m_requestTimeToLive(DiscoveryDatagram::c_timeToLive),        
     m_allowLocalDiscovery(_allowLocalDiscovery),
     m_timers(_io)
@@ -301,7 +301,7 @@ void NodeTable::ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const&
             return;
 
         NodeIPEndpoint src;
-        src = m_hostNodeEndpoint;
+        src = m_nodeEndpoint;
         PingNode p(src, _nodeEntry.endpoint);
         p.ts = nextRequestExpirationTime();
         auto const pingHash = p.sign(m_secret);
@@ -458,10 +458,10 @@ void NodeTable::onPacketReceived(
                 // update our endpoint address and UDP port
                 DEV_GUARDED(x_nodes)
                 {
-                    if ((!m_hostNodeEndpoint || !isAllowedEndpoint(m_hostNodeEndpoint)) &&
+                    if ((!m_nodeEndpoint || !isAllowedEndpoint(m_nodeEndpoint)) &&
                         isPublicAddress(pong.destination.address()))
-                        m_hostNodeEndpoint.setAddress(pong.destination.address());
-                    m_hostNodeEndpoint.setUdpPort(pong.destination.udpPort());
+                        m_nodeEndpoint.setAddress(pong.destination.address());
+                    m_nodeEndpoint.setUdpPort(pong.destination.udpPort());
                 }
                 break;
             }

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -140,6 +140,10 @@ public:
     /// Returns distance based on xor metric two node ids. Used by NodeEntry and NodeTable.
     static int distance(NodeID const& _a, NodeID const& _b) { u256 d = sha3(_a) ^ sha3(_b); unsigned ret; for (ret = 0; d >>= 1; ++ret) {}; return ret; }
 
+    std::string listenAddress() const { return m_nodeEndpoint.address().to_string(); }
+
+    unsigned short listenPort() const { return m_nodeEndpoint.udpPort(); }
+
     /// Set event handler for NodeEntryAdded and NodeEntryDropped events.
     void setEventHandler(NodeTableEventHandler* _handler) { m_nodeEventHandler.reset(_handler); }
 
@@ -269,7 +273,9 @@ protected:
     std::unique_ptr<NodeTableEventHandler> m_nodeEventHandler;		///< Event handler for node events.
 
     NodeID const m_hostNodeID;
-    NodeIPEndpoint m_hostNodeEndpoint;
+
+    /// Host's endpoint if p2p is started, otherwise an endpoint specific to the NodeTable
+    NodeIPEndpoint m_nodeEndpoint;
     Secret m_secret;												///< This nodes secret key.
 
     mutable Mutex x_nodes;											///< LOCK x_state first if both locks are required. Mutable for thread-safe copy in nodes() const.
@@ -322,8 +328,8 @@ struct NodeEntry : public Node
 inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable)
 {
     _out << _nodeTable.m_hostNodeID << "\t"
-         << "0\t" << _nodeTable.m_hostNodeEndpoint.address() << ":"
-         << _nodeTable.m_hostNodeEndpoint.udpPort() << std::endl;
+         << "0\t" << _nodeTable.m_nodeEndpoint.address() << ":"
+         << _nodeTable.m_nodeEndpoint.udpPort() << std::endl;
     auto s = _nodeTable.snapshot();
     for (auto n: s)
         _out << n.address() << "\t" << n.distance << "\t" << n.endpoint.address() << ":"

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -169,7 +169,7 @@ struct TestNodeTable: public NodeTable
     using NodeTable::m_allNodes;
     using NodeTable::m_buckets;
     using NodeTable::m_hostNodeID;
-    using NodeTable::m_hostNodeEndpoint;
+    using NodeTable::m_nodeEndpoint;
     using NodeTable::m_sentPings;
     using NodeTable::m_socket;
     using NodeTable::noteActiveNode;
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(unexpectedPong)
     nodeTableHost.start();
     auto& nodeTable = nodeTableHost.nodeTable;
 
-    Pong pong(nodeTable->m_hostNodeEndpoint);
+    Pong pong(nodeTable->m_nodeEndpoint);
     auto nodeKeyPair = KeyPair::create();
     pong.sign(nodeKeyPair.secret());
 
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE(invalidPong)
     nodeTable->addNode(Node{nodePubKey, nodeEndpoint});
 
     // send PONG
-    Pong pong(nodeTable->m_hostNodeEndpoint);
+    Pong pong(nodeTable->m_nodeEndpoint);
     pong.sign(nodeKeyPair.secret());
 
     nodeSocketHost.socket->send(pong);
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(validPong)
     auto ping = dynamic_cast<PingNode const&>(*pingDatagram);
 
     // send PONG
-    Pong pong(nodeTable->m_hostNodeEndpoint);
+    Pong pong(nodeTable->m_nodeEndpoint);
     pong.echo = ping.echo;
     pong.sign(nodeKeyPair.secret());
     nodeSocketHost.socket->send(pong);
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE(pingTimeout)
     auto ping = dynamic_cast<PingNode const&>(*pingDatagram);
 
     // send PONG after timeout
-    Pong pong(nodeTable->m_hostNodeEndpoint);
+    Pong pong(nodeTable->m_nodeEndpoint);
     pong.echo = ping.echo;
     pong.sign(nodeKeyPair.secret());
     nodeSocketHost.socket->send(pong);
@@ -735,7 +735,7 @@ BOOST_AUTO_TEST_CASE(evictionWithOldNodeAnswering)
     auto ping = dynamic_cast<PingNode const&>(*pingDatagram);
 
     // send valid PONG
-    Pong pong(nodeTable->m_hostNodeEndpoint);
+    Pong pong(nodeTable->m_nodeEndpoint);
     pong.echo = ping.echo;
     pong.sign(nodeKeyPair.secret());
     nodeSocketHost.socket->send(pong);
@@ -828,13 +828,13 @@ BOOST_AUTO_TEST_CASE(findNodeIsSentAfterPong)
     nodeTableHost1.start();
     auto& nodeTable1 = nodeTableHost1.nodeTable;
 
-    TestNodeTableHost nodeTableHost2(512, nodeTable1->m_hostNodeEndpoint.udpPort() + 1);
+    TestNodeTableHost nodeTableHost2(512, nodeTable1->m_nodeEndpoint.udpPort() + 1);
     nodeTableHost2.populate();
     nodeTableHost2.start();
     auto& nodeTable2 = nodeTableHost2.nodeTable;
 
     // add node1 to table2 initiating PING from table2 to table1
-    nodeTable2->addNode(Node{nodeTable1->m_hostNodeID, nodeTable1->m_hostNodeEndpoint});
+    nodeTable2->addNode(Node{nodeTable1->m_hostNodeID, nodeTable1->m_nodeEndpoint});
 
     auto packetReceived1 = nodeTable2->packetsReceived.pop();
     auto datagram1 =

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -56,6 +56,8 @@ BOOST_FIXTURE_TEST_SUITE(p2p, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
+    // Need to supply 0 for port when creating more than 1 host to get random listen port,
+    // otherwise NodeTable won't receive packets
     Host host1("Test", NetworkConfig("127.0.0.1", 0 /* listen port */, false /* upnp */,
                            true /* allow local discovery */));
     host1.registerCapability(make_shared<TestCap>());
@@ -130,6 +132,8 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 
     for (unsigned i = 0; i < c_nodes; ++i)
     {
+        // Need to supply 0 for port when creating more than 1 host to get random listen port,
+        // otherwise NodeTable won't receive packets
         Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0 /* listen port */, false /* upnp */,
                                        true /* allow local discovery */));
         h->registerCapability(make_shared<TestCap>());

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -56,20 +56,21 @@ BOOST_FIXTURE_TEST_SUITE(p2p, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
-    Host host1("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+    Host host1("Test", NetworkConfig("127.0.0.1", 0 /* listen port */, false /* upnp */,
+                           true /* allow local discovery */));
+    host1.registerCapability(make_shared<TestCap>());
     host1.start();
     auto host1port = host1.listenPort();
     BOOST_REQUIRE(host1port);
 
-    Host host2("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+    Host host2("Test", NetworkConfig("127.0.0.1", 0 /* listen port */, false /* upnp */,
+                           true /* allow local discovery */));
+    host2.registerCapability(make_shared<TestCap>());
     host2.start();
     auto host2port = host2.listenPort();
     BOOST_REQUIRE(host2port);
     
     BOOST_REQUIRE_NE(host1port, host2port);
-
-    host1.registerCapability(make_shared<TestCap>());
-    host2.registerCapability(make_shared<TestCap>());
 
     auto node2 = host2.id();
     int const step = 10;
@@ -129,8 +130,10 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 
     for (unsigned i = 0; i < c_nodes; ++i)
     {
-        Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
-        h->setIdealPeerCount(10);		
+        Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0 /* listen port */, false /* upnp */,
+                                       true /* allow local discovery */));
+        h->registerCapability(make_shared<TestCap>());
+        h->setIdealPeerCount(10);
         h->start(); // starting host is required so listenport is available
         while (!h->haveNetwork())
             this_thread::sleep_for(chrono::milliseconds(c_step));
@@ -138,7 +141,6 @@ BOOST_AUTO_TEST_CASE(saveNodes)
         BOOST_REQUIRE(h->listenPort());
         bool inserted = ports.insert(h->listenPort()).second;
         BOOST_REQUIRE(inserted);
-        h->registerCapability(make_shared<TestCap>());
         hosts.push_back(h);
     }
     
@@ -187,11 +189,15 @@ BOOST_AUTO_TEST_CASE(requirePeer)
 {
     unsigned const step = 10;
     const char* const localhost = "127.0.0.1";
-    NetworkConfig prefs1(localhost, 0, false /* upnp */, true /* allow local discovery */);
-    NetworkConfig prefs2(localhost, 0, false /* upnp */, true /* allow local discovery */);
+    NetworkConfig prefs1(
+        localhost, 0 /* listen port */, false /* upnp */, true /* allow local discovery */);
+    NetworkConfig prefs2(
+        localhost, 0 /* listen port */, false /* upnp */, true /* allow local discovery */);
     Host host1("Test", prefs1);
-    Host host2("Test", prefs2);
+    host1.registerCapability(make_shared<TestCap>());
     host1.start();
+    Host host2("Test", prefs2);
+    host2.registerCapability(make_shared<TestCap>());
     host2.start();
     auto node2 = host2.id();
     auto port1 = host1.listenPort();
@@ -199,9 +205,6 @@ BOOST_AUTO_TEST_CASE(requirePeer)
     BOOST_REQUIRE(port1);
     BOOST_REQUIRE(port2);
     BOOST_REQUIRE_NE(port1, port2);
-
-    host1.registerCapability(make_shared<TestCap>());
-    host2.registerCapability(make_shared<TestCap>());
 
     host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
 


### PR DESCRIPTION
Address item 1 in #5391 and fix #5388 

Only start p2p functionality if capabilities have been registered for the host. Otherwise, only start discovery. This will prevent a TCP listener from being opened when running `aleth-bootnode` (which only needs to open a UDP listener since it only needs to run discovery)