### PR TITLE
Allow less strict account in genesis config

### DIFF
--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -130,8 +130,7 @@ void validateAccountObj(js::mObject const& _obj)
                 {c_codeFromFile, {{js::str_type}, JsonFieldPresence::Optional}}});
 
         // At least one field must be set
-        if (!_obj.count(c_code) && !_obj.count(c_nonce) && !_obj.count(c_storage) &&
-            !_obj.count(c_balance) && !_obj.count(c_wei) && !_obj.count(c_codeFromFile))
+        if (_obj.empty())
         {
             string comment =
                 "Error in validateAccountObj: At least one field must be set (code, nonce, "

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -118,36 +118,41 @@ void validateAccountObj(js::mObject const& _obj)
                 {c_wei, {{js::str_type}, JsonFieldPresence::Optional}},
                 {c_balance, {{js::str_type}, JsonFieldPresence::Optional}}});
     }
-    else if (_obj.size() == 1)
-    {
-        // A genesis account with only balance set
-        if (_obj.count(c_balance))
-            requireJsonFields(_obj, "validateAccountObj",
-                {{c_balance, {{js::str_type}, JsonFieldPresence::Required}}});
-        else
-            requireJsonFields(_obj, "validateAccountObj",
-                {{c_wei, {{js::str_type}, JsonFieldPresence::Required}}});
-    }
     else
     {
-        if (_obj.count(c_codeFromFile))
+        // Extendable account description. Check typo errors and fields type.
+        requireJsonFields(_obj, "validateAccountObj",
+            {{c_code, {{js::str_type}, JsonFieldPresence::Optional}},
+                {c_nonce, {{js::str_type}, JsonFieldPresence::Optional}},
+                {c_storage, {{js::obj_type}, JsonFieldPresence::Optional}},
+                {c_balance, {{js::str_type}, JsonFieldPresence::Optional}},
+                {c_wei, {{js::str_type}, JsonFieldPresence::Optional}},
+                {c_codeFromFile, {{js::str_type}, JsonFieldPresence::Optional}}});
+
+        // At least one field must be set
+        if (!_obj.count(c_code) && !_obj.count(c_nonce) && !_obj.count(c_storage) &&
+            !_obj.count(c_balance) && !_obj.count(c_wei) && !_obj.count(c_codeFromFile))
         {
-            // A standart account with external code
-            requireJsonFields(_obj, "validateAccountObj",
-                {{c_codeFromFile, {{js::str_type}, JsonFieldPresence::Required}},
-                    {c_nonce, {{js::str_type}, JsonFieldPresence::Required}},
-                    {c_storage, {{js::obj_type}, JsonFieldPresence::Required}},
-                    {c_balance, {{js::str_type}, JsonFieldPresence::Required}}});
+            string comment =
+                "Error in validateAccountObj: At least one field must be set (code, nonce, "
+                "storage, balance, wei, codeFromFile)!";
+            BOOST_THROW_EXCEPTION(MissingField() << errinfo_comment(comment));
         }
-        else
+
+        // c_code, c_codeFromFile could not coexist
+        if (_obj.count(c_code) && _obj.count(c_codeFromFile))
         {
-            // A standart account with all fields
-            requireJsonFields(_obj, "validateAccountObj",
-                {{c_code, {{js::str_type}, JsonFieldPresence::Required}},
-                    {c_nonce, {{js::str_type}, JsonFieldPresence::Required}},
-                    {c_storage, {{js::obj_type}, JsonFieldPresence::Required}},
-                    {c_balance, {{js::str_type}, JsonFieldPresence::Required}}});
+            string comment =
+                "Error in validateAccountObj: field 'code' contradicts field 'codeFromFile'!";
+            BOOST_THROW_EXCEPTION(UnknownField() << errinfo_comment(comment));
         }
+    }
+
+    // c_wei, c_balance could not coexist
+    if (_obj.count(c_wei) && _obj.count(c_balance))
+    {
+        string comment = "Error in validateAccountObj: field 'balance' contradicts field 'wei'!";
+        BOOST_THROW_EXCEPTION(UnknownField() << errinfo_comment(comment));
     }
 }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(unittest_sources
     unittests/libweb3core/statecachedb.cpp
 
     unittests/libweb3jsonrpc/AccountHolder.cpp
+    unittests/libethereum/ValidationSchemes.cpp
 )
 
 add_executable(aleth-unittests ${unittest_sources})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(unittest_sources
 )
 
 add_executable(aleth-unittests ${unittest_sources})
