### PR TITLE
Refactor network unit tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,16 +47,27 @@ DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IncludeCategories:
+
+  # Local includes "":
   - Regex:           '^".*'
     Priority:        1
-  - Regex:           '^<boost.*'
-    Priority:        98
-  - Regex:           '^<.*\.h>'
+
+  # Standard library extensions / common generic purpose libraries:
+  - Regex:           '^<boost/.*'
+    Priority:        80
+
+  # Public includes <>:
+  - Regex:           '^<.*\.h|hpp>'
     Priority:        2
+
+  # Standard library:
   - Regex:           '^<.*'
-    Priority:        99
+    Priority:        100
+
+  # Anything else:
   - Regex:           '.*'
     Priority:        4
+
 IndentCaseLabels: false
 IndentWidth:     4
 IndentWrappedFunctionNames: false

--- a/.clang-format
+++ b/.clang-format
@@ -56,6 +56,12 @@ IncludeCategories:
   - Regex:           '^<boost/.*'
     Priority:        80
 
+  # Testing libraries:
+  - Regex:           '^<benchmark/.*'
+    Priority:        90
+  - Regex:           '^<gtest/.*'
+    Priority:        90
+
   # Public includes <>:
   - Regex:           '^<.*\.h|hpp>'
     Priority:        2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,8 @@ set(unittest_sources
 
     unittests/libethereum/ValidationSchemes.cpp
 
+    unittests/libp2p/capability.cpp
+
     unittests/libweb3core/memorydb.cpp
     unittests/libweb3core/overlaydb.cpp
     unittests/libweb3core/statecachedb.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,12 +18,13 @@ set(unittest_sources
     unittests/libethcore/CommonJS.cpp
     unittests/libethcore/KeyManager.cpp
 
+    unittests/libethereum/ValidationSchemes.cpp
+
     unittests/libweb3core/memorydb.cpp
     unittests/libweb3core/overlaydb.cpp
     unittests/libweb3core/statecachedb.cpp
 
     unittests/libweb3jsonrpc/AccountHolder.cpp
-    unittests/libethereum/ValidationSchemes.cpp
 )
 
 add_executable(aleth-unittests ${unittest_sources})

--- a/test/unittests/libethereum/Block.cpp
+++ b/test/unittests/libethereum/Block.cpp
@@ -100,7 +100,8 @@ BOOST_AUTO_TEST_CASE(bCopyOperator)
     Block block = blockchain.genesisBlock(genesisDB);
     block.setAuthor(genesisBlock.beneficiary());
 
-    block = block;
+    auto& blockRef = block;  // Hide itself, compilers can complain about direct self-assignments.
+    block = blockRef;        // Assign to itself.
     Block block2 = block;
     BOOST_REQUIRE(ImportTest::compareStates(block.state(), block2.state()) == 0);
     BOOST_REQUIRE(block2.pending() == block.pending());
@@ -309,7 +310,7 @@ BOOST_AUTO_TEST_CASE(bBlockhashContractIsUpdated)
     block.sync(blockchain); // sync to the beginning of block 3
     h256 storageRoot3 = block.state().storageRoot(Address(0xf0));
     BOOST_CHECK(storageRoot3 != EmptyTrie);
-    
+
     BOOST_REQUIRE(storageRoot2 != storageRoot3);
 }
 


### PR DESCRIPTION
I don't want to interfere with your work in P2P, but looks like those unit tests can be easily converted to GTest. This is a small proof. 