### PR TITLE
Rename network timers and log NodeEntry using ostream operator

### DIFF
--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -163,7 +163,9 @@ void Host::doneWorking()
     m_ioService.reset();
 
     DEV_GUARDED(x_networkTimers)
-    m_networkTimers.clear();
+    {
+        m_networkTimers.clear();
+    }
 
     // shutdown acceptor
     m_tcp4Acceptor.cancel();
@@ -683,9 +685,11 @@ void Host::run(boost::system::error_code const& _ec)
     DEV_GUARDED(x_connecting)
         m_connecting.remove_if([](weak_ptr<RLPXHandshake> h){ return h.expired(); });
     DEV_GUARDED(x_networkTimers)
-    m_networkTimers.remove_if([](unique_ptr<io::deadline_timer> const& t) {
-        return t->expires_from_now().total_milliseconds() < 0;
-    });
+    {
+        m_networkTimers.remove_if([](unique_ptr<io::deadline_timer> const& t) {
+            return t->expires_from_now().total_milliseconds() < 0;
+        });
+    }
 
     keepAlivePeers();
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -31,6 +31,9 @@ constexpr chrono::seconds c_keepAliveInterval = chrono::seconds(30);
 
 /// Disconnect timeout after failure to respond to keepAlivePeers ping.
 constexpr chrono::seconds c_keepAliveTimeOut = chrono::seconds(1);
+
+/// Interval which m_runTimer is run when network is connected.
+constexpr unsigned int c_runTimerIntervalMs = 100;
 }  // namespace
 
 HostNodeTableHandler::HostNodeTableHandler(Host& _host): m_host(_host) {}
@@ -87,7 +90,7 @@ Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkConfig co
     m_ioService(2),  // concurrency hint, suggests how many threads it should allow to run
                      // simultaneously
     m_tcp4Acceptor(m_ioService),
-    m_timer(m_ioService),
+    m_runTimer(m_ioService),
     m_alias(_alias),
     m_lastPing(chrono::steady_clock::time_point::min()),
     m_capabilityHost(createCapabilityHost(*this))
@@ -159,9 +162,9 @@ void Host::doneWorking()
     // reset ioservice (cancels all timers and allows manually polling network, below)
     m_ioService.reset();
 
-    DEV_GUARDED(x_timers)
-        m_timers.clear();
-    
+    DEV_GUARDED(x_networkTimers)
+    m_networkTimers.clear();
+
     // shutdown acceptor
     m_tcp4Acceptor.cancel();
     if (m_tcp4Acceptor.is_open())
@@ -672,37 +675,39 @@ void Host::run(boost::system::error_code const& _ec)
     if (!m_run || _ec)
         return;
 
-    if (auto nodeTable = this->nodeTable()) // This again requires x_nodeTable, which is why an additional variable nodeTable is used.
+    // This again requires x_nodeTable, which is why an additional variable nodeTable is used.
+    if (auto nodeTable = this->nodeTable())
         nodeTable->processEvents();
 
     // cleanup zombies
     DEV_GUARDED(x_connecting)
         m_connecting.remove_if([](weak_ptr<RLPXHandshake> h){ return h.expired(); });
-    DEV_GUARDED(x_timers)
-    m_timers.remove_if([](unique_ptr<io::deadline_timer> const& t) {
+    DEV_GUARDED(x_networkTimers)
+    m_networkTimers.remove_if([](unique_ptr<io::deadline_timer> const& t) {
         return t->expires_from_now().total_milliseconds() < 0;
     });
 
     keepAlivePeers();
-    
+
     // At this time peers will be disconnected based on natural TCP timeout.
     // disconnectLatePeers needs to be updated for the assumption that Session
     // is always live and to ensure reputation and fallback timers are properly
     // updated. // disconnectLatePeers();
 
     // todo: update peerSlotsAvailable()
-    
+
     list<shared_ptr<Peer>> toConnect;
     unsigned reqConn = 0;
     {
         RecursiveGuard l(x_sessions);
-        for (auto const& p: m_peers)
+        for (auto const& p : m_peers)
         {
             bool haveSession = havePeerSession(p.second->id);
             bool required = p.second->peerType == PeerType::Required;
             if (haveSession && required)
                 reqConn++;
-            else if (!haveSession && p.second->shouldReconnect() && (!m_netConfig.pin || required))
+            else if (!haveSession && p.second->shouldReconnect() &&
+                        (!m_netConfig.pin || required))
                 toConnect.push_back(p.second);
         }
     }
@@ -730,8 +735,8 @@ void Host::run(boost::system::error_code const& _ec)
         return;
 
     auto runcb = [this](boost::system::error_code const& error) { run(error); };
-    m_timer.expires_from_now(boost::posix_time::milliseconds(c_timerInterval));
-    m_timer.async_wait(runcb);
+    m_runTimer.expires_from_now(boost::posix_time::milliseconds(c_runTimerIntervalMs));
+    m_runTimer.async_wait(runcb);
 }
 
 // Called after thread has been started to perform additional class-specific state
@@ -1031,5 +1036,5 @@ void Host::scheduleExecution(int _delayMs, function<void()> _f)
         if (!_ec)
             _f();
     });
