### PR TITLE
Update Aleth tools to return error codes

### DIFF
--- a/aleth-bootnode/main.cpp
+++ b/aleth-bootnode/main.cpp
@@ -17,6 +17,7 @@
 
 #include <libdevcore/FileSystem.h>
 #include <libdevcore/LoggingProgramOptions.h>
+#include <libethcore/Common.h>
 #include <libp2p/Host.h>
 #include <boost/program_options.hpp>
 #include <boost/program_options/options_description.hpp>
@@ -28,6 +29,7 @@ namespace fs = boost::filesystem;
 
 using namespace dev;
 using namespace dev::p2p;
+using namespace dev::eth;
 using namespace std;
 
 namespace
@@ -77,7 +79,7 @@ int main(int argc, char** argv)
     catch (po::error const& e)
     {
         cout << e.what() << "\n";
-        return -1;
+        return AlethErrors::ArgumentProcessingFailure;
     }
 
     if (vm.count("help"))
@@ -87,7 +89,7 @@ int main(int argc, char** argv)
              << "USAGE:\n"
              << "   " << c_programName << " [options]\n\n";
         cout << generalOptions << clientNetworking << loggingProgramOptions;
-        return 0;
+        return AlethErrors::Success;
     }
 
     /// Networking params.
@@ -149,5 +151,5 @@ int main(int argc, char** argv)
     if (!netData.empty())
         writeFile(getDataDir() / fs::path(c_networkConfigFileName), &netData);
 
-    return 0;
+    return AlethErrors::Success;
 }

--- a/aleth-key/main.cpp
+++ b/aleth-key/main.cpp
@@ -1,23 +1,12 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include "KeyAux.h"
 
 #include <libdevcore/FileSystem.h>
 #include <libdevcore/LoggingProgramOptions.h>
+#include <libethcore/Common.h>
 #include <libethcore/KeyManager.h>
 
 #include <aleth/buildinfo.h>
@@ -40,7 +29,7 @@ void version()
     const auto* buildinfo = aleth_get_buildinfo();
     cout << "aleth-key " << buildinfo->project_version << "\nBuild: " << buildinfo->system_name << "/"
          << buildinfo->build_type << endl;
-    exit(0);
+    exit(AlethErrors::Success);
 }
 
 int main(int argc, char** argv)
@@ -73,14 +62,14 @@ int main(int argc, char** argv)
     catch (po::error const& e)
     {
         cerr << e.what();
-        return -1;
+        return AlethErrors::ArgumentProcessingFailure;
     }
 
     for (size_t i = 0; i < unrecognisedOptions.size(); ++i)
         if (!m.interpretOption(i, unrecognisedOptions))
         {
             cerr << "Invalid argument: " << unrecognisedOptions[i] << endl;
-            return -1;
+            return AlethErrors::ArgumentProcessingFailure;
         }
 
     if (vm.count("help"))
@@ -90,7 +79,7 @@ int main(int argc, char** argv)
             << "Options:" << endl << endl;
         KeyCLI::streamHelp(cout);
         cout << allowedOptions;
-        return 0;
+        return AlethErrors::Success;
     }
     if (vm.count("version"))
         version();
@@ -99,5 +88,5 @@ int main(int argc, char** argv)
 
     m.execute();
 
-    return 0;
+    return AlethErrors::Success;
 }

--- a/aleth-vm/main.cpp
+++ b/aleth-vm/main.cpp
@@ -1,28 +1,13 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/// @file
-/// EVM Execution tool.
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/LoggingProgramOptions.h>
 #include <libdevcore/SHA3.h>
 #include <libethashseal/Ethash.h>
 #include <libethashseal/GenesisInfo.h>
+#include <libethcore/Common.h>
 #include <libethcore/SealEngine.h>
 #include <libethereum/Block.h>
 #include <libethereum/ChainParams.h>
@@ -58,7 +43,7 @@ void version()
     const auto* buildinfo = aleth_get_buildinfo();
     cout << "aleth-vm " << buildinfo->project_version << "\n";
     cout << "Build: " << buildinfo->system_name << "/" << buildinfo->build_type << "\n";
-    exit(0);
+    exit(AlethErrors::Success);
 }
 
 enum class Mode
@@ -191,13 +176,13 @@ int main(int argc, char** argv)
         else
         {
             cerr << "Unknown argument: " << arg << '\n';
-            return -1;
+            return AlethErrors::UnknownArgument;
         }
     }
     if (vm.count("help"))
     {
         cout << allowedOptions;
-        return 0;
+        return AlethErrors::Success;
     }
     if (vm.count("version"))
     {
@@ -243,7 +228,7 @@ int main(int argc, char** argv)
         else
         {
             cerr << "Unknown network type: " << network << "\n";
-            return -1;
+            return AlethErrors::UnknownNetworkType;
         }
     }
     if (vm.count("input"))
@@ -377,5 +362,5 @@ int main(int argc, char** argv)
              << '\n';
         cout << "exec time: " << fixed << setprecision(6) << execTime << '\n';
     }
-    return 0;
+    return AlethErrors::Success;
 }

--- a/libethcore/Common.h
+++ b/libethcore/Common.h
@@ -1,25 +1,6 @@
-/*
-	This file is part of cpp-ethereum.
-
-	cpp-ethereum is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
-
-	cpp-ethereum is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
-
-	You should have received a copy of the GNU General Public License
-	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file Common.h
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- *
- * Ethereum-specific data structures & algorithms.
- */
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #pragma once
 
@@ -236,5 +217,34 @@ enum class IfDropped
 	Retry 	///< Import transaction even if it was dropped before.
 };
 
+/// Errors returned from main
+enum AlethErrors
+{
+    Success = 0,
+    UnrecognizedPeerset,
+    ArgumentProcessingFailure,
+    UnknownArgument,
+    UnknownMiningOption,
+    ConfigFileEmptyOrNotFound,
+    UnknownNetworkType,
+    BadNetworkIdOption,
+    BadConfigOption,
+    BadExtraDataOption,
+    BadAskOption,
+    BadBidOption,
+    BadFormatOption,
+    BadUpnpOption,
+    BadPrivateOption,
+    BadAddressOption,
+    BadHexValueInAddressOption,
+    BadBlockNumberHashOption,
+    KeyManagerInitializationFailure,
+    SnapshotImportFailure,
+    NetworkStartFailure,
+    BadRlp,
+    RlpDataNotAList,
+    UnsupportedJsonType,
+    InvalidJson
+};
 }
 }


### PR DESCRIPTION
Prior to these changes the various Aleth tools (e.g. aleth, aleth-bootnode, aleth-vm) would return -1 on error. These changes define a new error enum (AlethError) with error codes for the various error conditions and update the various tools to return these codes.