### PR TITLE
Update network tests to use random ports

### DIFF
--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
 
     /// Networking params.
     string listenIP;
-    unsigned short listenPort = c_defaultIPPort;
+    unsigned short listenPort = c_defaultListenPort;
     string publicIP;
     bool upnp = true;
 

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -150,10 +150,10 @@ int main(int argc, char** argv)
 
     /// Networking params.
     string listenIP;
-    unsigned short listenPort = dev::p2p::c_defaultIPPort;
+    unsigned short listenPort = dev::p2p::c_defaultListenPort;
     string publicIP;
     string remoteHost;
-    unsigned short remotePort = dev::p2p::c_defaultIPPort;
+    unsigned short remotePort = dev::p2p::c_defaultListenPort;
 
     unsigned peers = 11;
     unsigned peerStretch = 7;
@@ -303,7 +303,7 @@ int main(int argc, char** argv)
         "        Ports:\n"
         "        The first port argument is the tcp port used for direct communication among peers. If the second port\n"
         "        argument isn't supplied, the first port argument will also be the udp port used for node discovery.\n"
-        "        If neither the first nor second port arguments are supplied, a default port of " << dev::p2p::c_defaultIPPort << " will be used for\n"
+        "        If neither the first nor second port arguments are supplied, a default port of " << dev::p2p::c_defaultListenPort << " will be used for\n"
         "        both peer communication and node discovery.";
     string peersetDescription = peersetDescriptionStream.str();
     addNetworkingOption("peerset", po::value<string>()->value_name("<list>"), peersetDescription.c_str());

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -27,7 +27,6 @@ using namespace dev;
 using namespace dev::p2p;
 
 const unsigned dev::p2p::c_protocolVersion = 4;
-const unsigned dev::p2p::c_defaultIPPort = 30303;
 static_assert(dev::p2p::c_protocolVersion == 4, "Replace v3 compatbility with v4 compatibility before updating network version.");
 
 const dev::p2p::NodeIPEndpoint dev::p2p::UnspecifiedNodeIPEndpoint = NodeIPEndpoint(bi::address(), 0, 0);

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -93,7 +93,7 @@ bool p2p::isLocalHostAddress(bi::address const& _addressToCheck)
 {
     // @todo: ivp6 link-local adresses (macos), ex: fe80::1%lo0
     static const set<bi::address> c_rejectAddresses = {
-        {bi::address_v4::from_string("127.0.0.1")},
+        {bi::address_v4::from_string(c_localhostIp)},
         {bi::address_v4::from_string("0.0.0.0")},
         {bi::address_v6::from_string("::1")},
         {bi::address_v6::from_string("::")}

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -53,7 +53,6 @@ namespace p2p
 
 /// Peer network protocol version.
 extern const unsigned c_protocolVersion;
-extern const unsigned c_defaultIPPort;
 
 class NodeIPEndpoint;
 class Node;

--- a/libp2p/Network.cpp
+++ b/libp2p/Network.cpp
@@ -219,7 +219,7 @@ bi::tcp::endpoint Network::resolveHost(string const& _addr)
 
     vector<string> split;
     boost::split(split, _addr, boost::is_any_of(":"));
-    unsigned port = dev::p2p::c_defaultIPPort;
+    unsigned port = dev::p2p::c_defaultListenPort;
 
     try
     {

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -37,8 +37,8 @@ namespace dev
 namespace p2p
 {
 
-static constexpr unsigned short c_defaultListenPort = 30303;
-static constexpr const char* c_localhostIp = "127.0.0.1";
+constexpr unsigned short c_defaultListenPort = 30303;
+constexpr const char* c_localhostIp = "127.0.0.1";
 
 struct NetworkConfig
 {

--- a/libp2p/Network.h
+++ b/libp2p/Network.h
@@ -37,7 +37,8 @@ namespace dev
 namespace p2p
 {
 
-static const unsigned short c_defaultListenPort = 30303;
+static constexpr unsigned short c_defaultListenPort = 30303;
+static constexpr const char* c_localhostIp = "127.0.0.1";
 
 struct NetworkConfig
 {


### PR DESCRIPTION
The network tests can sometimes interfere with each other - update them
to use random ports which should reduce the chances of test failures due
to test interference.