### PR TITLE
Only send ping after sending pong response to nodes with invalid endpoint proofs

### DIFF
--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -105,13 +105,15 @@ bool NodeTable::addNode(Node const& _node, NodeRelation _relation)
     }
 
     bool bFound = false;
-    std::shared_ptr<NodeEntry> nodeEntry = nullptr;
+    std::shared_ptr<NodeEntry> nodeEntry;
     DEV_GUARDED(x_nodes)
     {
-        auto nodePair = m_allNodes.insert(
-            {_node.id, make_shared<NodeEntry>(m_hostNodeID, _node.id, _node.endpoint)});
-        bFound = !nodePair.second;
-        nodeEntry = nodePair.first->second;
+        auto iterPair = m_allNodes.insert({_node.id, nullptr});
+        if (iterPair.second)  // Node id inserted, construct node entry:
+            iterPair.first->second = make_shared<NodeEntry>(m_hostNodeID, _node.id, _node.endpoint);
+        else
+            bFound = true;
+        nodeEntry = iterPair.first->second;
     }
 
     // Log here to avoid holding the x_nodes mutex longer than necessary

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -104,6 +104,12 @@ bool NodeTable::addNode(Node const& _node, NodeRelation _relation)
         return false;
     }
 
+    if (m_hostNodeID == _node.id)
+    {
+        LOG(m_logger) << "Skip adding self to node table (" << _node.id << ")";
+        return false;
+    }
+
     bool bFound = false;
     std::shared_ptr<NodeEntry> nodeEntry;
     DEV_GUARDED(x_nodes)

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -1,16 +1,16 @@
 /*
  This file is part of cpp-ethereum.
- 
+
  cpp-ethereum is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  cpp-ethereum is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -53,7 +53,7 @@ NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint 
     m_secret(_alias.secret()),
     m_socket(make_shared<NodeSocket>(
         _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)m_hostNodeEndpoint)),
-    m_requestTimeToLive(DiscoveryDatagram::c_timeToLive),        
+    m_requestTimeToLive(DiscoveryDatagram::c_timeToLive),
     m_allowLocalDiscovery(_allowLocalDiscovery),
     m_timers(_io)
 {
@@ -120,10 +120,9 @@ bool NodeTable::addNode(Node const& _node, NodeRelation _relation)
     if (bFound)
         LOG(m_logger) << "Node " << _node.id << "@" << _node.endpoint
                       << " is already in the node table";
-    else if (!bFound && _relation != Known)
-        LOG(m_logger) << "Pending node " << _node.id << "@" << _node.endpoint;
-    else if (!bFound && _relation == Known)
-        LOG(m_logger) << "Known node " << _node.id << "@" << _node.endpoint;
+    else
+        LOG(m_logger) << (_relation == Known ? "Known" : "Pending") << " node " << _node.id << "@"
+                      << _node.endpoint;
 
     if (_relation == Known)
     {
@@ -186,10 +185,10 @@ shared_ptr<NodeEntry> NodeTable::nodeEntry(NodeID _id)
 void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_ptr<NodeEntry>>> _tried)
 {
     // NOTE: ONLY called by doDiscovery!
-    
+
     if (!m_socket->isOpen())
         return;
-    
+
     auto const nearestNodes = nearestNodeEntries(_node);
     auto newTriedCount = 0;
     for (auto const& node : nearestNodes)
@@ -216,7 +215,7 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
                 break;
         }
     }
-    
+
     if (_round == s_maxSteps || newTriedCount == 0)
     {
         LOG(m_logger) << "Terminating discover after " << _round << " rounds.";
@@ -235,9 +234,9 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
         if (_ec.value() == boost::asio::error::operation_aborted || m_timers.isStopped())
             return;
 
-        // error::operation_aborted means that the timer was probably aborted. 
-        // It usually happens when "this" object is deallocated, in which case 
-        // subsequent call to doDiscover() would cause a crash. We can not rely on 
+        // error::operation_aborted means that the timer was probably aborted.
+        // It usually happens when "this" object is deallocated, in which case
+        // subsequent call to doDiscover() would cause a crash. We can not rely on
         // m_timers.isStopped(), because "this" pointer was captured by the lambda,
         // and therefore, in case of deallocation m_timers object no longer exists.
 
@@ -251,9 +250,9 @@ vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID _target)
     static unsigned lastBin = s_bins - 1;
     unsigned head = distance(m_hostNodeID, _target);
     unsigned tail = head == 0 ? lastBin : (head - 1) % s_bins;
-    
+
     map<unsigned, list<shared_ptr<NodeEntry>>> found;
-    
+
     // if d is 0, then we roll look forward, if last, we reverse, else, spread from d
     if (head > 1 && tail != lastBin)
         while (head != tail && head < s_bins)

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -137,6 +137,7 @@ bool NodeTable::addNode(Node const& _node, NodeRelation _relation)
         // configuration file. This means that the "last pong received time" needs to be serialized
         // and deserialized before we can accept the pong time as an input to this function.
         nodeEntry->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
+        nodeEntry->endpoint = _node.endpoint; // Update the endpoint in case it has changed
         noteActiveNode(nodeEntry->id, nodeEntry->endpoint);
     }
     else if (_relation != Known && !nodeEntry->hasValidEndpointProof())

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -207,7 +207,8 @@ protected:
         std::list<std::weak_ptr<NodeEntry>> nodes;
     };
 
-    /// Used ping known node. Used by node table when refreshing buckets and as part of eviction process (see evict).
+    /// Used ping known node. Used by node table when refreshing buckets and as part of eviction
+    /// process (see evict). Not synchronous - the ping operation is queued via a timer
     void ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const& _replacementNodeID = {});
 
     /// Used by asynchronous operations to return NodeEntry which is active and managed by node table.

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -207,8 +207,9 @@ protected:
         std::list<std::weak_ptr<NodeEntry>> nodes;
     };
 
-    /// Used ping known node. Used by node table when refreshing buckets and as part of eviction
-    /// process (see evict). Not synchronous - the ping operation is queued via a timer
+    /// Used to ping a node to initiate the endpoint proof. Used when contacting neighbours if they
+    /// don't have a valid endpoint proof (see doDiscover), refreshing buckets and as part of
+    /// eviction process (see evict). Not synchronous - the ping operation is queued via a timer
     void ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const& _replacementNodeID = {});
 
     /// Used by asynchronous operations to return NodeEntry which is active and managed by node table.

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -984,15 +984,14 @@ BOOST_AUTO_TEST_CASE(pingNotSentAfterPongForKnownNode)
     // * A ping is sent after a pong for a known node with an invalid endpoint proof
 
     TestNodeTableHost nodeTableHost1(0);
-    nodeTableHost1.populate();
     nodeTableHost1.start();
     auto& nodeTable1 = nodeTableHost1.nodeTable;
 
-    TestUDPSocketHost nodeSocketHost2{30500};
+    TestUDPSocketHost nodeSocketHost2{getRandomPortNumber()};
     nodeSocketHost2.start();
     auto nodePort2 = nodeSocketHost2.port;
     auto nodeEndpoint2 =
-        NodeIPEndpoint{bi::address::from_string("127.0.0.1"), nodePort2, nodePort2};
+        NodeIPEndpoint{bi::address::from_string(c_localhostIp), nodePort2, nodePort2};
 
     // Add node to the node table to trigger ping
     auto nodeKeyPair2 = KeyPair::create();


### PR DESCRIPTION
Fix item 3 in #4959 

When receiving a ping from a node for which we've already completed the endpoint proof, don't send a ping in addition to the pong response. Note that prior to these changes, we wouldn't send a ping after the pong to nodes whose endpoint proofs had expired. 

I've also added a unit test which validates this behavior. 