+target_include_directories(aleth-unittests PRIVATE ${UTILS_INCLUDE_DIR})
 target_link_libraries(aleth-unittests PRIVATE
     web3jsonrpc ethashseal devcrypto devcore
     GTest::gtest GTest::main

--- a/test/unittests/libethereum/ValidationSchemes.cpp
+++ b/test/unittests/libethereum/ValidationSchemes.cpp
@@ -1,0 +1,216 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file ValidationSchemes.cpp
+ * @author Dimitry Khokhlov <dimitry@ethereum.org>
+ * @date 2019
+ * Validation scheme unit tests.
+ */
+
+#include <libethereum/ValidationSchemes.h>
+#include <test/tools/libtesteth/JsonSpiritHeaders.h>
+#include <test/tools/libtesteth/TestHelper.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+using namespace dev::test;
+namespace js = json_spirit;
+
+BOOST_FIXTURE_TEST_SUITE(ValidationSchemes, TestOutputHelperFixture)
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_incomplete)
+{
+    js::mValue val;
+    string s = R"({
+        "balance": "1234",
+        "nonce": "34"
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_incomplete_wrongfield)
+{
+    js::mValue val;
+    string s = R"({
+        "balance": "1234",
+        "nonce": "34",
+        "wrong": "2345"
+    })";
+    js::read_string(s, val);
+    auto is_critical = [](std::exception const& _e) {
+        return string(_e.what()).find("Unexpected") != string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_balance_wrongtype)
+{
+    js::mValue val;
+    string s = R"({
+        "balance": 1234
+    })";
+    js::read_string(s, val);
+    auto is_critical = [](std::exception const& _e) {
+        return string(_e.what()).find("expected") != string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(
+        validation::validateAccountObj(val.get_obj()), WrongFieldType, is_critical);
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_balance)
+{
+    js::mValue val;
+    string s = R"({
+        "balance": "1234"
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_balancewei)
+{
+    js::mValue val;
+    string s = R"({
+        "balance": "1234",
+        "wei": "1235"
+    })";
+    js::read_string(s, val);
+    auto is_critical = [](std::exception const& _e) {
+        return string(_e.what()).find("contradicts") != string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_nonce)
+{
+    js::mValue val;
+    string s = R"({
+        "nonce": "1234"
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_code)
+{
+    js::mValue val;
+    string s = R"({
+        "code": "0x1234"
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_codeFromFile)
+{
+    js::mValue val;
+    string s = R"({
+        "codeFromFile": "0x1234"
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_codeFromFileAndCode)
+{
+    js::mValue val;
+    string s = R"({
+        "code": "0x1234",
+        "codeFromFile": "0x1235"
+    })";
+    js::read_string(s, val);
+    auto is_critical = [](std::exception const& _e) {
+        return string(_e.what()).find("contradicts") != string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+}
+
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_just_storage)
+{
+    js::mValue val;
+    string s = R"({
+        "storage": {}
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled)
+{
+    js::mValue val;
+    string s = R"({
+        "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } }
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_wei)
+{
+    js::mValue val;
+    string s = R"({
+        "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } },
+        "wei" : "123456"
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_balance)
+{
+    js::mValue val;
+    string s = R"({
+        "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } },
+        "balance" : "123456"
+    })";
+    js::read_string(s, val);
+    validation::validateAccountObj(val.get_obj());
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_weibalance)
+{
+    js::mValue val;
+    string s = R"({
+        "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } },
+        "wei" : "123456",
+        "balance" : "321345"
+    })";
+    js::read_string(s, val);
+    auto is_critical = [](std::exception const& _e) {
+        return string(_e.what()).find("contradicts") != string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+}
+
+BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_wrongfield)
+{
+    js::mValue val;
+    string s = R"({
+        "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } },
+        "transition" : "123456"
+    })";
+    js::read_string(s, val);
+    auto is_critical = [](std::exception const& _e) {
+        return string(_e.what()).find("Unexpected") != string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethereum/ValidationSchemes.cpp
+++ b/test/unittests/libethereum/ValidationSchemes.cpp
@@ -1,38 +1,20 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file ValidationSchemes.cpp
- * @author Dimitry Khokhlov <dimitry@ethereum.org>
- * @date 2019
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2018 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+/**
  * Validation scheme unit tests.
  */
 
+#include <gtest/gtest.h>
+#include <libdevcore/Exceptions.h>
 #include <libethereum/ValidationSchemes.h>
-#include <test/tools/libtesteth/JsonSpiritHeaders.h>
-#include <test/tools/libtesteth/TestHelper.h>
 
 using namespace std;
 using namespace dev;
 using namespace dev::eth;
-using namespace dev::test;
 namespace js = json_spirit;
 
-BOOST_FIXTURE_TEST_SUITE(ValidationSchemes, TestOutputHelperFixture)
-
-BOOST_AUTO_TEST_CASE(validateAccountObj_incomplete)
+TEST(validation, validateAccountObj_incomplete)
 {
     js::mValue val;
     string s = R"({
@@ -43,8 +25,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_incomplete)
     validation::validateAccountObj(val.get_obj());
 }
 
