### PR TITLE
Better output for endpoint

### DIFF
--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -12,8 +12,6 @@ namespace p2p
 {
 using namespace std;
 
-const unsigned c_protocolVersion = 4;
-
 const NodeIPEndpoint UnspecifiedNodeIPEndpoint = NodeIPEndpoint{{}, 0, 0};
 const Node UnspecifiedNode = Node{{}, UnspecifiedNodeIPEndpoint};
 

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -83,8 +83,8 @@ bool isLocalHostAddress(bi::address const& _addressToCheck)
         {bi::address_v6::from_string("::1")},
         {bi::address_v6::from_string("::")}
     };
-    
-    return find(c_rejectAddresses.begin(), c_rejectAddresses.end(), _addressToCheck) != c_rejectAddresses.end();
+
+    return c_rejectAddresses.find(_addressToCheck) != c_rejectAddresses.end();
 }
 
 bool isLocalHostAddress(std::string const& _addressToCheck)
@@ -144,7 +144,7 @@ void DeadlineOps::reap()
         return;
 
     Guard l(x_timers);
-    std::vector<DeadlineOp>::iterator t = m_timers.begin();
+    auto t = m_timers.begin();
     while (t != m_timers.end())
         if (t->expired())
         {
@@ -180,7 +180,8 @@ NodeSpec::NodeSpec(string const& _user)
     //      enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@52.232.243.152:30305
     //      enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@52.232.243.152:30305?discport=30303
     //      enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@52.232.243.152
-    const char* peerPattern = "^(enode://)([\\dabcdef]{128})@(\\d{1,3}.\\d{1,3}.\\d{1,3}.\\d{1,3})((:\\d{2,5})(\\?discport=(\\d{2,5}))?)?$";
+    const char* peerPattern =
+        R"(^(enode://)([\dabcdef]{128})@(\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})((:\d{2,5})(\?discport=(\d{2,5}))?)?$)";
     regex rx(peerPattern);
     smatch match;
 
@@ -200,7 +201,7 @@ NodeSpec::NodeSpec(string const& _user)
 
 NodeIPEndpoint NodeSpec::nodeIPEndpoint() const
 {
-    return NodeIPEndpoint(Network::resolveHost(m_address).address(), m_udpPort, m_tcpPort);
+    return {Network::resolveHost(m_address).address(), m_udpPort, m_tcpPort};
 }
 
 std::string NodeSpec::enode() const
@@ -214,7 +215,7 @@ std::string NodeSpec::enode() const
         else
             ret += ":" + toString(m_tcpPort);
     }
-   
+
     if (m_id)
         return "enode://" + m_id.hex() + "@" + ret;
     return ret;