-    DEV_GUARDED(x_timers) { m_timers.emplace_back(move(t)); }
+    DEV_GUARDED(x_networkTimers) { m_networkTimers.emplace_back(move(t)); }
 }

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -310,9 +310,7 @@ private:
     bi::tcp::acceptor m_tcp4Acceptor;										///< Listening acceptor.
 
     /// Timer which, when network is running, calls run() every c_timerInterval ms.
-    io::deadline_timer m_timer;
-
-    static constexpr unsigned c_timerInterval = 100;							///< Interval which m_timer is run when network is connected.
+    io::deadline_timer m_runTimer;
 
     std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).
 
@@ -344,8 +342,8 @@ private:
     std::map<CapDesc, std::shared_ptr<CapabilityFace>> m_capabilities;
 
     /// Deadline timers used for isolated network events. GC'd by run.
-    std::list<std::unique_ptr<io::deadline_timer>> m_timers;
-    Mutex x_timers;
+    std::list<std::unique_ptr<io::deadline_timer>> m_networkTimers;
+    Mutex x_networkTimers;
 
     std::chrono::steady_clock::time_point m_lastPing;						///< Time we sent the last ping to all peers.
     bool m_accepting = false;

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -360,14 +360,14 @@ void NodeTable::noteActiveNode(shared_ptr<NodeEntry> _nodeEntry, bi::udp::endpoi
     }
     if (!isAllowedEndpoint(NodeIPEndpoint(_endpoint.address(), _endpoint.port(), _endpoint.port())))
     {
-        LOG(m_logger) << "Skipping making node with unallowed endpoint active. Node " << dynamic_cast<Node const&>(*_nodeEntry);
+        LOG(m_logger) << "Skipping making node with unallowed endpoint active. Node " << static_cast<Node const&>(*_nodeEntry);
         return;
     }
 
     if (!_nodeEntry->hasValidEndpointProof())
         return;
 
-    LOG(m_logger) << "Active node " << dynamic_cast<Node const&>(*_nodeEntry);
+    LOG(m_logger) << "Active node " << static_cast<Node const&>(*_nodeEntry);
     // TODO don't activate in case endpoint has changed
     _nodeEntry->endpoint.setAddress(_endpoint.address());
     _nodeEntry->endpoint.setUdpPort(_endpoint.port());

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -360,15 +360,14 @@ void NodeTable::noteActiveNode(shared_ptr<NodeEntry> _nodeEntry, bi::udp::endpoi
     }
     if (!isAllowedEndpoint(NodeIPEndpoint(_endpoint.address(), _endpoint.port(), _endpoint.port())))
     {
-        LOG(m_logger) << "Skipping making node with unallowed endpoint active. Node "
-                      << _nodeEntry->id << "@" << _endpoint;
+        LOG(m_logger) << "Skipping making node with unallowed endpoint active. Node " << dynamic_cast<Node const&>(*_nodeEntry);
         return;
     }
 
     if (!_nodeEntry->hasValidEndpointProof())
         return;
 
-    LOG(m_logger) << "Active node " << _nodeEntry->id << '@' << _endpoint;
+    LOG(m_logger) << "Active node " << dynamic_cast<Node const&>(*_nodeEntry);
     // TODO don't activate in case endpoint has changed
     _nodeEntry->endpoint.setAddress(_endpoint.address());
     _nodeEntry->endpoint.setUdpPort(_endpoint.port());

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -1,23 +1,6 @@
-/*
- This file is part of cpp-ethereum.
- 
- cpp-ethereum is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
- 
- cpp-ethereum is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
- 
- You should have received a copy of the GNU General Public License
- along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
- */
-/** @file RLPXHandshake.cpp
- * @author Alex Leverington <nessence@gmail.com>
- * @date 2015
- */
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2018 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include "Host.h"
 #include "Session.h"

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -1,24 +1,6 @@
-/*
- This file is part of cpp-ethereum.
- 
- cpp-ethereum is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
- 
- cpp-ethereum is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
- 
- You should have received a copy of the GNU General Public License
- along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
- */
-/** @file RLPXHandshake.h
- * @author Alex Leverington <nessence@gmail.com>
- * @date 2015
- */
-
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2018 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #pragma once
 
@@ -35,7 +17,7 @@ namespace dev
 namespace p2p
 {
 
-static const unsigned c_rlpxVersion = 4;
+static constexpr unsigned c_rlpxVersion = 4;
 
 /**
  * @brief Setup inbound or outbound connection for communication over RLPXFrameCoder.


### PR DESCRIPTION
Rename timers in the node table and host for better code readability and log NodeEntry using the ostream operator. Also change the run timer interval from a static class var to a var in an unnnamed namespace since it's not accessed outside of Host.cpp.