-
-BOOST_AUTO_TEST_CASE(validateAccountObj_incomplete_wrongfield)
+TEST(validation, validateAccountObj_incomplete_wrongfield)
 {
     js::mValue val;
     string s = R"({
@@ -53,27 +34,20 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_incomplete_wrongfield)
         "wrong": "2345"
     })";
     js::read_string(s, val);
-    auto is_critical = [](std::exception const& _e) {
-        return string(_e.what()).find("Unexpected") != string::npos;
-    };
-    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+    EXPECT_THROW(validation::validateAccountObj(val.get_obj()), UnknownField);
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_balance_wrongtype)
+TEST(validation, validateAccountObj_just_balance_wrongtype)
 {
     js::mValue val;
     string s = R"({
         "balance": 1234
     })";
     js::read_string(s, val);
-    auto is_critical = [](std::exception const& _e) {
-        return string(_e.what()).find("expected") != string::npos;
-    };
-    BOOST_CHECK_EXCEPTION(
-        validation::validateAccountObj(val.get_obj()), WrongFieldType, is_critical);
+    EXPECT_THROW(validation::validateAccountObj(val.get_obj()), WrongFieldType);
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_balance)
+TEST(validation, validateAccountObj_just_balance)
 {
     js::mValue val;
     string s = R"({
@@ -83,7 +57,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_just_balance)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_balancewei)
+TEST(validation, validateAccountObj_just_balancewei)
 {
     js::mValue val;
     string s = R"({
@@ -91,13 +65,10 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_just_balancewei)
         "wei": "1235"
     })";
     js::read_string(s, val);
-    auto is_critical = [](std::exception const& _e) {
-        return string(_e.what()).find("contradicts") != string::npos;
-    };
-    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+    EXPECT_THROW(validation::validateAccountObj(val.get_obj()), UnknownField);
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_nonce)
+TEST(validation, validateAccountObj_just_nonce)
 {
     js::mValue val;
     string s = R"({
@@ -107,7 +78,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_just_nonce)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_code)
+TEST(validation, validateAccountObj_just_code)
 {
     js::mValue val;
     string s = R"({
@@ -117,7 +88,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_just_code)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_codeFromFile)
+TEST(validation, validateAccountObj_just_codeFromFile)
 {
     js::mValue val;
     string s = R"({
@@ -127,7 +98,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_just_codeFromFile)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_codeFromFileAndCode)
+TEST(validation, validateAccountObj_just_codeFromFileAndCode)
 {
     js::mValue val;
     string s = R"({
@@ -135,14 +106,11 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_just_codeFromFileAndCode)
         "codeFromFile": "0x1235"
     })";
     js::read_string(s, val);
-    auto is_critical = [](std::exception const& _e) {
-        return string(_e.what()).find("contradicts") != string::npos;
-    };
-    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+    EXPECT_THROW(validation::validateAccountObj(val.get_obj()), UnknownField);
 }
 
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_just_storage)
+TEST(validation, validateAccountObj_just_storage)
 {
     js::mValue val;
     string s = R"({
@@ -152,7 +120,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_just_storage)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled)
+TEST(validation, validateAccountObj_precompiled)
 {
     js::mValue val;
     string s = R"({
@@ -162,7 +130,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_wei)
+TEST(validation, validateAccountObj_precompiled_wei)
 {
     js::mValue val;
     string s = R"({
@@ -173,7 +141,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_wei)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_balance)
+TEST(validation, validateAccountObj_precompiled_balance)
 {
     js::mValue val;
     string s = R"({
@@ -184,7 +152,7 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_balance)
     validation::validateAccountObj(val.get_obj());
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_weibalance)
+TEST(validation, validateAccountObj_precompiled_weibalance)
 {
     js::mValue val;
     string s = R"({
@@ -193,13 +161,10 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_weibalance)
         "balance" : "321345"
     })";
     js::read_string(s, val);
-    auto is_critical = [](std::exception const& _e) {
-        return string(_e.what()).find("contradicts") != string::npos;
-    };
-    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+    EXPECT_THROW(validation::validateAccountObj(val.get_obj()), UnknownField);
 }
 
-BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_wrongfield)
+TEST(validation, validateAccountObj_precompiled_wrongfield)
 {
     js::mValue val;
     string s = R"({
@@ -207,10 +172,6 @@ BOOST_AUTO_TEST_CASE(validateAccountObj_precompiled_wrongfield)
         "transition" : "123456"
     })";
     js::read_string(s, val);
-    auto is_critical = [](std::exception const& _e) {
-        return string(_e.what()).find("Unexpected") != string::npos;
-    };
-    BOOST_CHECK_EXCEPTION(validation::validateAccountObj(val.get_obj()), UnknownField, is_critical);
+    EXPECT_THROW(validation::validateAccountObj(val.get_obj()), UnknownField);
 }
 
-BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
https://github.com/ethereum/aleth/issues/5414

This also applies for tests (same code check accounts in tests). which is not really good as in tests account description is strict (4 fields only). but for tests we have a second scheme validation at python scripts in test repo. 