### PR TITLE
Fix multiple Ping and assertion failure in Discovery

### DIFF
--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -69,6 +69,8 @@ void NodeTable::processEvents()
 
 bool NodeTable::addNode(Node const& _node)
 {
+    LOG(m_logger) << "Adding node " << _node;
+
     shared_ptr<NodeEntry> entry;
     DEV_GUARDED(x_nodes)
     {
@@ -90,6 +92,8 @@ bool NodeTable::addNode(Node const& _node)
 bool NodeTable::addKnownNode(
     Node const& _node, uint32_t _lastPongReceivedTime, uint32_t _lastPongSentTime)
 {
+    LOG(m_logger) << "Adding known node " << _node;
+
     shared_ptr<NodeEntry> entry;
     DEV_GUARDED(x_nodes)
     {
@@ -204,6 +208,8 @@ void NodeTable::doDiscover(NodeID _node, unsigned _round, shared_ptr<set<shared_
             // This prevents being considered invalid node and FindNode being ignored.
             if (!node->hasValidEndpointProof())
             {
+                LOG(m_logger) << "Node " << static_cast<Node const&>(*node)
+                              << " endpoint proof expired.";
                 ping(*node);
                 continue;
             }
@@ -311,6 +317,9 @@ void NodeTable::ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const&
         if (_ec || m_timers.isStopped())
             return;
 
+        if (contains(m_sentPings, _nodeEntry.id))
+            return;
+
         NodeIPEndpoint src;
         src = m_hostNodeEndpoint;
         PingNode p(src, _nodeEntry.endpoint);
@@ -330,6 +339,7 @@ void NodeTable::evict(NodeEntry const& _leastSeen, NodeEntry const& _new)
     if (!m_socket->isOpen())
         return;
 
+    LOG(m_logger) << "Evicting node " << static_cast<Node const&>(_leastSeen);
     ping(_leastSeen, _new.id);
 }
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -317,8 +317,15 @@ void NodeTable::ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const&
         if (_ec || m_timers.isStopped())
             return;
 
-        if (contains(m_sentPings, _nodeEntry.id))
+        // don't sent Ping if one is already sent
+        auto sentPing = m_sentPings.find(_nodeEntry.id);
+        if (sentPing != m_sentPings.end())
+        {
+            // we don't need replacement if we're not going to ping
+            if (_replacementNodeID && sentPing->second.replacementNodeID != _replacementNodeID)
+                DEV_GUARDED(x_nodes) { m_allNodes.erase(*_replacementNodeID); }
             return;
+        }
 
         NodeIPEndpoint src;
         src = m_hostNodeEndpoint;

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -71,20 +71,21 @@ bool NodeTable::addNode(Node const& _node)
 {
     LOG(m_logger) << "Adding node " << _node;
 
-    shared_ptr<NodeEntry> entry;
+    if (!isValidNode(_node))
+        return false;
+
+    bool needToPing = false;
     DEV_GUARDED(x_nodes)
     {
         auto const it = m_allNodes.find(_node.id);
-        if (it == m_allNodes.end())
-            entry = createNodeEntry(_node, 0, 0);
-        else
-            entry = it->second;
+        needToPing = (it == m_allNodes.end() || !it->second->hasValidEndpointProof());
     }
-    if (!entry)
-        return false;
 
-    if (!entry->hasValidEndpointProof())
-        schedulePing(*entry);
+    if (needToPing)
+    {
+        LOG(m_logger) << "Pending " << _node;
+        schedulePing(_node);
+    }
 
     return true;
 }
@@ -94,58 +95,55 @@ bool NodeTable::addKnownNode(
 {
     LOG(m_logger) << "Adding known node " << _node;
 
-    shared_ptr<NodeEntry> entry;
-    DEV_GUARDED(x_nodes)
-    {
-        entry = createNodeEntry(_node, _lastPongReceivedTime, _lastPongSentTime);
-    }
-    if (!entry)
+    if (!isValidNode(_node))
         return false;
 
+    if (nodeEntry(_node.id))
+    {
+        LOG(m_logger) << "Node " << _node << " is already in the node table";
+        return true;
+    }
+
+    auto entry = make_shared<NodeEntry>(
+        m_hostNodeID, _node.id, _node.endpoint, _lastPongReceivedTime, _lastPongSentTime);
+
     if (entry->hasValidEndpointProof())
-        noteActiveNode(entry->id, entry->endpoint);
+    {
+        LOG(m_logger) << "Known " << _node;
+        noteActiveNode(move(entry), entry->endpoint);
+    }
     else
-        schedulePing(*entry);
+    {
+        LOG(m_logger) << "Pending " << _node;
+        schedulePing(_node);
+    }
 
     return true;
 }
 
-std::shared_ptr<NodeEntry> NodeTable::createNodeEntry(
-    Node const& _node, uint32_t _lastPongReceivedTime, uint32_t _lastPongSentTime)
+bool NodeTable::isValidNode(Node const& _node) const
 {
     if (!_node.endpoint || !_node.id)
     {
         LOG(m_logger) << "Supplied node " << _node
                       << " has an invalid endpoint or id. Skipping adding node to node table.";
-        return {};
+        return false;
     }
 
     if (!isAllowedEndpoint(_node.endpoint))
     {
         LOG(m_logger) << "Supplied node" << _node
                       << " doesn't have an allowed endpoint. Skipping adding node to node table";
-        return {};
+        return false;
     }
 
     if (m_hostNodeID == _node.id)
     {
         LOG(m_logger) << "Skip adding self to node table (" << _node.id << ")";
-        return {};
+        return false;
     }
 
-    if (m_allNodes.find(_node.id) != m_allNodes.end())
-    {
-        LOG(m_logger) << "Node " << _node << " is already in the node table";
-        return {};
-    }
-
-    auto nodeEntry = make_shared<NodeEntry>(
-        m_hostNodeID, _node.id, _node.endpoint, _lastPongReceivedTime, _lastPongSentTime);
-    m_allNodes.insert({_node.id, nodeEntry});
-
-    LOG(m_logger) << (_lastPongReceivedTime > 0 ? "Known " : "Pending ") << _node;
-
-    return nodeEntry;
+    return true;
 }
 
 list<NodeID> NodeTable::nodes() const
@@ -184,7 +182,7 @@ Node NodeTable::node(NodeID const& _id)
     return UnspecifiedNode;
 }
 
-shared_ptr<NodeEntry> NodeTable::nodeEntry(NodeID _id)
+shared_ptr<NodeEntry> NodeTable::nodeEntry(NodeID const& _id)
 {
     Guard l(x_nodes);
     auto const it = m_allNodes.find(_id);
@@ -310,118 +308,116 @@ vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID _target)
     return ret;
 }
 
-void NodeTable::ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const& _replacementNodeID)
+void NodeTable::ping(Node const& _node, shared_ptr<NodeEntry> _replacementNodeEntry)
 {
-    // don't sent Ping if one is already sent
-    if (contains(m_sentPings, _nodeEntry.id))
+    // Don't sent Ping if one is already sent
+    if (contains(m_sentPings, _node.id))
         return;
 
     NodeIPEndpoint src;
     src = m_hostNodeEndpoint;
-    PingNode p(src, _nodeEntry.endpoint);
+    PingNode p(src, _node.endpoint);
     p.ts = nextRequestExpirationTime();
     auto const pingHash = p.sign(m_secret);
-    LOG(m_logger) << p.typeName() << " to " << _nodeEntry.id << "@" << p.destination;
+    LOG(m_logger) << p.typeName() << " to " << _node;
     m_socket->send(p);
 
-    m_sentPings[_nodeEntry.id] = {chrono::steady_clock::now(), pingHash, _replacementNodeID};
-    if (m_nodeEventHandler && _replacementNodeID)
-        m_nodeEventHandler->appendEvent(_nodeEntry.id, NodeEntryScheduledForEviction);
+    m_sentPings[_node.id] = {
+        _node.endpoint, chrono::steady_clock::now(), pingHash, move(_replacementNodeEntry)};
 }
 
-void NodeTable::schedulePing(NodeEntry const& _nodeEntry)
+void NodeTable::schedulePing(Node const& _node)
 {
-    m_timers.schedule(0, [this, _nodeEntry](boost::system::error_code const& _ec) {
+    m_timers.schedule(0, [this, _node](boost::system::error_code const& _ec) {
         if (_ec || m_timers.isStopped())
             return;
 
-        ping(_nodeEntry, {});
+        ping(_node, {});
     });
 }
 
-void NodeTable::evict(NodeEntry const& _leastSeen, NodeEntry const& _new)
+void NodeTable::evict(NodeEntry const& _leastSeen, shared_ptr<NodeEntry> _replacement)
 {
     if (!m_socket->isOpen())
         return;
 
-    // if eviction for _leastSeen already started, just forget about _new
-    auto sentPing = m_sentPings.find(_leastSeen.id);
-    if (sentPing != m_sentPings.end() && sentPing->second.replacementNodeID != _new.id)
-    {
-        DEV_GUARDED(x_nodes) { m_allNodes.erase(_new.id); }
-        return;
-    }
-
     LOG(m_logger) << "Evicting node " << static_cast<Node const&>(_leastSeen);
-    ping(_leastSeen, _new.id);
+    ping(_leastSeen, std::move(_replacement));
+
+    if (m_nodeEventHandler)
+        m_nodeEventHandler->appendEvent(_leastSeen.id, NodeEntryScheduledForEviction);
 }
 
-void NodeTable::noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint)
+void NodeTable::noteActiveNode(shared_ptr<NodeEntry> _nodeEntry, bi::udp::endpoint const& _endpoint)
 {
-    if (_pubk == m_hostNodeID)
+    assert(_nodeEntry);
+
+    if (_nodeEntry->id == m_hostNodeID)
     {
         LOG(m_logger) << "Skipping making self active.";
         return;
     }
     if (!isAllowedEndpoint(NodeIPEndpoint(_endpoint.address(), _endpoint.port(), _endpoint.port())))
     {
-        LOG(m_logger) << "Skipping making node with unallowed endpoint active. Node " << _pubk
-                      << "@" << _endpoint;
+        LOG(m_logger) << "Skipping making node with unallowed endpoint active. Node "
+                      << _nodeEntry->id << "@" << _endpoint;
         return;
     }
 
-    shared_ptr<NodeEntry> newNode = nodeEntry(_pubk);
-    if (newNode && newNode->hasValidEndpointProof())
+    if (!_nodeEntry->hasValidEndpointProof())
+        return;
+
+    LOG(m_logger) << "Active node " << _nodeEntry->id << '@' << _endpoint;
+    // TODO don't activate in case endpoint has changed
+    _nodeEntry->endpoint.setAddress(_endpoint.address());
+    _nodeEntry->endpoint.setUdpPort(_endpoint.port());
+
+
+    shared_ptr<NodeEntry> nodeToEvict;
     {
-        LOG(m_logger) << "Active node " << _pubk << '@' << _endpoint;
-        newNode->endpoint.setAddress(_endpoint.address());
-        newNode->endpoint.setUdpPort(_endpoint.port());
+        Guard l(x_state);
+        // Find a bucket to put a node to
+        NodeBucket& s = bucket_UNSAFE(_nodeEntry.get());
+        auto& nodes = s.nodes;
 
-
-        shared_ptr<NodeEntry> nodeToEvict;
+        // check if the node is already in the bucket
+        auto it = std::find(nodes.begin(), nodes.end(), _nodeEntry);
+        if (it != nodes.end())
         {
-            Guard l(x_state);
-            // Find a bucket to put a node to
-            NodeBucket& s = bucket_UNSAFE(newNode.get());
-            auto& nodes = s.nodes;
-
-            // check if the node is already in the bucket
-            auto it = std::find(nodes.begin(), nodes.end(), newNode);
-            if (it != nodes.end())
+            // if it was in the bucket, move it to the last position
+            nodes.splice(nodes.end(), nodes, it);
+        }
+        else
+        {
+            if (nodes.size() < s_bucketSize)
             {
-                // if it was in the bucket, move it to the last position
-                nodes.splice(nodes.end(), nodes, it);
+                // if it was not there, just add it as a most recently seen node
+                // (i.e. to the end of the list)
+                nodes.push_back(_nodeEntry);
+                DEV_GUARDED(x_nodes) { m_allNodes.insert({_nodeEntry->id, _nodeEntry}); }
+                if (m_nodeEventHandler)
+                    m_nodeEventHandler->appendEvent(_nodeEntry->id, NodeEntryAdded);
             }
             else
             {
-                if (nodes.size() < s_bucketSize)
+                // if bucket is full, start eviction process for the least recently seen node
+                nodeToEvict = nodes.front().lock();
+                // It could have been replaced in addNode(), then weak_ptr is expired.
+                // If so, just add a new one instead of expired
+                if (!nodeToEvict)
                 {
-                    // if it was not there, just add it as a most recently seen node
-                    // (i.e. to the end of the list)
-                    nodes.push_back(newNode);
+                    nodes.pop_front();
+                    nodes.push_back(_nodeEntry);
+                    DEV_GUARDED(x_nodes) { m_allNodes.insert({_nodeEntry->id, _nodeEntry}); }
                     if (m_nodeEventHandler)
-                        m_nodeEventHandler->appendEvent(newNode->id, NodeEntryAdded);
-                }
-                else
-                {
-                    // if bucket is full, start eviction process for the least recently seen node
-                    nodeToEvict = nodes.front().lock();
-                    // It could have been replaced in addNode(), then weak_ptr is expired.
-                    // If so, just add a new one instead of expired
-                    if (!nodeToEvict)
-                    {
-                        nodes.pop_front();
-                        nodes.push_back(newNode);
-                        if (m_nodeEventHandler)
-                            m_nodeEventHandler->appendEvent(newNode->id, NodeEntryAdded);
-                    }
+                        m_nodeEventHandler->appendEvent(_nodeEntry->id, NodeEntryAdded);
                 }
             }
         }
-
-        if (nodeToEvict)
-            evict(*nodeToEvict, *newNode);
     }
+
+    if (nodeToEvict)
+        evict(*nodeToEvict, _nodeEntry);
 }
 
 void NodeTable::dropNode(shared_ptr<NodeEntry> _n)
@@ -462,6 +458,8 @@ void NodeTable::onPacketReceived(
         }
 
         LOG(m_logger) << packet->typeName() << " from " << packet->sourceid << "@" << _from;
+
+        shared_ptr<NodeEntry> sourceNodeEntry;
         switch (packet->packetType())
         {
             case Pong::type:
@@ -485,19 +483,20 @@ void NodeTable::onPacketReceived(
                     return;
                 }
 
-                auto const sourceNodeEntry = nodeEntry(sourceId);
-                assert(sourceNodeEntry);
-                sourceNodeEntry->lastPongReceivedTime = RLPXDatagramFace::secondsSinceEpoch();
-
-                // Valid PONG received, so we don't want to evict this node,
-                // and we don't need to remember replacement node anymore
-                auto const& optionalReplacementID = sentPing->second.replacementNodeID;
-                if (optionalReplacementID)
-                    if (auto replacementNode = nodeEntry(*optionalReplacementID))
+                // create or update nodeEntry with new Pong received time
+                DEV_GUARDED(x_nodes)
+                {
+                    auto it = m_allNodes.find(sourceId);
+                    if (it == m_allNodes.end())
+                        sourceNodeEntry = make_shared<NodeEntry>(m_hostNodeID, sourceId,
+                            sentPing->second.endpoint, RLPXDatagramFace::secondsSinceEpoch(), 0);
+                    else
                     {
-                        m_sentPings.erase(replacementNode->id);
-                        dropNode(move(replacementNode));
+                        sourceNodeEntry = it->second;
+                        sourceNodeEntry->lastPongReceivedTime =
+                            RLPXDatagramFace::secondsSinceEpoch();
                     }
+                }
 
                 m_sentPings.erase(sentPing);
 
@@ -514,7 +513,16 @@ void NodeTable::onPacketReceived(
 
             case Neighbours::type:
             {
+                sourceNodeEntry = nodeEntry(packet->sourceid);
+                if (!sourceNodeEntry)
+                {
+                    LOG(m_logger) << "Source node (" << packet->sourceid << "@" << _from
+                                  << ") not found in node table. Ignoring Neighbours packet.";
+                    return;
+                }
+
                 auto const& in = dynamic_cast<Neighbours const&>(*packet);
+
                 bool expected = false;
                 auto now = chrono::steady_clock::now();
                 m_sentFindNodes.remove_if([&](NodeIdTimePoint const& _t) noexcept {
@@ -538,7 +546,7 @@ void NodeTable::onPacketReceived(
 
             case FindNode::type:
             {
-                auto const& sourceNodeEntry = nodeEntry(packet->sourceid);
+                sourceNodeEntry = nodeEntry(packet->sourceid);
                 if (!sourceNodeEntry)
                 {
                     LOG(m_logger) << "Source node (" << packet->sourceid << "@" << _from
@@ -588,17 +596,20 @@ void NodeTable::onPacketReceived(
                 p.sign(m_secret);
                 m_socket->send(p);
 
-                DEV_GUARDED(x_nodes)
-                {
-                    auto const it = m_allNodes.find(in.sourceid);
-                    if (it != m_allNodes.end())
-                        it->second->lastPongSentTime = RLPXDatagramFace::secondsSinceEpoch();
-                }
+                // Quirk: when the node is a replacement node (that is, not added to the node table
+                // yet, but can be added after another node's eviction), it will not be returned
+                // from nodeEntry() and we won't update its lastPongSentTime. But that shouldn't be
+                // a big problem, at worst it can lead to more Ping-Pongs than needed.
+                sourceNodeEntry = nodeEntry(packet->sourceid);
+                if (sourceNodeEntry)
+                    sourceNodeEntry->lastPongSentTime = RLPXDatagramFace::secondsSinceEpoch();
+
                 break;
             }
         }
 
-        noteActiveNode(packet->sourceid, _from);
+        if (sourceNodeEntry)
+            noteActiveNode(move(sourceNodeEntry), _from);
     }
     catch (std::exception const& _e)
     {
@@ -650,10 +661,8 @@ void NodeTable::doHandleTimeouts()
                     dropNode(move(node));
 
                     // save the replacement node that should be activated
-                    if (it->second.replacementNodeID)
-                        if (auto replacement = nodeEntry(*it->second.replacementNodeID))
-                            nodesToActivate.emplace_back(replacement);
-
+                    if (it->second.replacementNodeEntry)
+                        nodesToActivate.emplace_back(move(it->second.replacementNodeEntry));
                 }
 
                 it = m_sentPings.erase(it);
@@ -664,7 +673,7 @@ void NodeTable::doHandleTimeouts()
 
         // activate replacement nodes and put them into buckets
         for (auto const& n : nodesToActivate)
-            noteActiveNode(n->id, n->endpoint);
+            noteActiveNode(n, n->endpoint);
 
         doHandleTimeouts();
     });

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -110,7 +110,7 @@ bool NodeTable::addKnownNode(
     if (entry->hasValidEndpointProof())
     {
         LOG(m_logger) << "Known " << _node;
-        noteActiveNode(move(entry), entry->endpoint);
+        noteActiveNode(move(entry), _node.endpoint);
     }
     else
     {

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -312,11 +312,12 @@ void NodeTable::ping(Node const& _node, shared_ptr<NodeEntry> _replacementNodeEn
 {
     // Don't sent Ping if one is already sent
     if (contains(m_sentPings, _node.id))
+    {
+        LOG(m_logger) << "Ignoring request to ping " << _node << ", because it's already pinged";
         return;
+    }
 
-    NodeIPEndpoint src;
-    src = m_hostNodeEndpoint;
-    PingNode p(src, _node.endpoint);
+    PingNode p{m_hostNodeEndpoint, _node.endpoint};
     p.ts = nextRequestExpirationTime();
     auto const pingHash = p.sign(m_secret);
     LOG(m_logger) << p.typeName() << " to " << _node;

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -205,8 +205,12 @@ protected:
 
     /// Used to ping a node to initiate the endpoint proof. Used when contacting neighbours if they
     /// don't have a valid endpoint proof (see doDiscover), refreshing buckets and as part of
-    /// eviction process (see evict). Not synchronous - the ping operation is queued via a timer
+    /// eviction process (see evict). Synchronous, has to be called only from the network thread.
     void ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const& _replacementNodeID = {});
+
+    /// Schedules ping() method to be called from the network thread.
+    /// Not synchronous - the ping operation is queued via a timer.
+    void schedulePing(NodeEntry const& _nodeEntry);
 
     /// Used by asynchronous operations to return NodeEntry which is active and managed by node table.
     std::shared_ptr<NodeEntry> nodeEntry(NodeID _id);

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -126,10 +126,10 @@ public:
     /// Called by implementation which provided handler to process NodeEntryAdded/NodeEntryDropped events. Events are coalesced by type whereby old events are ignored.
     void processEvents();
 
-    /// Starts async node adding tot the node table by pinging it to trigger the endpoint proof.
+    /// Starts async node add to the node table by pinging it to trigger the endpoint proof.
     /// In case the node is already in the node table, pings only if the endpoint proof expired.
     ///
-    /// @return True if the node id valid.
+    /// @return True if the node is valid.
     bool addNode(Node const& _node);
 
     /// Add node to the list of all nodes and add it to the node table.

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -126,14 +126,17 @@ public:
     /// Called by implementation which provided handler to process NodeEntryAdded/NodeEntryDropped events. Events are coalesced by type whereby old events are ignored.
     void processEvents();
 
-    /// Add node to the list of all nodes and ping it to trigger the endpoint proof.
+    /// Starts async node adding tot the node table by pinging it to trigger the endpoint proof.
+    /// In case the node is already in the node table, pings only if the endpoint proof expired.
     ///
-    /// @return True if the node has been added.
+    /// @return True if the node id valid.
     bool addNode(Node const& _node);
 
     /// Add node to the list of all nodes and add it to the node table.
+    /// In case the node's endpoint proof expired, pings it.
+    /// In case the nodes is already in the node table, ignores add request.
     ///
-    /// @return True if the node has been added to the table.
+    /// @return True if the node is valid.
     bool addKnownNode(
         Node const& _node, uint32_t _lastPongReceivedTime, uint32_t _lastPongSentTime);
 
@@ -163,14 +166,15 @@ public:
 // protected only for derived classes in tests
 protected:
     /**
-     * NodeValidation is used to record the timepoint of sent PING,
+     * NodeValidation is used to record Pinged node's endpoint, the timepoint of sent PING,
      * time of sending and the new node ID to replace unresponsive node.
      */
     struct NodeValidation
     {
+        NodeIPEndpoint endpoint;
         TimePoint pingSendTime;
         h256 pingHash;
-        boost::optional<NodeID> replacementNodeID;
+        std::shared_ptr<NodeEntry> replacementNodeEntry;
     };
 
     /// Constants for Kademlia, derived from address space.
@@ -200,20 +204,21 @@ protected:
         std::list<std::weak_ptr<NodeEntry>> nodes;
     };
 
-    std::shared_ptr<NodeEntry> createNodeEntry(
-        Node const& _node, uint32_t _lastPongReceivedTime, uint32_t _lastPongSentTime);
+    /// @return true if the node is valid to be added to the node table.
+    /// (validates node ID and endpoint)
+    bool isValidNode(Node const& _node) const;
 
     /// Used to ping a node to initiate the endpoint proof. Used when contacting neighbours if they
     /// don't have a valid endpoint proof (see doDiscover), refreshing buckets and as part of
     /// eviction process (see evict). Synchronous, has to be called only from the network thread.
-    void ping(NodeEntry const& _nodeEntry, boost::optional<NodeID> const& _replacementNodeID = {});
+    void ping(Node const& _node, std::shared_ptr<NodeEntry> _replacementNodeEntry = {});
 
     /// Schedules ping() method to be called from the network thread.
     /// Not synchronous - the ping operation is queued via a timer.
-    void schedulePing(NodeEntry const& _nodeEntry);
+    void schedulePing(Node const& _node);
 
     /// Used by asynchronous operations to return NodeEntry which is active and managed by node table.
-    std::shared_ptr<NodeEntry> nodeEntry(NodeID _id);
+    std::shared_ptr<NodeEntry> nodeEntry(NodeID const& _id);
 
     /// Used to discovery nodes on network which are close to the given target.
     /// Sends s_alpha concurrent requests to nodes nearest to target, for nodes nearest to target, up to s_maxSteps rounds.
@@ -222,12 +227,13 @@ protected:
     /// Returns nodes from node table which are closest to target.
     std::vector<std::shared_ptr<NodeEntry>> nearestNodeEntries(NodeID _target);
 
-    /// Asynchronously drops _leastSeen node if it doesn't reply and adds _new node, otherwise _new node is thrown away.
-    void evict(NodeEntry const& _leastSeen, NodeEntry const& _new);
+    /// Asynchronously drops _leastSeen node if it doesn't reply and adds _replacement node,
+    /// otherwise _replacement is thrown away.
+    void evict(NodeEntry const& _leastSeen, std::shared_ptr<NodeEntry> _replacement);
 
     /// Called whenever activity is received from a node in order to maintain node table. Only
     /// called for nodes for which we've completed an endpoint proof.
-    void noteActiveNode(Public const& _pubk, bi::udp::endpoint const& _endpoint);
+    void noteActiveNode(std::shared_ptr<NodeEntry> _nodeEntry, bi::udp::endpoint const& _endpoint);
 
     /// Used to drop node when timeout occurs or when evict() result is to keep previous node.
     void dropNode(std::shared_ptr<NodeEntry> _n);
@@ -277,9 +283,8 @@ protected:
 
     mutable Mutex x_nodes;											///< LOCK x_state first if both locks are required. Mutable for thread-safe copy in nodes() const.
 
-    /// Node endpoints. Includes all nodes that we've been in contact with and which haven't been
-    /// evicted. This includes nodes for which we both have and haven't completed the endpoint
-    /// proof.
+    /// Node endpoints. Includes all nodes that were added into node table's buckets
+    /// and have not been evicted yet.
     std::unordered_map<NodeID, std::shared_ptr<NodeEntry>> m_allNodes;
 
     mutable Mutex x_state;											///< LOCK x_state first if both x_nodes and x_state locks are required.


### PR DESCRIPTION
Addresses https://github.com/ethereum/aleth/issues/5471 and probably some things from https://github.com/ethereum/aleth/issues/5484

Summary of changes:

- checking whether we've already sent one `Ping` (by looking at `m_sentPings`) before sending another one
- `ping` method is split into `ping` and `schedulePing` - when we are already in the network thread, we can just directly access `m_sentPings` without additional `m_timers.schedule(0, ...)`. So now when we need to ping from the network thread we just call `ping` method without scheduling
- `m_allNodes` now contains only the nodes from the node table buckets. 
- So the nodes that are still pending (`Pong` not received yet) and the nodes that didn't fit into the bucket, and wait for older node to be evicted, are not put into `m_allNodes`
- Nodes are added to `m_allNodes` only in `noteActiveNode` together with being put into the bucket.
This allows us not to care about erasing from `m_allNodes` the nodes that didn't get validated or are being thrown away when eviction ends with the old node answering.
(maybe `m_allNodes` should be renamed now)
- replacement nodes are remembered only in the `m_sentPings` items (as a `shared_ptr<NodeEntry> replacementNodeEntry` member). They are dropped when we erase from `m_sentPings` in `Pong` handler.
- we have to save node's `NodeIPEndpoint` in `m_sentPings` now, because this data is sent to us in `Ping` (or in `Neighbours`) and when we receive it from an unnknown node, we have to save it somewhere until the moment when we'll add it to the node table and to the `m_allNodes`.
(actually I think it's only TCP port number that is important to save, the rest is overwritten from the actual source of UDP packet anyway. But I expect this part to be changed somewhat when addressing the problem described in https://github.com/ethereum/aleth/issues/5455#issuecomment-460754175
I expect `m_sentPings` to have in the future the UDP endpoint as a map key instead of `NodeID`)