### PR TITLE
Backport 1.5: Check for endpoint proof timeout on FindNode (squashed)

### DIFF
--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -73,6 +73,7 @@ DEV_SIMPLE_EXCEPTION(MissingField);
 DEV_SIMPLE_EXCEPTION(WrongFieldType);
 DEV_SIMPLE_EXCEPTION(InterfaceNotSupported);
 DEV_SIMPLE_EXCEPTION(ExternalFunctionFailure);
+DEV_SIMPLE_EXCEPTION(WaitTimeout);
 
 // error information to be added to exceptions
 using errinfo_invalidSymbol = boost::error_info<struct tag_invalidSymbol, char>;

--- a/libdevcore/concurrent_queue.h
+++ b/libdevcore/concurrent_queue.h
@@ -1,60 +1,60 @@
-/*
-	This file is part of cpp-ethereum.
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2018 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
-
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
 #pragma once
-#include <utility>
-#include <queue>
+
+#include "Exceptions.h"
+
 #include <condition_variable>
 #include <mutex>
-
+#include <queue>
+#include <utility>
 
 namespace dev
 {
-
 /// Concurrent queue.
 /// You can push and pop elements to/from the queue. Pop will block until the queue is not empty.
 /// The default backend (_QueueT) is std::queue. It can be changed to any type that has
 /// proper push(), pop(), empty() and front() methods.
-template<typename _T, typename _QueueT = std::queue<_T>>
+template <typename _T, typename _QueueT = std::queue<_T>>
 class concurrent_queue
 {
 public:
-	template<typename _U>
-	void push(_U&& _elem)
-	{
-		{
-			std::lock_guard<decltype(x_mutex)> guard{x_mutex};
-			m_queue.push(std::forward<_U>(_elem));
-		}
-		m_cv.notify_one();
-	}
+    template <typename _U>
+    void push(_U&& _elem)
+    {
+        {
+            std::lock_guard<decltype(x_mutex)> guard{x_mutex};
+            m_queue.push(std::forward<_U>(_elem));
+        }
+        m_cv.notify_one();
+    }
 
 	_T pop()
 	{
-		std::unique_lock<std::mutex> lock{x_mutex};
-		m_cv.wait(lock, [this]{ return !m_queue.empty(); });
+		std::unique_lock<std::mutex> lock{ x_mutex };
+		m_cv.wait(lock, [this] { return !m_queue.empty(); });
 		auto item = std::move(m_queue.front());
 		m_queue.pop();
 		return item;
 	}
 
+    _T pop(std::chrono::milliseconds const& _waitDuration)
+    {
+        std::unique_lock<std::mutex> lock{x_mutex};
+        if (!m_cv.wait_for(lock, _waitDuration, [this] { return !m_queue.empty(); }))
+            BOOST_THROW_EXCEPTION(WaitTimeout());
+
+        auto item = std::move(m_queue.front());
+        m_queue.pop();
+        return item;
+    }
+
 private:
-	_QueueT m_queue;
-	std::mutex x_mutex;
-	std::condition_variable m_cv;
+    _QueueT m_queue;
+    std::mutex x_mutex;
+    std::condition_variable m_cv;
 };
 
-}
+}  // namespace dev

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -29,18 +29,6 @@ namespace dev
 namespace p2p
 {
 
-/**
- * NodeEntry
- * @brief Entry in Node Table
- */
-struct NodeEntry: public Node
-{
-    NodeEntry(NodeID const& _src, Public const& _pubk, NodeIPEndpoint const& _gw);
-    int const distance = 0;  ///< Node's distance (xor of _src as integer).
-    uint32_t lastPongReceivedTime = 0;
-    uint32_t lastPongSentTime = 0;
-};
-
 enum NodeTableEventType
 {
     NodeEntryAdded,
@@ -86,6 +74,8 @@ protected:
 
 class NodeTable;
 inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable);
