### PR TITLE
Don't start TCP listener without registered capabilities

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -426,8 +426,7 @@ void Host::runAcceptor()
 
     if (m_tcp4Acceptor.is_open() && !m_accepting)
     {
-        cnetdetails << "Listening on local port " << m_listenPort << " (public: " << m_tcpPublic
-                    << ")";
+        cnetdetails << "Listening on local port " << m_listenPort;
         m_accepting = true;
 
         auto socket = make_shared<RLPXSocket>(m_ioService);
@@ -771,18 +770,15 @@ void Host::startedWorking()
         if (port > 0)
         {
             m_listenPort = port;
-            determinePublic();
             runAcceptor();
         }
         else
             LOG(m_logger) << "p2p.start.notice id: " << id() << " TCP Listen port is invalid or unavailable.";
     }
     else
-    {
         m_listenPort = m_netConfig.listenPort;
-        determinePublic();
-    }
 
+    determinePublic();
     auto nodeTable = make_shared<NodeTable>(
         m_ioService,
         m_alias,

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -151,6 +151,11 @@ void Host::stop()
 
 void Host::doneWorking()
 {
+    // Return early if we have no capabilities since there's nothing to do. We've already stopped
+    // the io service and cleared the node table timers which means discovery is no longer running.
+    if (!haveCapabilities())
+        return;
+
     // reset ioservice (cancels all timers and allows manually polling network, below)
     m_ioService.reset();
 
@@ -494,6 +499,11 @@ void Host::registerCapability(std::shared_ptr<CapabilityFace> const& _cap)
 void Host::registerCapability(
     std::shared_ptr<CapabilityFace> const& _cap, std::string const& _name, u256 const& _version)
 {
+    if (haveNetwork())
+    {
+        cwarn << "Capabilities must be registered before the network is started";
+        return;
+    }
     m_capabilities[std::make_pair(_name, _version)] = _cap;
 }
 
@@ -529,6 +539,12 @@ void Host::requirePeer(NodeID const& _n, NodeIPEndpoint const& _endpoint)
     {
         cwarn << "Network not running so node (" << _n << ") with endpoint (" << _endpoint
               << ") cannot be added as a required peer";
+        return;
+    }
+    if (!haveCapabilities())
+    {
+        cwarn << "No capabilities registered so node (" << _n << ") with endpoint (" << _endpoint
+            << ") cannot be added as a required peer";
         return;
     }
 
@@ -590,7 +606,15 @@ void Host::relinquishPeer(NodeID const& _node)
 void Host::connect(std::shared_ptr<Peer> const& _p)
 {
     if (!m_run)
+    {
+        cwarn << "Network not running so cannot connect to peer " << _p->id << "@" << _p->address();
         return;
+    }
+    if (!haveCapabilities())
+    {
+        cwarn << "No capabilities registered so cannot connect to peer " << _p->id << "@" << _p->address();
+        return;
+    }
     
     if (havePeerSession(_p->id))
     {
@@ -740,16 +764,24 @@ void Host::startedWorking()
     for (auto const& h: m_capabilities)
         h.second->onStarting();
     
-    // try to open acceptor (todo: ipv6)
-    int port = Network::tcp4Listen(m_tcp4Acceptor, m_netConfig);
-    if (port > 0)
+    if (haveCapabilities())
     {
-        m_listenPort = port;
-        determinePublic();
-        runAcceptor();
+        // try to open acceptor (todo: ipv6)
+        int port = Network::tcp4Listen(m_tcp4Acceptor, m_netConfig);
+        if (port > 0)
+        {
+            m_listenPort = port;
+            determinePublic();
+            runAcceptor();
+        }
+        else
+            LOG(m_logger) << "p2p.start.notice id: " << id() << " TCP Listen port is invalid or unavailable.";
     }
     else
-        LOG(m_logger) << "p2p.start.notice id: " << id() << " TCP Listen port is invalid or unavailable.";
+    {
+        m_listenPort = m_netConfig.listenPort;
+        determinePublic();
+    }
 
     auto nodeTable = make_shared<NodeTable>(
         m_ioService,
@@ -763,11 +795,14 @@ void Host::startedWorking()
         m_nodeTable = nodeTable;
     restoreNetwork(&m_restoreNetwork);
 
-    LOG(m_logger) << "p2p.started id: " << id();
-
     m_run = true;
-
-    run(boost::system::error_code());
+    if (haveCapabilities())
+    {
+        LOG(m_logger) << "devp2p started. Node id: " << id();
+        run(boost::system::error_code());
+    }
+    else
+        LOG(m_logger) << "No registered capabilities, devp2p not started.";
 }
 
 void Host::doWork()

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -144,6 +144,7 @@ public:
         u256 const& _version);
 
     bool haveCapability(CapDesc const& _name) const { return m_capabilities.count(_name) != 0; }
+    bool haveCapabilities() const { return !caps().empty(); }
     CapDescs caps() const { CapDescs ret; for (auto const& i: m_capabilities) ret.push_back(i.first); return ret; }
 
     /// Add a potential peer.

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -61,7 +61,9 @@ int dev::test::randomNumber(int _min, int _max)
 
 unsigned short dev::test::randomPortNumber(unsigned short _min, unsigned short _max)
 {
-    return static_cast<unsigned short>(randomNumber(_min, _max));
+    static std::mt19937 randomGenerator(utcTime());
+    randomGenerator.seed(std::random_device()());
+    return std::uniform_int_distribution<unsigned short>(_min, _max)(randomGenerator);
 }
 
 Json::Value dev::test::loadJsonFromFile(fs::path const& _path)

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -52,11 +52,16 @@ boost::filesystem::path dev::test::getTestPath()
     return boost::filesystem::path(testPath);
 }
 
-int dev::test::randomNumber()
+int dev::test::randomNumber(int _min, int _max)
 {
     static std::mt19937 randomGenerator(utcTime());
     randomGenerator.seed(std::random_device()());
-    return std::uniform_int_distribution<int>(1)(randomGenerator);
+    return std::uniform_int_distribution<int>(_min, _max)(randomGenerator);
+}
+
+unsigned short dev::test::randomPortNumber(unsigned short _min, unsigned short _max)
+{
+    return static_cast<unsigned short>(randomNumber(_min, _max));
 }
 
 Json::Value dev::test::loadJsonFromFile(fs::path const& _path)

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -1,14 +1,14 @@
 // Aleth: Ethereum C++ client, tools and libraries.
-// Copyright 2018 Aleth Authors.
+// Copyright 2019 Aleth Authors.
 // Licensed under the GNU General Public License, Version 3.
 
-#include <random>
+#include "Common.h"
 #include <libdevcore/CommonData.h>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/FileSystem.h>
 #include <test/tools/libtesteth/Options.h>
-#include "Common.h"
 #include <boost/filesystem.hpp>
+#include <random>
 
 using namespace std;
 using namespace dev;
@@ -17,7 +17,7 @@ namespace fs = boost::filesystem;
 
 namespace
 {
-mt19937 g_randomGenerator(chrono::system_clock::now().time_since_epoch().count());
+mt19937_64 g_randomGenerator(random_device{}());
 }
 
 boost::filesystem::path dev::test::getTestPath()
@@ -42,13 +42,11 @@ boost::filesystem::path dev::test::getTestPath()
 
 int dev::test::randomNumber(int _min, int _max)
 {
-    g_randomGenerator.seed(random_device{}());
     return std::uniform_int_distribution<int>{_min, _max}(g_randomGenerator);
 }
 
 unsigned short dev::test::randomPortNumber(unsigned short _min, unsigned short _max)
 {
-    g_randomGenerator.seed(random_device{}());
     return std::uniform_int_distribution<unsigned short>{_min, _max}(g_randomGenerator);
 }
 

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -1,23 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
- 
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
- 
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
- 
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
- */
-/** @file Common.cpp
- * @author Marek Kotewicz <marek@ethdev.com>
- * @date 2015
- */
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2018 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include <random>
 #include <libdevcore/CommonData.h>

--- a/test/tools/libtestutils/Common.cpp
+++ b/test/tools/libtestutils/Common.cpp
@@ -32,6 +32,11 @@ using namespace dev;
 using namespace dev::test;
 namespace fs = boost::filesystem;
 
+namespace
+{
+mt19937 g_randomGenerator(chrono::system_clock::now().time_since_epoch().count());
+}
+
 boost::filesystem::path dev::test::getTestPath()
 {
     if (!Options::get().testpath.empty())
@@ -54,16 +59,14 @@ boost::filesystem::path dev::test::getTestPath()
 
 int dev::test::randomNumber(int _min, int _max)
 {
-    static std::mt19937 randomGenerator(utcTime());
-    randomGenerator.seed(std::random_device()());
-    return std::uniform_int_distribution<int>(_min, _max)(randomGenerator);
+    g_randomGenerator.seed(random_device{}());
+    return std::uniform_int_distribution<int>{_min, _max}(g_randomGenerator);
 }
 
 unsigned short dev::test::randomPortNumber(unsigned short _min, unsigned short _max)
 {
-    static std::mt19937 randomGenerator(utcTime());
-    randomGenerator.seed(std::random_device()());
-    return std::uniform_int_distribution<unsigned short>(_min, _max)(randomGenerator);
+    g_randomGenerator.seed(random_device{}());
+    return std::uniform_int_distribution<unsigned short>{_min, _max}(g_randomGenerator);
 }
 
 Json::Value dev::test::loadJsonFromFile(fs::path const& _path)

--- a/test/tools/libtestutils/Common.h
+++ b/test/tools/libtestutils/Common.h
@@ -33,7 +33,8 @@ namespace test
 {
 
 boost::filesystem::path getTestPath();
-int randomNumber();
+int randomNumber(int _min = 1, int _max = INT_MAX);
+unsigned short randomPortNumber(unsigned short _min = 1024, unsigned short _max = USHRT_MAX);
 Json::Value loadJsonFromFile(boost::filesystem::path const& _path);
 boost::filesystem::path toTestFilePath(std::string const& _filename);
 boost::filesystem::path getRandomPath();

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -22,14 +22,6 @@ using namespace dev::p2p;
 namespace ba = boost::asio;
 namespace bi = ba::ip;
 
-namespace
-{
-unsigned short getRandomPortNumber(unsigned short _min = 1024, unsigned short _max = 65535)
-{
-    return static_cast<unsigned short>(_min + randomNumber() % (_max + 1));
-}
-}  // namespace
-
 BOOST_AUTO_TEST_SUITE(network)
 
 BOOST_FIXTURE_TEST_SUITE(net, TestOutputHelperFixture)
@@ -68,7 +60,7 @@ struct TestNodeTable: public NodeTable
         for (unsigned i = 0; i < _count; i++)
         {
             KeyPair k = KeyPair::create();
-            ret.push_back(make_pair(k.pub(), getRandomPortNumber()));
+            ret.push_back(make_pair(k.pub(), randomPortNumber()));
         }
 
         return ret;
@@ -287,7 +279,7 @@ struct TestNodeTableHost : public TestHost
 class TestUDPSocketHost : UDPSocketEvents, public TestHost
 {
 public:
-    TestUDPSocketHost(unsigned _port = getRandomPortNumber()) : port(_port)
+    TestUDPSocketHost(unsigned _port = randomPortNumber()) : port(_port)
     {
         // find free port
         while (!socket || !socket->isOpen())
@@ -299,7 +291,7 @@ public:
             }
             catch (std::exception const&)
             {
-                port = getRandomPortNumber();
+                port = randomPortNumber();
             }
         }
     }
@@ -375,7 +367,7 @@ BOOST_AUTO_TEST_CASE(neighboursPacketLength)
 {
     KeyPair k = KeyPair::create();
     std::vector<std::pair<Public, uint16_t>> testNodes(TestNodeTable::createTestNodes(16));
-    bi::udp::endpoint to(boost::asio::ip::address::from_string(c_localhostIp), getRandomPortNumber());
+    bi::udp::endpoint to(boost::asio::ip::address::from_string(c_localhostIp), randomPortNumber());
 
     // hash(32), signature(65), overhead: packetSz(3), type(1), nodeListSz(3), ts(5),
     static unsigned constexpr nlimit = (1280 - 109) / 90; // neighbour: 2 + 65 + 3 + 3 + 17
@@ -403,7 +395,7 @@ BOOST_AUTO_TEST_CASE(neighboursPacket)
 {
     KeyPair k = KeyPair::create();
     std::vector<std::pair<Public, uint16_t>> testNodes(TestNodeTable::createTestNodes(16));
-    bi::udp::endpoint to(boost::asio::ip::address::from_string(c_localhostIp), getRandomPortNumber());
+    bi::udp::endpoint to(boost::asio::ip::address::from_string(c_localhostIp), randomPortNumber());
 
     Neighbours out(to);
     for (auto n: testNodes)
@@ -547,7 +539,7 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeEvictsTheNodeWhenBucketIsFull)
 
     auto leastRecentlySeenNode = nodeTable->bucketFirstNode(bucketIndex);
 
-    auto const port = getRandomPortNumber();
+    auto const port = randomPortNumber();
     nodeTable->addNode(
         Node(newNodeId, NodeIPEndpoint(bi::address::from_string(c_localhostIp), port, port)),
         NodeTable::Known);
@@ -577,7 +569,7 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeReplacesNodeInFullBucketWhenEndpointChanged)
 
     // addNode will replace the node in the m_allNodes map, because it's the same id with enother
     // endpoint
-    auto const port = getRandomPortNumber();
+    auto const port = randomPortNumber();
     NodeIPEndpoint newEndpoint{bi::address::from_string(c_localhostIp), port, port };
     nodeTable->addNode(Node(leastRecentlySeenNodeId, newEndpoint), NodeTable::Known);
 
@@ -910,7 +902,7 @@ BOOST_AUTO_TEST_CASE(evictionWithOldNodeDropped)
 
     // add new node to node table
     // port doesn't matter, it won't be pinged because we're adding it as known
-    auto const port = getRandomPortNumber();
+    auto const port = randomPortNumber();
     auto newNodeEndpoint = NodeIPEndpoint{bi::address::from_string(c_localhostIp), port, port };
     nodeTable->addNode(Node{newNodeId, newNodeEndpoint}, NodeTable::Known);
 
@@ -941,7 +933,7 @@ BOOST_AUTO_TEST_CASE(pingFromLocalhost)
     nodeTable->m_allowLocalDiscovery = false;
 
     // Ping from localhost and verify node isn't added to node table
-    TestUDPSocketHost nodeSocketHost{getRandomPortNumber()};
+    TestUDPSocketHost nodeSocketHost{randomPortNumber()};
     nodeSocketHost.start();
     auto const nodePort = nodeSocketHost.port;
     auto nodeEndpoint = NodeIPEndpoint{bi::address::from_string(c_localhostIp), nodePort, nodePort};
@@ -1152,7 +1144,7 @@ BOOST_AUTO_TEST_CASE(unspecifiedNode)
 BOOST_AUTO_TEST_CASE(nodeTableReturnsUnspecifiedNode)
 {
     ba::io_service io;
-    auto const port = getRandomPortNumber();
+    auto const port = randomPortNumber();
     NodeTable t(io, KeyPair::create(), NodeIPEndpoint(bi::address::from_string(c_localhostIp), port, port));
     if (Node n = t.node(NodeID()))
         BOOST_REQUIRE(false);

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -434,10 +434,8 @@ BOOST_AUTO_TEST_CASE(kademlia)
 
 BOOST_AUTO_TEST_CASE(hostNoCapsNoTcpListener)
 {
-	Host host("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
+	Host host("Test", NetworkConfig(c_localhostIp, randomPortNumber(), false /* upnp */, true /* allow local discovery */));
 	host.start();
-	auto const hostPort = host.listenPort();
-	BOOST_REQUIRE(hostPort);
 
 	// Wait 6 seconds for network to come up
 	uint32_t const step = 10;
@@ -448,7 +446,9 @@ BOOST_AUTO_TEST_CASE(hostNoCapsNoTcpListener)
 			break;
 	}
 
-	BOOST_REQUIRE(host.haveNetwork());
+    BOOST_REQUIRE(host.haveNetwork());
+    auto const hostPort = host.listenPort();
+    BOOST_REQUIRE(hostPort);
 	BOOST_REQUIRE(host.caps().empty());
 
 	{

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -434,42 +434,42 @@ BOOST_AUTO_TEST_CASE(kademlia)
 
 BOOST_AUTO_TEST_CASE(hostNoCapsNoTcpListener)
 {
-	Host host("Test", NetworkConfig(c_localhostIp, randomPortNumber(), false /* upnp */, true /* allow local discovery */));
-	host.start();
+    Host host("Test", NetworkConfig(c_localhostIp, randomPortNumber(), false /* upnp */, true /* allow local discovery */));
+    host.start();
 
-	// Wait 6 seconds for network to come up
-	uint32_t const step = 10;
-	for (unsigned i = 0; i < 6000; i += step)
-	{
-		this_thread::sleep_for(chrono::milliseconds(step));
-		if (host.haveNetwork())
-			break;
-	}
+    // Wait 6 seconds for network to come up
+    uint32_t const step = 10;
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
+        if (host.haveNetwork())
+            break;
+    }
 
     BOOST_REQUIRE(host.haveNetwork());
     auto const hostPort = host.listenPort();
     BOOST_REQUIRE(hostPort);
-	BOOST_REQUIRE(host.caps().empty());
+    BOOST_REQUIRE(host.caps().empty());
 
-	{
-		// Verify no TCP listener on the host port
-		io::io_service ioService;
-		bi::tcp::acceptor tcp4Acceptor{ioService};
-		auto const tcpListenPort = Network::tcp4Listen(tcp4Acceptor, NetworkConfig{ c_localhostIp, hostPort});
-		BOOST_REQUIRE_EQUAL(tcpListenPort, hostPort);
-	}
+    {
+        // Verify no TCP listener on the host port
+        io::io_service ioService;
+        bi::tcp::acceptor tcp4Acceptor{ioService};
+        auto const tcpListenPort = Network::tcp4Listen(tcp4Acceptor, NetworkConfig{ c_localhostIp, hostPort});
+        BOOST_REQUIRE_EQUAL(tcpListenPort, hostPort);
+    }
 
-	// Verify discovery is running - ping the host and verify a response is received
-	TestUDPSocketHost nodeSocketHost;
-	nodeSocketHost.start();
-	auto const sourcePort = nodeSocketHost.port;
-	NodeIPEndpoint sourceEndpoint{ boost::asio::ip::address::from_string(c_localhostIp), sourcePort, sourcePort };
-	NodeIPEndpoint targetEndpoint { boost::asio::ip::address::from_string(c_localhostIp), hostPort, hostPort};
-	PingNode ping(sourceEndpoint, targetEndpoint);
-	ping.sign(KeyPair::create().secret());
-	nodeSocketHost.socket->send(ping);
+    // Verify discovery is running - ping the host and verify a response is received
+    TestUDPSocketHost nodeSocketHost;
+    nodeSocketHost.start();
+    auto const sourcePort = nodeSocketHost.port;
+    NodeIPEndpoint sourceEndpoint{ boost::asio::ip::address::from_string(c_localhostIp), sourcePort, sourcePort };
+    NodeIPEndpoint targetEndpoint { boost::asio::ip::address::from_string(c_localhostIp), hostPort, hostPort};
+    PingNode ping(sourceEndpoint, targetEndpoint);
+    ping.sign(KeyPair::create().secret());
+    nodeSocketHost.socket->send(ping);
 
-	BOOST_REQUIRE_NO_THROW(nodeSocketHost.packetsReceived.pop(chrono::milliseconds(5000)));
+    BOOST_REQUIRE_NO_THROW(nodeSocketHost.packetsReceived.pop(chrono::milliseconds(5000)));
 }
 
 BOOST_AUTO_TEST_CASE(udpOnce)

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -131,6 +131,27 @@ BOOST_AUTO_TEST_CASE(networkConfig)
     BOOST_REQUIRE(save.id() == restore.id());
 }
 
+BOOST_AUTO_TEST_CASE(registerCapabilityAfterNetworkStart)
+{
+    Host host("Test",
+        NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
+    host.start();
+
+    // Wait for up to 6 seconds, to give the hosts time to get their network connection established
+    int const step = 10;
+    for (unsigned i = 0; i < 6000; i += step)
+    {
+        this_thread::sleep_for(chrono::milliseconds(step));
+
+        if (host.haveNetwork())
+            break;
+    }
+    BOOST_REQUIRE(host.haveNetwork());
+    BOOST_REQUIRE(!host.haveCapabilities());
+    host.registerCapability(make_shared<TestCap>());
+    BOOST_REQUIRE(!host.haveCapabilities());
+}
+
 BOOST_AUTO_TEST_CASE(saveNodes)
 {
     std::list<Host*> hosts;

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -142,12 +142,8 @@ BOOST_AUTO_TEST_CASE(saveNodes)
     for (unsigned i = 0; i < c_nodes; ++i)
     {
         Host* h = new Host("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
-<<<<<<< HEAD
-        h->setIdealPeerCount(10);		
-=======
         h->setIdealPeerCount(10);
         h->registerCapability(make_shared<TestCap>());
->>>>>>> 4619d8b2e... Peer test
         h->start(); // starting host is required so listenport is available
         while (!h->haveNetwork())
             this_thread::sleep_for(chrono::milliseconds(c_step));

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -57,19 +57,18 @@ BOOST_FIXTURE_TEST_SUITE(p2p, TestOutputHelperFixture)
 BOOST_AUTO_TEST_CASE(host)
 {
     Host host1("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
+    host1.registerCapability(make_shared<TestCap>());
     host1.start();
     auto host1port = host1.listenPort();
     BOOST_REQUIRE(host1port);
 
     Host host2("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
+    host2.registerCapability(make_shared<TestCap>());
     host2.start();
     auto host2port = host2.listenPort();
     BOOST_REQUIRE(host2port);
     
     BOOST_REQUIRE_NE(host1port, host2port);
-
-    host1.registerCapability(make_shared<TestCap>());
-    host2.registerCapability(make_shared<TestCap>());
 
     auto node2 = host2.id();
     int const step = 10;
@@ -113,7 +112,7 @@ BOOST_AUTO_TEST_CASE(host)
 BOOST_AUTO_TEST_CASE(attemptNetworkRestart)
 {
     Host host("Test",
-        NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
+        NetworkConfig(c_localhostIp, randomPortNumber(), false /* upnp */, true /* allow local discovery */));
     host.start();
     BOOST_REQUIRE(host.listenPort());
     BOOST_REQUIRE(host.haveNetwork());
@@ -236,6 +235,8 @@ BOOST_AUTO_TEST_CASE(requirePeer)
     NetworkConfig prefs2(localhost, 0, false /* upnp */, true /* allow local discovery */);
     Host host1("Test", prefs1);
     Host host2("Test", prefs2);
+    host1.registerCapability(make_shared<TestCap>());
+    host2.registerCapability(make_shared<TestCap>());
     host1.start();
     host2.start();
     auto node2 = host2.id();
@@ -244,9 +245,6 @@ BOOST_AUTO_TEST_CASE(requirePeer)
     BOOST_REQUIRE(port1);
     BOOST_REQUIRE(port2);
     BOOST_REQUIRE_NE(port1, port2);
-
-    host1.registerCapability(make_shared<TestCap>());
-    host2.registerCapability(make_shared<TestCap>());
 
     host1.requirePeer(node2, NodeIPEndpoint(bi::address::from_string(localhost), port2, port2));
 

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -142,7 +142,12 @@ BOOST_AUTO_TEST_CASE(saveNodes)
     for (unsigned i = 0; i < c_nodes; ++i)
     {
         Host* h = new Host("Test", NetworkConfig(c_localhostIp, 0, false /* upnp */, true /* allow local discovery */));
+<<<<<<< HEAD
         h->setIdealPeerCount(10);		
+=======
+        h->setIdealPeerCount(10);
+        h->registerCapability(make_shared<TestCap>());
+>>>>>>> 4619d8b2e... Peer test
         h->start(); // starting host is required so listenport is available
         while (!h->haveNetwork())
             this_thread::sleep_for(chrono::milliseconds(c_step));


### PR DESCRIPTION
Don't start the TCP listener when no capabilities are registered. The purpose of this work is to prevent aleth-bootnode from starting a TCP listener since it only runs discovery (which uses UDP) and doesn't support peer connections. These changes include a new unit test which validates this behavior.

This branch is currently based on my branch for the host shutdown PR - once that's merged I'll rebase. 

Note that these changes add the requirement that capabilities must be registered before the host is started - I think this makes sense since these changes do a capability check to determine if it needs to create a TCP listener. 