### PR TITLE
Prevent a host from adding itself to its own node table

### DIFF
--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -110,6 +110,12 @@ void NodeTable::addNode(Node const& _node, NodeRelation _relation)
             return;
     }
 
+    if (m_hostNodeID == _node.id)
+    {
+        LOG(m_logger) << "Skip adding self to node table (" << _node.id << ")";
+        return;
+    }
+
     auto nodeEntry = make_shared<NodeEntry>(m_hostNodeID, _node.id, _node.endpoint);
     DEV_GUARDED(x_nodes) { m_allNodes[_node.id] = nodeEntry; }
     LOG(m_logger) << "Pending node " << _node.id << "@" << _node.endpoint;

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -733,6 +733,23 @@ BOOST_AUTO_TEST_CASE(evictionWithOldNodeDropped)
     BOOST_CHECK(nodes.back().lock()->id == newNodeId);
 }
 
+BOOST_AUTO_TEST_CASE(addSelf)
+{
+    TestNodeTableHost nodeTableHost(512);
+    auto& nodeTable = nodeTableHost.nodeTable;
+    
+    TestUDPSocketHost nodeSocketHost{ 30500 };
+    auto nodePort = nodeSocketHost.port;
+
+    auto nodeEndpoint = NodeIPEndpoint{ bi::address::from_string("127.0.0.1"), nodePort, nodePort };
+
+    Node self(nodeTableHost.m_alias.pub(), nodeEndpoint);
+    auto beforeNodeCount = nodeTable->count();
+    nodeTable->addNode(self);
+    auto afterNodeCount = nodeTable->count();
+    BOOST_CHECK(beforeNodeCount == afterNodeCount);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(netTypes, TestOutputHelperFixture)

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -738,16 +738,23 @@ BOOST_AUTO_TEST_CASE(addSelf)
     TestNodeTableHost nodeTableHost(512);
     auto& nodeTable = nodeTableHost.nodeTable;
     
+    size_t expectedNodeCount = 0;
+    BOOST_REQUIRE(nodeTable->count() == expectedNodeCount);
+    
     TestUDPSocketHost nodeSocketHost{ 30500 };
     auto nodePort = nodeSocketHost.port;
-
     auto nodeEndpoint = NodeIPEndpoint{ bi::address::from_string("127.0.0.1"), nodePort, nodePort };
 
+    // Create arbitrary node and verify it can be added to the node table
+    auto nodeKeyPair = KeyPair::create();
+    Node node(nodeKeyPair.pub(), nodeEndpoint);
+    nodeTable->addNode(node);
+    BOOST_CHECK(nodeTable->count() == ++expectedNodeCount);
+    
+    // Create self node and verify it isn't added to the node table
     Node self(nodeTableHost.m_alias.pub(), nodeEndpoint);
-    auto beforeNodeCount = nodeTable->count();
     nodeTable->addNode(self);
-    auto afterNodeCount = nodeTable->count();
-    BOOST_CHECK(beforeNodeCount == afterNodeCount);
+    BOOST_CHECK(nodeTable->count() == ++expectedNodeCount - 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fix #5401 

An Aleth host can add itself to its own node table when it receives itself in a neighbors node list from another node. My changes check for this condition in `NodeTable::addNode` and skip adding the node to the node table if its ID is the same as the host's ID. I've also added a unit test which validates this new behavior.



