### PR TITLE
Shut down network before saving network config

### DIFF
--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -1,19 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include <thread>
 #include <fstream>

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -1028,17 +1028,20 @@ int main(int argc, char** argv)
         cout << "JSONRPC Admin Session Key: " << jsonAdmin << "\n";
     }
 
-    for (auto const& p: preferredNodes)
-        if (p.second.second)
-            web3.requirePeer(p.first, p.second.first);
-        else
-            web3.addNode(p.first, p.second.first);
+    if (web3.isNetworkStarted())
+    {
+        for (auto const& p: preferredNodes)
+            if (p.second.second)
+                web3.requirePeer(p.first, p.second.first);
+            else
+                web3.addNode(p.first, p.second.first);
 
-    if (bootstrap && privateChain.empty())
-        for (auto const& i: Host::pocHosts())
-            web3.requirePeer(i.first, i.second);
-    if (!remoteHost.empty())
-        web3.addNode(p2p::NodeID(), remoteHost + ":" + toString(remotePort));
+        if (bootstrap && privateChain.empty())
+            for (auto const& i: Host::pocHosts())
+                web3.requirePeer(i.first, i.second);
+        if (!remoteHost.empty())
+            web3.addNode(p2p::NodeID(), remoteHost + ":" + toString(remotePort));
+    }
 
     signal(SIGABRT, &ExitHandler::exitHandler);
     signal(SIGTERM, &ExitHandler::exitHandler);
@@ -1054,8 +1057,12 @@ int main(int argc, char** argv)
     if (jsonrpcIpcServer.get())
         jsonrpcIpcServer->StopListening();
 
-    auto netData = web3.saveNetwork();
-    if (!netData.empty())
-        writeFile(getDataDir() / fs::path("network.rlp"), netData);
+    if (web3.isNetworkStarted())
+    {
+        web3.stopNetwork();
+        auto netData = web3.saveNetwork();
+        if (!netData.empty())
+            writeFile(getDataDir() / fs::path("network.rlp"), netData);
+    }
     return 0;
 }


### PR DESCRIPTION
Fix #5479 

The network must be shut down before the network config is saved - this is done in aleth-bootnode but not in Aleth, which results in a warning on exit and the network config not being saved. Note that this code path isn't hit on Windows due to #5370.


