### PR TITLE
config: Remove Constantinople block number from mainnet config

### DIFF
--- a/libethashseal/genesis/mainNetwork.cpp
+++ b/libethashseal/genesis/mainNetwork.cpp
@@ -28,7 +28,6 @@ R"E(
         "EIP150ForkBlock": "0x259518",
         "EIP158ForkBlock": "0x28d138",
         "byzantiumForkBlock": "0x42ae50",
-        "constantinopleForkBlock": "0x6c0840",
         "networkID" : "0x01",
         "chainID": "0x01",
         "maximumExtraDataSize": "0x20",


### PR DESCRIPTION
The Constantinople upgrade was postponed.