@@ -227,7 +228,7 @@ bool NodeSpec::isValid() const
 std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep)
 {
     _out << _ep.address() << ':' << _ep.tcpPort();
-    // It rarely happens that TCP and UDP are different, so safe space
+    // It rarely happens that TCP and UDP are different, so save space
     // and only display the UDP one when different.
     if (_ep.udpPort() != _ep.tcpPort())
         _out << ":udp" << _ep.udpPort();

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -1,54 +1,40 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file Common.cpp
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include "Common.h"
 #include "Network.h"
 #include <regex>
+
+namespace dev
+{
+namespace p2p
+{
 using namespace std;
-using namespace dev;
-using namespace dev::p2p;
 
-const unsigned dev::p2p::c_protocolVersion = 4;
-static_assert(dev::p2p::c_protocolVersion == 4, "Replace v3 compatbility with v4 compatibility before updating network version.");
+const unsigned c_protocolVersion = 4;
+static_assert(c_protocolVersion == 4, "Replace v3 compatbility with v4 compatibility before updating network version.");
 
-const dev::p2p::NodeIPEndpoint dev::p2p::UnspecifiedNodeIPEndpoint = NodeIPEndpoint(bi::address(), 0, 0);
-const dev::p2p::Node dev::p2p::UnspecifiedNode = dev::p2p::Node(NodeID(), UnspecifiedNodeIPEndpoint);
+const NodeIPEndpoint UnspecifiedNodeIPEndpoint = NodeIPEndpoint{{}, 0, 0};
+const Node UnspecifiedNode = Node{{}, UnspecifiedNodeIPEndpoint};
 
-bool p2p::isPublicAddress(std::string const& _addressToCheck)
+bool isPublicAddress(std::string const& _addressToCheck)
 {
     return _addressToCheck.empty() ? false : isPublicAddress(bi::address::from_string(_addressToCheck));
 }
 
-bool p2p::isPublicAddress(bi::address const& _addressToCheck)
+bool isPublicAddress(bi::address const& _addressToCheck)
 {
     return !(isPrivateAddress(_addressToCheck) || isLocalHostAddress(_addressToCheck));
 }
 
-bool p2p::isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck)
+bool isAllowedAddress(bool _allowLocalDiscovery, bi::address const& _addressToCheck)
 {
     return _allowLocalDiscovery ? !_addressToCheck.is_unspecified() :
                                   isPublicAddress(_addressToCheck);
 }
 
-bool p2p::isAllowedEndpoint(bool _allowLocalDiscovery, NodeIPEndpoint const& _endpointToCheck)
+bool isAllowedEndpoint(bool _allowLocalDiscovery, NodeIPEndpoint const& _endpointToCheck)
 {
     return isAllowedAddress(_allowLocalDiscovery, _endpointToCheck.address());
 }
@@ -56,7 +42,7 @@ bool p2p::isAllowedEndpoint(bool _allowLocalDiscovery, NodeIPEndpoint const& _en
 // Helper function to determine if an address falls within one of the reserved ranges
 // For V4:
 // Class A "10.*", Class B "172.[16->31].*", Class C "192.168.*"
-bool p2p::isPrivateAddress(bi::address const& _addressToCheck)
+bool isPrivateAddress(bi::address const& _addressToCheck)
 {
     if (_addressToCheck.is_v4())
     {
@@ -82,13 +68,13 @@ bool p2p::isPrivateAddress(bi::address const& _addressToCheck)
     return false;
 }
 
-bool p2p::isPrivateAddress(std::string const& _addressToCheck)
+bool isPrivateAddress(std::string const& _addressToCheck)
 {
     return _addressToCheck.empty() ? false : isPrivateAddress(bi::address::from_string(_addressToCheck));
 }
 
 // Helper function to determine if an address is localhost
-bool p2p::isLocalHostAddress(bi::address const& _addressToCheck)
+bool isLocalHostAddress(bi::address const& _addressToCheck)
 {
     // @todo: ivp6 link-local adresses (macos), ex: fe80::1%lo0
     static const set<bi::address> c_rejectAddresses = {
@@ -101,12 +87,12 @@ bool p2p::isLocalHostAddress(bi::address const& _addressToCheck)
     return find(c_rejectAddresses.begin(), c_rejectAddresses.end(), _addressToCheck) != c_rejectAddresses.end();
 }
 
-bool p2p::isLocalHostAddress(std::string const& _addressToCheck)
+bool isLocalHostAddress(std::string const& _addressToCheck)
 {
     return _addressToCheck.empty() ? false : isLocalHostAddress(bi::address::from_string(_addressToCheck));
 }
 
-std::string p2p::reasonOf(DisconnectReason _r)
+std::string reasonOf(DisconnectReason _r)
 {
     switch (_r)
     {
@@ -201,7 +187,7 @@ NodeSpec::NodeSpec(string const& _user)
     m_tcpPort = m_udpPort = c_defaultListenPort;
     if (regex_match(_user, match, rx))
     {
-        m_id = p2p::NodeID(match.str(2));
+        m_id = NodeID(match.str(2));
         m_address = match.str(3);
         if (match[5].matched)
         {
@@ -214,7 +200,7 @@ NodeSpec::NodeSpec(string const& _user)
 
 NodeIPEndpoint NodeSpec::nodeIPEndpoint() const
 {
-    return NodeIPEndpoint(p2p::Network::resolveHost(m_address).address(), m_udpPort, m_tcpPort);
+    return NodeIPEndpoint(Network::resolveHost(m_address).address(), m_udpPort, m_tcpPort);
 }
 
 std::string NodeSpec::enode() const
@@ -238,11 +224,6 @@ bool NodeSpec::isValid() const
 {
     return m_id && !m_address.empty();
 }
-
-namespace dev
-{
-namespace p2p
-{
 std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep)
 {
     _out << _ep.address() << ':' << _ep.tcpPort();
@@ -253,5 +234,4 @@ std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep)
     return _out;
 }
 }  // namespace p2p
-}
-
+}  // namespace dev

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -245,7 +245,11 @@ namespace p2p
 {
 std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep)
 {
-    _out << _ep.address() << " UDP " << _ep.udpPort() << " TCP " << _ep.tcpPort();
+    _out << _ep.address() << ':' << _ep.tcpPort();
+    // It rarely happens that TCP and UDP are different, so safe space
+    // and only display the UDP one when different.
+    if (_ep.udpPort() != _ep.tcpPort())
+        _out << ":udp" << _ep.udpPort();
     return _out;
 }
 }  // namespace p2p

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -13,7 +13,6 @@ namespace p2p
 using namespace std;
 
 const unsigned c_protocolVersion = 4;
-static_assert(c_protocolVersion == 4, "Replace v3 compatbility with v4 compatibility before updating network version.");
 
 const NodeIPEndpoint UnspecifiedNodeIPEndpoint = NodeIPEndpoint{{}, 0, 0};
 const Node UnspecifiedNode = Node{{}, UnspecifiedNodeIPEndpoint};

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -19,7 +19,8 @@ const Node UnspecifiedNode = Node{{}, UnspecifiedNodeIPEndpoint};
 
 bool isPublicAddress(std::string const& _addressToCheck)
 {
-    return _addressToCheck.empty() ? false : isPublicAddress(bi::address::from_string(_addressToCheck));
+    return _addressToCheck.empty() ? false :
+                                     isPublicAddress(bi::address::from_string(_addressToCheck));
 }
 
 bool isPublicAddress(bi::address const& _addressToCheck)
@@ -60,8 +61,11 @@ bool isPrivateAddress(bi::address const& _addressToCheck)
         bi::address_v6::bytes_type bytesToCheck = v6Address.to_bytes();
         if (bytesToCheck[0] == 0xfd && bytesToCheck[1] == 0)
             return true;
-        if (!bytesToCheck[0] && !bytesToCheck[1] && !bytesToCheck[2] && !bytesToCheck[3] && !bytesToCheck[4] && !bytesToCheck[5] && !bytesToCheck[6] && !bytesToCheck[7]
-                 && !bytesToCheck[8] && !bytesToCheck[9] && !bytesToCheck[10] && !bytesToCheck[11] && !bytesToCheck[12] && !bytesToCheck[13] && !bytesToCheck[14] && (bytesToCheck[15] == 0 || bytesToCheck[15] == 1))
+        if (!bytesToCheck[0] && !bytesToCheck[1] && !bytesToCheck[2] && !bytesToCheck[3] &&
+            !bytesToCheck[4] && !bytesToCheck[5] && !bytesToCheck[6] && !bytesToCheck[7] &&
+            !bytesToCheck[8] && !bytesToCheck[9] && !bytesToCheck[10] && !bytesToCheck[11] &&
+            !bytesToCheck[12] && !bytesToCheck[13] && !bytesToCheck[14] &&
+            (bytesToCheck[15] == 0 || bytesToCheck[15] == 1))
             return true;
     }
     return false;
@@ -69,7 +73,8 @@ bool isPrivateAddress(bi::address const& _addressToCheck)
 
 bool isPrivateAddress(std::string const& _addressToCheck)
 {
-    return _addressToCheck.empty() ? false : isPrivateAddress(bi::address::from_string(_addressToCheck));
+    return _addressToCheck.empty() ? false :
+                                     isPrivateAddress(bi::address::from_string(_addressToCheck));
 }
 
 // Helper function to determine if an address is localhost
@@ -80,7 +85,7 @@ bool isLocalHostAddress(bi::address const& _addressToCheck)
         {bi::address_v4::from_string(c_localhostIp)},
         {bi::address_v4::from_string("0.0.0.0")},
         {bi::address_v6::from_string("::1")},
-        {bi::address_v6::from_string("::")}
+        {bi::address_v6::from_string("::")},
     };
 
     return c_rejectAddresses.find(_addressToCheck) != c_rejectAddresses.end();
@@ -88,27 +93,42 @@ bool isLocalHostAddress(bi::address const& _addressToCheck)
 
 bool isLocalHostAddress(std::string const& _addressToCheck)
 {
-    return _addressToCheck.empty() ? false : isLocalHostAddress(bi::address::from_string(_addressToCheck));
+    return _addressToCheck.empty() ? false :
+                                     isLocalHostAddress(bi::address::from_string(_addressToCheck));
 }
 
 std::string reasonOf(DisconnectReason _r)
 {
     switch (_r)
     {
-    case DisconnectRequested: return "Disconnect was requested.";
-    case TCPError: return "Low-level TCP communication error.";
-    case BadProtocol: return "Data format error.";
-    case UselessPeer: return "Peer had no use for this node.";
-    case TooManyPeers: return "Peer had too many connections.";
-    case DuplicatePeer: return "Peer was already connected.";
-    case IncompatibleProtocol: return "Peer protocol versions are incompatible.";
-    case NullIdentity: return "Null identity given.";
-    case ClientQuit: return "Peer is exiting.";
-    case UnexpectedIdentity: return "Unexpected identity given.";
-    case LocalIdentity: return "Connected to ourselves.";
-    case UserReason: return "Subprotocol reason.";
-    case NoDisconnect: return "(No disconnect has happened.)";
-    default: return "Unknown reason.";
+    case DisconnectRequested:
+        return "Disconnect was requested.";
+    case TCPError:
+        return "Low-level TCP communication error.";
+    case BadProtocol:
+        return "Data format error.";
+    case UselessPeer:
+        return "Peer had no use for this node.";
+    case TooManyPeers:
+        return "Peer had too many connections.";
+    case DuplicatePeer:
+        return "Peer was already connected.";
+    case IncompatibleProtocol:
+        return "Peer protocol versions are incompatible.";
+    case NullIdentity:
+        return "Null identity given.";
+    case ClientQuit:
+        return "Peer is exiting.";
+    case UnexpectedIdentity:
+        return "Unexpected identity given.";
+    case LocalIdentity:
+        return "Connected to ourselves.";
+    case UserReason:
+        return "Subprotocol reason.";
+    case NoDisconnect:
+        return "(No disconnect has happened.)";
+    default:
+        return "Unknown reason.";
     }
 }
 
@@ -153,23 +173,18 @@ void DeadlineOps::reap()
         else
             t++;
 
-    m_timers.emplace_back(m_io, m_reapIntervalMs, [this](boost::system::error_code const& ec)
-    {
+    m_timers.emplace_back(m_io, m_reapIntervalMs, [this](boost::system::error_code const& ec) {
         if (!ec && !m_stopped)
             reap();
     });
 }
 
-Node::Node(Node const& _original):
-    id(_original.id),
-    endpoint(_original.endpoint),
-    peerType(_original.peerType.load())
+Node::Node(Node const& _original)
+  : id(_original.id), endpoint(_original.endpoint), peerType(_original.peerType.load())
 {}
 
-Node::Node(NodeSpec const& _s, PeerType _p):
-    id(_s.id()),
-    endpoint(_s.nodeIPEndpoint()),
-    peerType(_p)
+Node::Node(NodeSpec const& _s, PeerType _p)
+  : id(_s.id()), endpoint(_s.nodeIPEndpoint()), peerType(_p)
 {}
 
 NodeSpec::NodeSpec(string const& _user)

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -52,7 +52,7 @@ namespace p2p
 {
 
 /// Peer network protocol version.
-extern const unsigned c_protocolVersion;
+constexpr unsigned c_protocolVersion = 4;
 
 class NodeIPEndpoint;
 class Node;


### PR DESCRIPTION
I wanted to create an `operator<<` for `Node`, but ended up with cleaning up the `p2p/Common.cpp` file.

The only functional change is in `operator<<` of the endpoint. Now it looks like
```
DEBUG 02-04 11:57:25 p2p  discov Ping to ##e2bb9f88…@101.80.168.235:30303:udp59556
```
and the `:udp...` part is added only when the port is different from the TCP one.

Some other code uses `?discport=` convention. Still ok to me. I noticed it after the change was done.

I will send the `operator<<` for `Node` in the next PR.