### PR TITLE
Remove network start/stop RPC methods

### DIFF
--- a/libweb3jsonrpc/AdminNet.cpp
+++ b/libweb3jsonrpc/AdminNet.cpp
@@ -12,20 +12,6 @@ using namespace dev::rpc;
 
 AdminNet::AdminNet(NetworkFace& _network, SessionManager& _sm): m_network(_network), m_sm(_sm) {}
 
-bool AdminNet::admin_net_start(std::string const& _session)
-{
-	RPC_ADMIN;
-	m_network.startNetwork();
-	return true;
-}
-
-bool AdminNet::admin_net_stop(std::string const& _session)
-{
-	RPC_ADMIN;
-	m_network.stopNetwork();
-	return true;
-}
-
 bool AdminNet::admin_net_connect(std::string const& _node, std::string const& _session)
 {
 	RPC_ADMIN;

--- a/libweb3jsonrpc/AdminNet.h
+++ b/libweb3jsonrpc/AdminNet.h
@@ -19,8 +19,6 @@ public:
 	{
 		return RPCModules{RPCModule{"admin", "1.0"}};
 	}
-	virtual bool admin_net_start(std::string const& _session) override;
-	virtual bool admin_net_stop(std::string const& _session) override;
 	virtual bool admin_net_connect(std::string const& _node, std::string const& _session) override;
 	virtual Json::Value admin_net_peers(std::string const& _session) override;
 	virtual Json::Value admin_net_nodeInfo(std::string const& _session) override;

--- a/libweb3jsonrpc/AdminNetFace.h
+++ b/libweb3jsonrpc/AdminNetFace.h
@@ -14,8 +14,6 @@ namespace dev {
             public:
                 AdminNetFace()
                 {
-                    this->bindAndAddMethod(jsonrpc::Procedure("admin_net_start", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminNetFace::admin_net_startI);
-                    this->bindAndAddMethod(jsonrpc::Procedure("admin_net_stop", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminNetFace::admin_net_stopI);
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_net_connect", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminNetFace::admin_net_connectI);
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_net_peers", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminNetFace::admin_net_peersI);
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_net_nodeInfo", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminNetFace::admin_net_nodeInfoI);
@@ -24,14 +22,6 @@ namespace dev {
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_addPeer", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminNetFace::admin_addPeerI);
                 }
 
-                inline virtual void admin_net_startI(const Json::Value &request, Json::Value &response)
-                {
-                    response = this->admin_net_start(request[0u].asString());
-                }
-                inline virtual void admin_net_stopI(const Json::Value &request, Json::Value &response)
-                {
-                    response = this->admin_net_stop(request[0u].asString());
-                }
                 inline virtual void admin_net_connectI(const Json::Value &request, Json::Value &response)
                 {
                     response = this->admin_net_connect(request[0u].asString(), request[1u].asString());
@@ -58,8 +48,6 @@ namespace dev {
                 {
                     response = this->admin_addPeer(request[0u].asString());
                 }
-                virtual bool admin_net_start(const std::string& param1) = 0;
-                virtual bool admin_net_stop(const std::string& param1) = 0;
                 virtual bool admin_net_connect(const std::string& param1, const std::string& param2) = 0;
                 virtual Json::Value admin_net_peers(const std::string& param1) = 0;
                 virtual Json::Value admin_net_nodeInfo(const std::string& param1) = 0;

--- a/libweb3jsonrpc/admin_net.json
+++ b/libweb3jsonrpc/admin_net.json
@@ -1,6 +1,4 @@
 [
-{ "name": "admin_net_start", "params": [""], "returns": true },
-{ "name": "admin_net_stop", "params": [""], "returns": true },
 { "name": "admin_net_connect", "params": ["", ""], "returns": true },
 { "name": "admin_net_peers", "params": [""], "returns": [] },
 { "name": "admin_net_nodeInfo", "params": [""], "returns": {}},

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
@@ -733,26 +733,6 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        bool admin_net_start(const std::string& param1) throw (jsonrpc::JsonRpcException)
-        {
-            Json::Value p;
-            p.append(param1);
-            Json::Value result = this->CallMethod("admin_net_start",p);
-            if (result.isBool())
-                return result.asBool();
-            else
-                throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
-        }
-        bool admin_net_stop(const std::string& param1) throw (jsonrpc::JsonRpcException)
-        {
-            Json::Value p;
-            p.append(param1);
-            Json::Value result = this->CallMethod("admin_net_stop",p);
-            if (result.isBool())
-                return result.asBool();
-            else
-                throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
-        }
         bool admin_net_connect(const std::string& param1, const std::string& param2) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -252,15 +252,6 @@ BOOST_AUTO_TEST_CASE(jsonrpc_peerCount)
     BOOST_CHECK_EQUAL(web3->peerCount(), peerCount);
 }
 
-BOOST_AUTO_TEST_CASE(jsonrpc_setListening)
-{
-    rpcClient->admin_net_start(adminSession);
-    BOOST_CHECK_EQUAL(web3->isNetworkStarted(), true);
-
-    rpcClient->admin_net_stop(adminSession);
-    BOOST_CHECK_EQUAL(web3->isNetworkStarted(), false);
-}
-
 BOOST_AUTO_TEST_CASE(jsonrpc_setMining)
 {
     rpcClient->admin_eth_setMining(true, adminSession);


### PR DESCRIPTION
Removing these functions will enable us to significantly simplify the design of the Host class's start/stop logic due to the lack of needing to support network restart.