### PR TITLE
Restore network after host marks network as initialized (m_run = true)

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -789,9 +789,9 @@ void Host::startedWorking()
     nodeTable->setEventHandler(new HostNodeTableHandler(*this));
     DEV_GUARDED(x_nodeTable)
         m_nodeTable = nodeTable;
-    restoreNetwork(&m_restoreNetwork);
-
+    
     m_run = true;
+    restoreNetwork(&m_restoreNetwork);
     if (haveCapabilities())
     {
         LOG(m_logger) << "devp2p started. Node id: " << id();


### PR DESCRIPTION
Move the network restore call in `Host::startedWorking` (`Host::restoreNetwork`) to occur after the host marks the network as initialized (`m_run = true`) because the network restore code calls `Host::requirePeer() `which depends on `m_run = true`.