+
+struct NodeEntry;
 
 /**
  * NodeTable using modified kademlia for node discovery and preference.
@@ -136,6 +126,9 @@ class NodeTable : UDPSocketEvents
     };
 
 public:
+    // Period during which we consider last PONG results to be valid before sending new PONG
+    static constexpr uint32_t c_bondingTimeSeconds{12 * 60 * 60};
+
     enum NodeRelation { Unknown = 0, Known };
     enum DiscoverType { Random = 0 };
     
@@ -153,7 +146,10 @@ public:
     /// Called by implementation which provided handler to process NodeEntryAdded/NodeEntryDropped events. Events are coalesced by type whereby old events are ignored.
     void processEvents();
 
-    /// Add node. Node will be pinged.
+    /// Add node to the list of all nodes and if the node is known (we've completed the endpoint
+    /// proof for it or it has been restored from the network config), also add it to the node table.
+    /// If the node is unknown (i.e. we haven't completed the endpoint proof for it yet) then ping
+    /// it to trigger the endpoint proof.
     ///
     /// @return True if the node has been added to the table.
     bool addNode(Node const& _node, NodeRelation _relation = NodeRelation::Unknown);
@@ -203,8 +199,6 @@ protected:
     static constexpr std::chrono::milliseconds c_reqTimeout{300};
     /// Refresh interval prevents bucket from becoming stale. [Kademlia]
     static constexpr std::chrono::milliseconds c_bucketRefresh{7200};
-    // Period during which we consider last PONG results to be valid before sending new PONG
-    static constexpr uint32_t c_bondingTimeSeconds{12 * 60 * 60};
 
     struct NodeBucket
     {
@@ -228,7 +222,8 @@ protected:
     /// Asynchronously drops _leastSeen node if it doesn't reply and adds _new node, otherwise _new node is thrown away.
     void evict(NodeEntry const& _leastSeen, NodeEntry const& _new);
 
-    /// Called whenever activity is received from a node in order to maintain node table.
+    /// Called whenever activity is received from a node in order to maintain node table. Only
+    /// called for nodes for which we've completed an endpoint proof.
     void noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint);
 
     /// Used to drop node when timeout occurs or when evict() result is to keep previous node.
@@ -278,11 +273,17 @@ protected:
     Secret m_secret;												///< This nodes secret key.
 
     mutable Mutex x_nodes;											///< LOCK x_state first if both locks are required. Mutable for thread-safe copy in nodes() const.
-    std::unordered_map<NodeID, std::shared_ptr<NodeEntry>> m_allNodes;  ///< Known Node Endpoints
+
+    /// Node endpoints. Includes all nodes that we've been in contact with and which haven't been
+    /// evicted. This includes nodes for which we both have and haven't completed the endpoint
+    /// proof.
+    std::unordered_map<NodeID, std::shared_ptr<NodeEntry>> m_allNodes;
 
     mutable Mutex x_state;											///< LOCK x_state first if both x_nodes and x_state locks are required.
-    std::array<NodeBucket, s_bins> m_buckets;                       ///< State of p2p node network.
-    
+
+    /// State of p2p node network. Only includes nodes for which we've completed the endpoint proof
+    std::array<NodeBucket, s_bins> m_buckets;
+
     std::list<NodeIdTimePoint> m_sentFindNodes;					///< Timeouts for FindNode requests.
 
     std::shared_ptr<NodeSocket> m_socket;							///< Shared pointer for our UDPSocket; ASIO requires shared_ptr.
@@ -298,6 +299,24 @@ protected:
     bool m_allowLocalDiscovery;                                     ///< Allow nodes with local addresses to be included in the discovery process
 
     DeadlineOps m_timers; ///< this should be the last member - it must be destroyed first
+};
+
+/**
+ * NodeEntry
+ * @brief Entry in Node Table
+ */
+struct NodeEntry : public Node
+{
+    NodeEntry(NodeID const& _src, Public const& _pubk, NodeIPEndpoint const& _gw);
+    bool hasValidEndpointProof() const
+    {
+        return RLPXDatagramFace::secondsSinceEpoch() <
+               lastPongReceivedTime + NodeTable::c_bondingTimeSeconds;
+    }
+
+    int const distance = 0;  ///< Node's distance (xor of _src as integer).
+    uint32_t lastPongReceivedTime = 0;
+    uint32_t lastPongSentTime = 0;
 };
 
 inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable)


### PR DESCRIPTION
Before processing a FindNode request, validate that the endpoint proof has been completed within the timeout window (12 hours). If so, service the request and send neighbors. Otherwise, ignore the request.