### PR TITLE
Don't involve nodes with localhost IPs in discovery process

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -520,9 +520,6 @@ void Host::addNode(NodeID const& _node, NodeIPEndpoint const& _endpoint)
         return;
     }
 
-    if (_endpoint.tcpPort() < c_minListenPort || _endpoint.tcpPort() > c_maxListenPort)
-        cnetdetails << "Non-standard port being recorded: " << _endpoint.tcpPort();
-
     addNodeToNodeTable(Node(_node, _endpoint));
 }
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -528,7 +528,8 @@ void Host::addNode(NodeID const& _node, NodeIPEndpoint const& _endpoint)
 
     if (!isAllowedEndpoint(_endpoint))
     {
-        cnetdetails << "Ignoring request to connect to node ( " << _node << ") with unallowed endpoint (" << _endpoint << ")";
+        cnetdetails << "Ignoring request to connect to node (" << _node
+                    << ") with unallowed endpoint (" << _endpoint << ")";
         return;
     }
 
@@ -541,16 +542,22 @@ void Host::addNode(NodeID const& _node, NodeIPEndpoint const& _endpoint)
 void Host::requirePeer(NodeID const& _n, NodeIPEndpoint const& _endpoint)
 {
     if (!m_run)
+    {
+        cwarn << "Network not running so node (" << _n << ") with endpoint (" << _endpoint
+              << ") cannot be added as a required peer";
         return;
+    }
     
     if (_n == id())
     {
         cnetdetails << "Ignoring request to connect to self " << _n;
         return;
     }
+
     if (!isAllowedEndpoint(_endpoint))
     {
-        cnetdetails << "Ignoring request to connect to node (" << _n << ") with unallowed endpoint (" << _endpoint << ")";
+        cnetdetails << "Ignoring request to connect to node (" << _n
+                    << ") with unallowed endpoint (" << _endpoint << ")";
         return;
     }
 

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -158,6 +158,9 @@ public:
     /// Create Peer and attempt keeping peer connected.
     void requirePeer(NodeID const& _node, bi::address const& _addr, unsigned short _udpPort, unsigned short _tcpPort) { requirePeer(_node, NodeIPEndpoint(_addr, _udpPort, _tcpPort)); }
 
+    /// returns true if a member of m_requiredPeers.
+    bool isRequiredPeer(NodeID const&) const;
+
     /// Note peer as no longer being required.
     void relinquishPeer(NodeID const& _node);
     
@@ -278,9 +281,6 @@ private:
 
     /// Get or create host identifier (KeyPair).
     static KeyPair networkAlias(bytesConstRef _b);
-
-    /// returns true if a member of m_requiredPeers
-    bool isRequiredPeer(NodeID const&) const;
 
     bool nodeTableHasNode(Public const& _id) const;
     Node nodeFromNodeTable(Public const& _id) const;

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -158,7 +158,7 @@ public:
     /// Create Peer and attempt keeping peer connected.
     void requirePeer(NodeID const& _node, bi::address const& _addr, unsigned short _udpPort, unsigned short _tcpPort) { requirePeer(_node, NodeIPEndpoint(_addr, _udpPort, _tcpPort)); }
 
-    /// returns true if a member of m_requiredPeers.
+    /// returns true if a member of m_requiredPeers
     bool isRequiredPeer(NodeID const&) const;
 
     /// Note peer as no longer being required.

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -37,8 +37,9 @@ namespace dev
 namespace p2p
 {
 
-constexpr unsigned short c_defaultListenPort = 30303;
 constexpr const char* c_localhostIp = "127.0.0.1";
+constexpr unsigned short c_defaultListenPort = 30303;
+constexpr unsigned short c_maxListenPort = 30305;
 
 struct NetworkConfig
 {

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -38,6 +38,7 @@ namespace p2p
 {
 
 constexpr const char* c_localhostIp = "127.0.0.1";
+constexpr unsigned short c_minListenPort = 30300;
 constexpr unsigned short c_defaultListenPort = 30303;
 constexpr unsigned short c_maxListenPort = 30305;
 

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -38,9 +38,7 @@ namespace p2p
 {
 
 constexpr const char* c_localhostIp = "127.0.0.1";
-constexpr unsigned short c_minListenPort = 30300;
 constexpr unsigned short c_defaultListenPort = 30303;
-constexpr unsigned short c_maxListenPort = 30305;
 
 struct NetworkConfig
 {

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -128,7 +128,8 @@ bool NodeTable::addNode(Node const& _node, NodeRelation _relation)
 
     if (!isAllowedEndpoint(_node.endpoint))
     {
-        LOG(m_logger) << "Skip adding node (" << _node.id << ") with unallowed endpoint (" << _node.endpoint << ") to node table";
+        LOG(m_logger) << "Skip adding node (" << _node.id << ") with unallowed endpoint ("
+                      << _node.endpoint << ") to node table";
         return false;
     }
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -548,7 +548,12 @@ void NodeTable::onPacketReceived(
                 auto& in = dynamic_cast<PingNode&>(*packet);
                 in.source.setAddress(_from.address());
                 in.source.setUdpPort(_from.port());
-                if (addNode(Node(in.sourceid, in.source)))
+
+                if (!addNode(Node(in.sourceid, in.source)))
+                    // We don't want to add nodes to the buckets (noteActiveNode) which couldn't be
+                    // added to the node list
+                    return;
+
                 {
                     // Send PONG response.
                     Pong p(in.source);
@@ -563,8 +568,6 @@ void NodeTable::onPacketReceived(
                     if (it != m_allNodes.end())
                         it->second->lastPongSentTime = RLPXDatagramFace::secondsSinceEpoch();
                 }
-                else
-                    return;
                 break;
             }
         }

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -229,6 +229,7 @@ struct TestNodeTable: public NodeTable
     using NodeTable::noteActiveNode;
     using NodeTable::setRequestTimeToLive;
     using NodeTable::nodeEntry;
+    using NodeTable::m_allowLocalDiscovery;
 };
 
 /**
@@ -881,6 +882,40 @@ BOOST_AUTO_TEST_CASE(evictionWithOldNodeDropped)
     auto newNode = nodeTable->nodeEntry(newNodeId);
     BOOST_CHECK(newNode->lastPongReceivedTime > 0);
     BOOST_CHECK(nodeTable->bucketLastNode(bucketIndex)->id == newNodeId);
+}
+
+BOOST_AUTO_TEST_CASE(pingFromLocalhost)
+{
+    TestNodeTableHost nodeTableHost(512);
+    nodeTableHost.start();
+    auto& nodeTable = nodeTableHost.nodeTable;
+
+    size_t expectedNodeCount = 0;
+    BOOST_REQUIRE(nodeTable->count() == expectedNodeCount);
+
+    // Need to disable local discovery otherwise node table will allow
+    // nodes with localhost IPs to be added
+    nodeTable->m_allowLocalDiscovery = false;
+
+    // Ping from localhost and verify node isn't added to node table
+    TestUDPSocketHost nodeSocketHost{ 30500 };
+    nodeSocketHost.start();
+    auto nodePort = nodeSocketHost.port;
+    auto nodeEndpoint = NodeIPEndpoint{ bi::address::from_string("127.0.0.1"), nodePort, nodePort };
+
+    PingNode ping(nodeEndpoint, nodeTable->m_hostNodeEndpoint);
+    ping.sign(KeyPair::create().secret());
+    
+    nodeSocketHost.socket->send(ping);
+    
+    // Wait for the node table to receive and process the ping
+    nodeTable->packetsReceived.pop(chrono::milliseconds(5000));
+
+    // Verify the node wasn't added to the node table
+    BOOST_REQUIRE(nodeTable->count() == expectedNodeCount);
+
+    // Verify that the node table doesn't respond with a pong
+    BOOST_REQUIRE_THROW(nodeSocketHost.packetsReceived.pop(chrono::milliseconds(5000)), WaitTimeout);
 }
 
 BOOST_AUTO_TEST_CASE(addSelf)

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -886,7 +886,7 @@ BOOST_AUTO_TEST_CASE(evictionWithOldNodeDropped)
 
 BOOST_AUTO_TEST_CASE(pingFromLocalhost)
 {
-    TestNodeTableHost nodeTableHost(512);
+    TestNodeTableHost nodeTableHost(0);
     nodeTableHost.start();
     auto& nodeTable = nodeTableHost.nodeTable;
 
@@ -898,10 +898,10 @@ BOOST_AUTO_TEST_CASE(pingFromLocalhost)
     nodeTable->m_allowLocalDiscovery = false;
 
     // Ping from localhost and verify node isn't added to node table
-    TestUDPSocketHost nodeSocketHost{30500};
+    TestUDPSocketHost nodeSocketHost{getRandomPortNumber()};
     nodeSocketHost.start();
-    auto nodePort = nodeSocketHost.port;
-    auto nodeEndpoint = NodeIPEndpoint{bi::address::from_string("127.0.0.1"), nodePort, nodePort};
+    auto const nodePort = nodeSocketHost.port;
+    auto nodeEndpoint = NodeIPEndpoint{bi::address::from_string(c_localhostIp), nodePort, nodePort};
 
     PingNode ping(nodeEndpoint, nodeTable->m_hostNodeEndpoint);
     ping.sign(KeyPair::create().secret());

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -898,16 +898,16 @@ BOOST_AUTO_TEST_CASE(pingFromLocalhost)
     nodeTable->m_allowLocalDiscovery = false;
 
     // Ping from localhost and verify node isn't added to node table
-    TestUDPSocketHost nodeSocketHost{ 30500 };
+    TestUDPSocketHost nodeSocketHost{30500};
     nodeSocketHost.start();
     auto nodePort = nodeSocketHost.port;
-    auto nodeEndpoint = NodeIPEndpoint{ bi::address::from_string("127.0.0.1"), nodePort, nodePort };
+    auto nodeEndpoint = NodeIPEndpoint{bi::address::from_string("127.0.0.1"), nodePort, nodePort};
 
     PingNode ping(nodeEndpoint, nodeTable->m_hostNodeEndpoint);
     ping.sign(KeyPair::create().secret());
-    
+
     nodeSocketHost.socket->send(ping);
-    
+
     // Wait for the node table to receive and process the ping
     nodeTable->packetsReceived.pop(chrono::milliseconds(5000));
 
@@ -915,7 +915,8 @@ BOOST_AUTO_TEST_CASE(pingFromLocalhost)
     BOOST_REQUIRE(nodeTable->count() == expectedNodeCount);
 
     // Verify that the node table doesn't respond with a pong
-    BOOST_REQUIRE_THROW(nodeSocketHost.packetsReceived.pop(chrono::milliseconds(5000)), WaitTimeout);
+    BOOST_REQUIRE_THROW(
+        nodeSocketHost.packetsReceived.pop(chrono::milliseconds(5000)), WaitTimeout);
 }
 
 BOOST_AUTO_TEST_CASE(addSelf)

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -33,11 +33,6 @@ using namespace dev;
 using namespace dev::test;
 using namespace dev::p2p;
 
-namespace
-{
-constexpr const char* c_localhostIp = "127.0.0.1";
-}
-
 class TestCap : public CapabilityFace, public Worker
 {
 public:

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -309,6 +309,27 @@ BOOST_AUTO_TEST_CASE(requirePeer)
     BOOST_REQUIRE_EQUAL(host2peerCount, 1);
 }
 
+BOOST_AUTO_TEST_CASE(requirePeerNoNetwork)
+{
+    NetworkConfig prefs1(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */);
+    NetworkConfig prefs2(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */);
+    Host host1("Test", prefs1);
+    Host host2("Test", prefs2);
+    auto node2 = host2.id();
+
+    // Both hosts' ports should be 0 since we haven't started their network threads
+    BOOST_REQUIRE_EQUAL(host1.listenPort(), 0);
+    BOOST_REQUIRE_EQUAL(host2.listenPort(), 0);
+
+    host1.registerCapability(make_shared<TestCap>());
+    host2.registerCapability(make_shared<TestCap>());
+
+    host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(c_localhostIp),
+                                 0 /* tcp port */, 0 /* udp port */));
+
+    BOOST_REQUIRE(!host1.isRequiredPeer(node2));
+}
+
 BOOST_AUTO_TEST_CASE(requireLocalhostPeer)
 {
     // Don't allow connections from nodes with localhost ips

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -33,6 +33,11 @@ using namespace dev;
 using namespace dev::test;
 using namespace dev::p2p;
 
+namespace
+{
+constexpr const char* c_localhostIp = "127.0.0.1";
+}
+
 class TestCap : public CapabilityFace, public Worker
 {
 public:
@@ -56,12 +61,12 @@ BOOST_FIXTURE_TEST_SUITE(p2p, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
-    Host host1("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+    Host host1("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
     host1.start();
     auto host1port = host1.listenPort();
     BOOST_REQUIRE(host1port);
 
-    Host host2("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+    Host host2("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
     host2.start();
     auto host2port = host2.listenPort();
     BOOST_REQUIRE(host2port);
@@ -95,7 +100,7 @@ BOOST_AUTO_TEST_CASE(host)
     }
 
     BOOST_REQUIRE(host1.haveNetwork() && host2.haveNetwork());
-    host1.addNode(node2, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), host2port, host2port));
+    host1.addNode(node2, NodeIPEndpoint(bi::address::from_string(c_localhostIp), host2port, host2port));
 
     // Wait for up to 24 seconds, to give the hosts time to find each other
     for (unsigned i = 0; i < 24000; i += step)
@@ -129,7 +134,7 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 
     for (unsigned i = 0; i < c_nodes; ++i)
     {
-        Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+        Host* h = new Host("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
         h->setIdealPeerCount(10);		
         h->start(); // starting host is required so listenport is available
         while (!h->haveNetwork())
@@ -144,14 +149,14 @@ BOOST_AUTO_TEST_CASE(saveNodes)
     
     Host& host = *hosts.front();
     for (auto const& h: hosts)
-        host.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
+        host.addNode(h->id(), NodeIPEndpoint(bi::address::from_string(c_localhostIp), h->listenPort(), h->listenPort()));
 
     for (unsigned i = 0; i < c_peers * 1000 && host.peerCount() < c_peers; i += c_step)
         this_thread::sleep_for(chrono::milliseconds(c_step));
 
     Host& host2 = *hosts.back();
     for (auto const& h: hosts)
-        host2.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
+        host2.addNode(h->id(), NodeIPEndpoint(bi::address::from_string(c_localhostIp), h->listenPort(), h->listenPort()));
 
     for (unsigned i = 0; i < c_peers * 2000 && host2.peerCount() < c_peers; i += c_step)
         this_thread::sleep_for(chrono::milliseconds(c_step));
@@ -186,7 +191,7 @@ BOOST_FIXTURE_TEST_SUITE(p2pPeer, TestOutputHelperFixture)
 BOOST_AUTO_TEST_CASE(requirePeer)
 {
     unsigned const step = 10;
-    const char* const localhost = "127.0.0.1";
+    const char* const localhost = c_localhostIp;
     NetworkConfig prefs1(localhost, 0, false /* upnp */, true /* allow local discovery */);
     NetworkConfig prefs2(localhost, 0, false /* upnp */, true /* allow local discovery */);
     Host host1("Test", prefs1);

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -33,6 +33,11 @@ using namespace dev;
 using namespace dev::test;
 using namespace dev::p2p;
 
+namespace
+{
+constexpr const char* c_localhostIp = "127.0.0.1";
+}
+
 class TestCap : public CapabilityFace, public Worker
 {
 public:
@@ -56,12 +61,12 @@ BOOST_FIXTURE_TEST_SUITE(p2p, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_CASE(host)
 {
-    Host host1("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+    Host host1("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
     host1.start();
     auto host1port = host1.listenPort();
     BOOST_REQUIRE(host1port);
 
-    Host host2("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+    Host host2("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
     host2.start();
     auto host2port = host2.listenPort();
     BOOST_REQUIRE(host2port);
@@ -95,7 +100,7 @@ BOOST_AUTO_TEST_CASE(host)
     }
 
     BOOST_REQUIRE(host1.haveNetwork() && host2.haveNetwork());
-    host1.addNode(node2, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), host2port, host2port));
+    host1.addNode(node2, NodeIPEndpoint(bi::address::from_string(c_localhostIp), host2port, host2port));
 
     // Wait for up to 24 seconds, to give the hosts time to find each other
     for (unsigned i = 0; i < 24000; i += step)
@@ -108,6 +113,60 @@ BOOST_AUTO_TEST_CASE(host)
 
     BOOST_REQUIRE_EQUAL(host1.peerCount(), 1);
     BOOST_REQUIRE_EQUAL(host2.peerCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(addLocalhostPeer)
+{
+    // Don't allow hosts to bond with hosts with localhost IPs
+    constexpr bool allowLocalDiscovery = false;
+
+    Host host1("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, allowLocalDiscovery));
+    host1.start();
+    auto host1port = host1.listenPort();
+    BOOST_REQUIRE(host1port);
+
+    Host host2("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, allowLocalDiscovery));
+    host2.start();
+    auto host2port = host2.listenPort();
+    BOOST_REQUIRE(host2port);
+
+    BOOST_REQUIRE_NE(host1port, host2port);
+
+    host1.registerCapability(make_shared<TestCap>());
+    host2.registerCapability(make_shared<TestCap>());
+
+    auto node2 = host2.id();
+    int const step = 10;
+
+    // Wait for up to 6 seconds, to give the hosts time to start.
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
+
+        if (host1.isStarted() && host2.isStarted())
+            break;
+    }
+
+    BOOST_REQUIRE(host1.isStarted() && host2.isStarted());
+
+    // Wait for up to 6 seconds, to give the hosts time to get their network connection established
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
+
+        if (host1.haveNetwork() && host2.haveNetwork())
+            break;
+    }
+
+    BOOST_REQUIRE(host1.haveNetwork() && host2.haveNetwork());
+    host1.addNode(
+        node2, NodeIPEndpoint(bi::address::from_string(c_localhostIp), host2port, host2port));
+
+    // Wait for 24 seconds and verify that neither peer adds each other
+    this_thread::sleep_for(chrono::milliseconds(24000));
+
+    BOOST_REQUIRE_EQUAL(host1.peerCount(), 0);
+    BOOST_REQUIRE_EQUAL(host2.peerCount(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(networkConfig)
@@ -129,7 +188,7 @@ BOOST_AUTO_TEST_CASE(saveNodes)
 
     for (unsigned i = 0; i < c_nodes; ++i)
     {
-        Host* h = new Host("Test", NetworkConfig("127.0.0.1", 0, false /* upnp */, true /* allow local discovery */));
+        Host* h = new Host("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
         h->setIdealPeerCount(10);		
         h->start(); // starting host is required so listenport is available
         while (!h->haveNetwork())
@@ -144,14 +203,14 @@ BOOST_AUTO_TEST_CASE(saveNodes)
     
     Host& host = *hosts.front();
     for (auto const& h: hosts)
-        host.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
+        host.addNode(h->id(), NodeIPEndpoint(bi::address::from_string(c_localhostIp), h->listenPort(), h->listenPort()));
 
     for (unsigned i = 0; i < c_peers * 1000 && host.peerCount() < c_peers; i += c_step)
         this_thread::sleep_for(chrono::milliseconds(c_step));
 
     Host& host2 = *hosts.back();
     for (auto const& h: hosts)
-        host2.addNode(h->id(), NodeIPEndpoint(bi::address::from_string("127.0.0.1"), h->listenPort(), h->listenPort()));
+        host2.addNode(h->id(), NodeIPEndpoint(bi::address::from_string(c_localhostIp), h->listenPort(), h->listenPort()));
 
     for (unsigned i = 0; i < c_peers * 2000 && host2.peerCount() < c_peers; i += c_step)
         this_thread::sleep_for(chrono::milliseconds(c_step));
@@ -186,9 +245,8 @@ BOOST_FIXTURE_TEST_SUITE(p2pPeer, TestOutputHelperFixture)
 BOOST_AUTO_TEST_CASE(requirePeer)
 {
     unsigned const step = 10;
-    const char* const localhost = "127.0.0.1";
-    NetworkConfig prefs1(localhost, 0, false /* upnp */, true /* allow local discovery */);
-    NetworkConfig prefs2(localhost, 0, false /* upnp */, true /* allow local discovery */);
+    NetworkConfig prefs1(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */);
+    NetworkConfig prefs2(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */);
     Host host1("Test", prefs1);
     Host host2("Test", prefs2);
     host1.start();
@@ -203,7 +261,7 @@ BOOST_AUTO_TEST_CASE(requirePeer)
     host1.registerCapability(make_shared<TestCap>());
     host2.registerCapability(make_shared<TestCap>());
 
-    host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
+    host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(c_localhostIp), port2, port2));
 
     // Wait for up to 12 seconds, to give the hosts time to connect to each other.
     for (unsigned i = 0; i < 12000; i += step)
@@ -249,6 +307,37 @@ BOOST_AUTO_TEST_CASE(requirePeer)
     host2peerCount = host2.peerCount();
     BOOST_REQUIRE_EQUAL(host1peerCount, 1);
     BOOST_REQUIRE_EQUAL(host2peerCount, 1);
+}
+
+BOOST_AUTO_TEST_CASE(requireLocalhostPeer)
+{
+    // Don't allow connections from nodes with localhost ips
+    constexpr bool allowLocalDiscovery = false;
+
+    NetworkConfig prefs1(c_localhostIp, 0, false /* upnp */, allowLocalDiscovery);
+    NetworkConfig prefs2(c_localhostIp, 0, false /* upnp */, allowLocalDiscovery);
+    Host host1("Test", prefs1);
+    Host host2("Test", prefs2);
+    host1.start();
+    host2.start();
+    auto node2 = host2.id();
+    auto port1 = host1.listenPort();
+    auto port2 = host2.listenPort();
+    BOOST_REQUIRE(port1);
+    BOOST_REQUIRE(port2);
+    BOOST_REQUIRE_NE(port1, port2);
+
+    host1.registerCapability(make_shared<TestCap>());
+    host2.registerCapability(make_shared<TestCap>());
+
+    host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(c_localhostIp), port2, port2));
+
+    // Wait for 12 seconds and verify that hosts haven't connected with each other
+    this_thread::sleep_for(chrono::milliseconds(12000));
+    auto host1peerCount = host1.peerCount();
+    auto host2peerCount = host2.peerCount();
+    BOOST_REQUIRE_EQUAL(host1peerCount, 0);
+    BOOST_REQUIRE_EQUAL(host2peerCount, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fix #5426 

Don't involve nodes which have localhost IPs in the discovery process (unless `allowLocalDiscovery `is enabled):
* Don't respond to pings received from localhost endpoints
* Don't add nodes with localhost endpoints to the node table (e.g. if received via a Neighbours packet)