### PR TITLE
Streamline host shutdown logic and fix use-after-free

### DIFF
--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -76,6 +76,7 @@ class Session;
 
 struct NetworkStartRequired: virtual dev::Exception {};
 struct InvalidPublicIPAddress: virtual dev::Exception {};
+struct NetworkRestartNotSupported : virtual dev::Exception {};
 
 /// The ECDHE agreement failed during RLPx handshake.
 struct ECDHEError: virtual Exception {};

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -109,6 +109,9 @@ Host::~Host()
 void Host::start()
 {
     DEV_TIMED_FUNCTION_ABOVE(500);
+    if (m_nodeTable)
+        BOOST_THROW_EXCEPTION(NetworkRestartNotSupported());
+
     startWorking();
     while (isWorking() && !haveNetwork())
         this_thread::sleep_for(chrono::milliseconds(10));
@@ -782,7 +785,7 @@ void Host::doWork()
 
 void Host::keepAlivePeers()
 {
-    if (chrono::steady_clock::now() - c_keepAliveInterval < m_lastPing)
+    if (!m_run || chrono::steady_clock::now() - c_keepAliveInterval < m_lastPing)
         return;
 
     RecursiveGuard l(x_sessions);

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -309,7 +309,9 @@ private:
     io::io_service m_ioService;											///< IOService for network stuff.
     bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.
 
-    std::unique_ptr<io::deadline_timer> m_timer;					///< Timer which, when network is running, calls run() every c_timerInterval ms.
+    /// Timer which, when network is running, calls run() every c_timerInterval ms.
+    io::deadline_timer m_timer;
+
     static constexpr unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
 
     std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -206,7 +206,7 @@ public:
     ReputationManager& repMan() { return m_repMan; }
 
     /// @returns if network is started and interactive.
-    bool haveNetwork() const { Guard l(x_runTimer); Guard ll(x_nodeTable); return m_run && !!m_nodeTable; }
+    bool haveNetwork() const { Guard ll(x_nodeTable); return m_run && !!m_nodeTable; }
     
     /// Validates and starts peer session, taking ownership of _io. Disconnects and returns false upon error.
     void startPeerSession(Public const& _id, RLP const& _hello, std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
@@ -310,9 +310,7 @@ private:
     bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.
 
     std::unique_ptr<io::deadline_timer> m_timer;					///< Timer which, when network is running, calls run() every c_timerInterval ms.
-    mutable std::mutex x_runTimer;	///< Start/stop mutex.
     static constexpr unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
-    std::condition_variable m_timerReset;
 
     std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).
 

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -206,7 +206,7 @@ public:
     ReputationManager& repMan() { return m_repMan; }
 
     /// @returns if network is started and interactive.
-    bool haveNetwork() const { Guard ll(x_nodeTable); return m_run && !!m_nodeTable; }
+    bool haveNetwork() const { return m_run; }
     
     /// Validates and starts peer session, taking ownership of _io. Disconnects and returns false upon error.
     void startPeerSession(Public const& _id, RLP const& _hello, std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -76,12 +76,6 @@ NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint 
     }
 }
 
-NodeTable::~NodeTable()
-{
-    m_socket->disconnect();
-    m_timers.stop();
-}
-
 void NodeTable::processEvents()
 {
     if (m_nodeEventHandler)

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -125,10 +125,16 @@ public:
     /// Constructor requiring host for I/O, credentials, and IP Address and port to listen on.
     NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint,
         bool _enabled = true, bool _allowLocalDiscovery = false);
-    ~NodeTable();
+    ~NodeTable() { stop(); }
 
     /// Returns distance based on xor metric two node ids. Used by NodeEntry and NodeTable.
     static int distance(NodeID const& _a, NodeID const& _b) { u256 d = sha3(_a) ^ sha3(_b); unsigned ret; for (ret = 0; d >>= 1; ++ret) {}; return ret; }
+
+    void stop()
+    {
+        m_socket->disconnect();
+        m_timers.stop();
+    }
 
     /// Set event handler for NodeEntryAdded and NodeEntryDropped events.
     void setEventHandler(NodeTableEventHandler* _handler) { m_nodeEventHandler.reset(_handler); }

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -110,6 +110,18 @@ BOOST_AUTO_TEST_CASE(host)
     BOOST_REQUIRE_EQUAL(host2.peerCount(), 1);
 }
 
+BOOST_AUTO_TEST_CASE(attemptNetworkRestart)
+{
+    Host host("Test",
+        NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
+    host.start();
+    BOOST_REQUIRE(host.listenPort());
+    BOOST_REQUIRE(host.haveNetwork());
+    host.stop();
+    BOOST_REQUIRE(!host.haveNetwork());
+    BOOST_REQUIRE_THROW(host.start(), NetworkRestartNotSupported);
+}
+
 BOOST_AUTO_TEST_CASE(networkConfig)
 {
     Host save("Test", NetworkConfig(false));

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -171,6 +171,17 @@ BOOST_AUTO_TEST_CASE(saveNodes)
     BOOST_CHECK_EQUAL(host.peerCount(), c_peers);
     BOOST_CHECK_EQUAL(host2.peerCount(), c_peers);
 
+    host.stop();
+
+    // Wait for up to 6 seconds, to give the host time to shut down
+    int const step = 10;
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
+        if (!host.haveNetwork())
+            break;
+    }
+
     bytes firstHostNetwork(host.saveNetwork());
     bytes secondHostNetwork(host.saveNetwork());	
     BOOST_REQUIRE_EQUAL(sha3(firstHostNetwork), sha3(secondHostNetwork));	


### PR DESCRIPTION
Prior to these changes, host shutdown would involve the app thread setting m_run to false and waiting on a condition variable until the timer used to schedule the host's main work loop (Host::run) was destroyed on the network thread. Note that as a part of shutting down the network thread, the node table was destroyed and the boost io service was stopped (in that order). Because the timer was accessed on two threads, it was protected by a mutex. Additionally, because the node table was destroyed before the io service and the node table scheduled discovery round execution via boost deadline timers which used the node table's captured this pointer, the node table could be destroyed while there was an outstanding scheduled execution which would cause a use-after-free.

I've simplified host shutdown by moving io service stoppage to the app thread (Host::stop) and letting the node table and timer be destroyed automatically when the Host instance is destroyed. Since the timer can now only be accessed on the network thread, I've removed the associated mutex. Since the app thread no longer needs to wait while the network thread shuts down, we no longer need the timer condition variable either (m_timerReset).

This should also address the use-after-free since the io service is now stopped before node table is destroyed.