### PR TITLE
Fix deadline timer race condition which was causing premature discovery termination

### DIFF
--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -303,6 +303,8 @@ void setDefaultOrCLocale();
 
 static constexpr unsigned c_lineWidth = 160;
 
+static const auto c_steadyClockMin = std::chrono::steady_clock::time_point::min();
+
 class ExitHandler
 {
 public:

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -155,28 +155,6 @@ void NodeIPEndpoint::interpretRLP(RLP const& _r)
     m_tcpPort = _r[2].toInt<uint16_t>();
 }
 
-void DeadlineOps::reap()
-{
-    if (m_stopped)
-        return;
-
-    Guard l(x_timers);
-    auto t = m_timers.begin();
-    while (t != m_timers.end())
-        if (t->expired())
-        {
-            t->wait();
-            t = m_timers.erase(t);
-        }
-        else
-            t++;
-
-    m_timers.emplace_back(m_io, m_reapIntervalMs, [this](boost::system::error_code const& ec) {
-        if (!ec && !m_stopped)
-            reap();
-    });
-}
-
 Node::Node(Node const& _original)
   : id(_original.id), endpoint(_original.endpoint), peerType(_original.peerType.load())
 {}

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -16,6 +16,7 @@
 // Make sure boost/asio.hpp is included before windows.h.
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/steady_timer.hpp>
 
 #include <chrono>
 #include <libdevcrypto/Common.h>

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -246,53 +246,6 @@ public:
 
 std::ostream& operator<<(std::ostream& _out, const Node& _node);
 
-class DeadlineOps
-{
-    // Boost deadline timer wrapper which provides thread-safety
-    class DeadlineOp
-    {
-    public:
-        DeadlineOp(ba::io_service& _io, unsigned _msInFuture, std::function<void(boost::system::error_code const&)> const& _f): m_timer(new ba::deadline_timer(_io)) { m_timer->expires_from_now(boost::posix_time::milliseconds(_msInFuture)); m_timer->async_wait(_f); }
-        ~DeadlineOp() { if (m_timer) m_timer->cancel(); }
-
-        DeadlineOp(DeadlineOp&& _s) noexcept : m_timer(std::move(_s.m_timer)) {}
-        DeadlineOp& operator=(DeadlineOp&& _s) noexcept
-        {
-            m_timer = std::move(_s.m_timer);
-            return *this;
-        }
-
-        bool expired() { Guard l(x_timer); return m_timer->expires_from_now().total_nanoseconds() <= 0; }
-        void wait() { Guard l(x_timer); m_timer->wait(); }
-
-    private:
-        std::unique_ptr<ba::deadline_timer> m_timer;
-        Mutex x_timer;
-    };
-
-public:
-    explicit DeadlineOps(ba::io_service& _io, unsigned _reapIntervalMs = 100): m_io(_io), m_reapIntervalMs(_reapIntervalMs), m_stopped(false) { reap(); }
-    ~DeadlineOps() { stop(); }
-
-    void schedule(unsigned _msInFuture, std::function<void(boost::system::error_code const&)> const& _f) { if (m_stopped) return; DEV_GUARDED(x_timers) m_timers.emplace_back(m_io, _msInFuture, _f); }	
-
-    void stop() { m_stopped = true; DEV_GUARDED(x_timers) m_timers.clear(); }
-
-    bool isStopped() const { return m_stopped; }
-    
-protected:
-    void reap();
-    
-private:
-    ba::io_service& m_io;
-    unsigned m_reapIntervalMs;
-    
-    std::vector<DeadlineOp> m_timers;
-    Mutex x_timers;
-    
-    std::atomic<bool> m_stopped;
-};
-
 /// Simple stream output for a NodeIPEndpoint.
 std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep);
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -774,7 +774,6 @@ void Host::startedWorking()
         m_netConfig.discovery,
         m_netConfig.allowLocalDiscovery
     );
-    nodeTable->start();
 
     // Don't set an event handler if we don't have capabilities, because no capabilities
     // means there's no host state to update in response to node table events

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -774,6 +774,7 @@ void Host::startedWorking()
         m_netConfig.discovery,
         m_netConfig.allowLocalDiscovery
     );
+    nodeTable->start();
 
     // Don't set an event handler if we don't have capabilities, because no capabilities
     // means there's no host state to update in response to node table events

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -125,8 +125,8 @@ public:
             // timers
             auto discoveryTimer{m_discoveryTimer};
             m_io.post([discoveryTimer] { discoveryTimer->expires_at(c_steadyClockMin); });
-            auto evictionTimer{m_evictionTimer};
-            m_io.post([evictionTimer] { evictionTimer->expires_at(c_steadyClockMin); });
+            auto timeoutsTimer{m_timeoutsTimer};
+            m_io.post([timeoutsTimer] { timeoutsTimer->expires_at(c_steadyClockMin); });
             m_socket->disconnect();
         }
     }
@@ -269,9 +269,9 @@ protected:
     /// Looks up a random node at @c_bucketRefresh interval.
     void doDiscovery();
 
-    /// Drop nodes from the node table which haven't responded to ping and bring in their
-    /// replacements
-    void doProcessEvictions();
+    /// Clear timed-out pings and drop nodes from the node table which haven't responded to ping and
+    /// bring in their replacements
+    void doHandleTimeouts();
 
     // Useful only for tests.
     void setRequestTimeToLive(std::chrono::seconds const& _time) { m_requestTimeToLive = _time; }
@@ -318,7 +318,7 @@ protected:
     bool m_allowLocalDiscovery;                                     ///< Allow nodes with local addresses to be included in the discovery process
 
     std::shared_ptr<ba::steady_timer> m_discoveryTimer;
-    std::shared_ptr<ba::steady_timer> m_evictionTimer;
+    std::shared_ptr<ba::steady_timer> m_timeoutsTimer;
 
     ba::io_service& m_io;
 };

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -123,9 +123,15 @@ public:
         {
             // We "cancel" the timers by setting min_date_time rather than calling cancel() because
             // cancel won't set the boost error code if the timers have already expired and the
-            // handlers are in the ready queue
-            m_discoveryTimer->expires_at(boost::posix_time::min_date_time);
-            m_evictionTimer->expires_at(boost::posix_time::min_date_time);
+            // handlers are in the ready queue.
+            //
+            // Note that we "cancel" via io_service::post to ensure thread safety when accessing the
+            // timers
+            auto self = shared_from_this();
+            m_io.post(
+                [this, self] { m_discoveryTimer->expires_at(boost::posix_time::min_date_time); });
+            m_io.post(
+                [this, self] { m_evictionTimer->expires_at(boost::posix_time::min_date_time); });
             m_socket->disconnect();
         }
     }

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -205,6 +205,8 @@ protected:
     static constexpr std::chrono::milliseconds c_evictionCheckInterval{75};
     /// How long to wait for requests (evict, find iterations).
     static constexpr std::chrono::milliseconds c_reqTimeout{300};
+    /// How long to wait before starting a new discovery round
+    static constexpr std::chrono::milliseconds c_discoveryRoundIntervalMs{c_reqTimeout * 2};
     /// Refresh interval prevents bucket from becoming stale. [Kademlia]
     static constexpr std::chrono::milliseconds c_bucketRefresh{7200};
 
@@ -219,7 +221,7 @@ protected:
     bool isValidNode(Node const& _node) const;
 
     /// Used to ping a node to initiate the endpoint proof. Used when contacting neighbours if they
-    /// don't have a valid endpoint proof (see doDiscover), refreshing buckets and as part of
+    /// don't have a valid endpoint proof (see doDiscoveryRound), refreshing buckets and as part of
     /// eviction process (see evict). Synchronous, has to be called only from the network thread.
     void ping(Node const& _node, std::shared_ptr<NodeEntry> _replacementNodeEntry = {});
 
@@ -232,9 +234,8 @@ protected:
 
     /// Used to discovery nodes on network which are close to the given target.
     /// Sends s_alpha concurrent requests to nodes nearest to target, for nodes nearest to target, up to s_maxSteps rounds.
-    void doDiscover(boost::system::error_code _ec, NodeID _target, unsigned _round,
-        std::shared_ptr<std::set<std::shared_ptr<NodeEntry>>> _tried,
-        std::shared_ptr<ba::deadline_timer> _timer);
+    void doDiscoveryRound(NodeID _target, unsigned _round,
+        std::shared_ptr<std::set<std::shared_ptr<NodeEntry>>> _tried);
 
     /// Returns nodes from node table which are closest to target.
     std::vector<std::shared_ptr<NodeEntry>> nearestNodeEntries(NodeID _target);
@@ -266,14 +267,11 @@ protected:
 
     /// Tasks
 
-    /// Called by evict() to ensure eviction check is scheduled to run and terminates when no evictions remain. Asynchronous.
-    void doCheckEvictions();
-
     /// Looks up a random node at @c_bucketRefresh interval.
     void doDiscovery();
 
-    void doHandleTimeouts(
-        boost::system::error_code const& _ec, std::shared_ptr<ba::deadline_timer> _timer);
+    /// Drop nodes from the node table who haven't responded to ping and bring in their replacements
+    void doProcessEvictions();
 
     // Useful only for tests.
     void setRequestTimeToLive(std::chrono::seconds const& _time) { m_requestTimeToLive = _time; }
@@ -288,7 +286,6 @@ protected:
         return dev::p2p::isAllowedEndpoint(m_allowLocalDiscovery, _endpointToCheck);
     }
 
-    bool m_enabled;                                                 /// Is discovery enabled?
     std::unique_ptr<NodeTableEventHandler> m_nodeEventHandler;		///< Event handler for node events.
 
     NodeID const m_hostNodeID;

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -237,11 +237,10 @@ struct TestNodeTableHost : public TestHost
     }
     ~TestNodeTableHost()
     {
+        nodeTable->stop();
         m_io.stop();
         terminate();
     }
-
-    void start() { TestHost::start(); nodeTable->start(); }
 
     void populate(size_t _count = 0) { nodeTable->populateTestNodes(testNodes, _count); }
 

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -242,6 +242,8 @@ struct TestNodeTableHost : public TestHost
         terminate();
     }
 
+    void start() { TestHost::start(); nodeTable->start(); }
+
     void populate(size_t _count = 0) { nodeTable->populateTestNodes(testNodes, _count); }
 
     int populateUntilBucketSize(size_t _size)
@@ -253,7 +255,6 @@ struct TestNodeTableHost : public TestHost
     {
         return nodeTable->populateUntilSpecificBucketSize(testNodes, _bucket, _size);
     }
-
 
     void processEvents(boost::system::error_code const& _e)
     {

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -51,9 +51,9 @@ struct TestNodeTable: public NodeTable
             true /* allow local discovery */)
     {}
 
-    static std::vector<std::pair<Public, uint16_t>> createTestNodes(unsigned _count)
+    static vector<pair<Public, uint16_t>> createTestNodes(unsigned _count)
     {
-        std::vector<std::pair<Public, uint16_t>> ret;
+        vector<pair<Public, uint16_t>> ret;
         asserts(_count <= 1000);
         
         ret.clear();
@@ -66,8 +66,7 @@ struct TestNodeTable: public NodeTable
         return ret;
     }
 
-    void populateTestNodes(
-        std::vector<std::pair<Public, uint16_t>> const& _testNodes, size_t _count = 0)
+    void populateTestNodes(vector<pair<Public, uint16_t>> const& _testNodes, size_t _count = 0)
     {
         if (!_count)
             _count = _testNodes.size();
@@ -89,7 +88,7 @@ struct TestNodeTable: public NodeTable
     // populate NodeTable until one of the buckets reaches the size of _bucketSize
     // return the index of this bucket
     int populateUntilBucketSize(
-        std::vector<std::pair<Public, uint16_t>> const& _testNodes, size_t _bucketSize)
+        vector<pair<Public, uint16_t>> const& _testNodes, size_t _bucketSize)
     {
         auto testNode = _testNodes.begin();
 
@@ -119,8 +118,8 @@ struct TestNodeTable: public NodeTable
 
     // populate NodeTable until bucket _bucket reaches the size of _bucketSize
     // return true if success, false if not enought test nodes
-    bool populateUntilSpecificBucketSize(std::vector<std::pair<Public, uint16_t>> const& _testNodes,
-        size_t _bucket, size_t _bucketSize)
+    bool populateUntilSpecificBucketSize(
+        vector<pair<Public, uint16_t>> const& _testNodes, size_t _bucket, size_t _bucketSize)
     {
         auto testNode = _testNodes.begin();
 
@@ -188,7 +187,7 @@ struct TestNodeTable: public NodeTable
 
     boost::optional<NodeValidation> nodeValidation(NodeID const& _id)
     {
-        std::promise<boost::optional<NodeValidation>> promise;
+        promise<boost::optional<NodeValidation>> promise;
         m_io.post([this, &promise, _id] {
             auto validation = m_sentPings.find(_id);
             if (validation != m_sentPings.end())
@@ -268,7 +267,7 @@ struct TestNodeTableHost : public TestHost
 
     KeyPair m_alias;
     shared_ptr<TestNodeTable> nodeTable;
-    std::vector<std::pair<Public, uint16_t>> testNodes;  // keypair and port
+    vector<pair<Public, uint16_t>> testNodes;  // keypair and port
     ba::deadline_timer timer;
 };
 
@@ -285,7 +284,7 @@ public:
             {
                 socket->connect();
             }
-            catch (std::exception const&)
+            catch (exception const&)
             {
                 port = randomPortNumber();
             }
@@ -309,7 +308,7 @@ public:
     shared_ptr<UDPSocket<TestUDPSocketHost, 1024>> socket;
     uint16_t port = 0;
 
-    std::atomic<bool> success{false};
+    atomic<bool> success{false};
 
     concurrent_queue<bytes> packetsReceived;
 };
@@ -331,7 +330,7 @@ BOOST_AUTO_TEST_CASE(isIPAddressType)
     BOOST_REQUIRE(bi::address::from_string(wildcard).is_unspecified());
 
     string empty = "";
-    BOOST_REQUIRE_THROW(bi::address::from_string(empty).is_unspecified(), std::exception);
+    BOOST_REQUIRE_THROW(bi::address::from_string(empty).is_unspecified(), exception);
 
     string publicAddress192 = "192.169.0.0";
     BOOST_REQUIRE(isPublicAddress(publicAddress192));
@@ -362,7 +361,7 @@ BOOST_AUTO_TEST_CASE(isIPAddressType)
 BOOST_AUTO_TEST_CASE(neighboursPacketLength)
 {
     KeyPair k = KeyPair::create();
-    std::vector<std::pair<Public, uint16_t>> testNodes(TestNodeTable::createTestNodes(16));
+    vector<pair<Public, uint16_t>> testNodes(TestNodeTable::createTestNodes(16));
     bi::udp::endpoint to(boost::asio::ip::address::from_string(c_localhostIp), randomPortNumber());
 
     // hash(32), signature(65), overhead: packetSz(3), type(1), nodeListSz(3), ts(5),
@@ -371,8 +370,7 @@ BOOST_AUTO_TEST_CASE(neighboursPacketLength)
     {
         Neighbours out(to);
 
-        auto limit =
-            nlimit ? std::min(testNodes.size(), (size_t)(offset + nlimit)) : testNodes.size();
+        auto limit = nlimit ? min(testNodes.size(), (size_t)(offset + nlimit)) : testNodes.size();
         for (auto i = offset; i < limit; i++)
         {
             Node n(testNodes[i].first,
@@ -390,7 +388,7 @@ BOOST_AUTO_TEST_CASE(neighboursPacketLength)
 BOOST_AUTO_TEST_CASE(neighboursPacket)
 {
     KeyPair k = KeyPair::create();
-    std::vector<std::pair<Public, uint16_t>> testNodes(TestNodeTable::createTestNodes(16));
+    vector<pair<Public, uint16_t>> testNodes(TestNodeTable::createTestNodes(16));
     bi::udp::endpoint to(boost::asio::ip::address::from_string(c_localhostIp), randomPortNumber());
 
     Neighbours out(to);
@@ -486,7 +484,7 @@ BOOST_AUTO_TEST_CASE(noteActiveNodeAppendsNewNode)
     nodeTableHost.populate(1);
 
     auto& nodeTable = nodeTableHost.nodeTable;
-    std::shared_ptr<NodeEntry> newNode = nodeTable->nodeEntry(nodeTableHost.testNodes.front().first);
+    shared_ptr<NodeEntry> newNode = nodeTable->nodeEntry(nodeTableHost.testNodes.front().first);
 
     BOOST_REQUIRE_GT(nodeTable->bucketSize(newNode->distance - 1), 0);
 
@@ -678,7 +676,7 @@ BOOST_AUTO_TEST_CASE(pingTimeout)
 
     nodeTableHost.start();
     auto& nodeTable = nodeTableHost.nodeTable;
-    nodeTable->setRequestTimeToLive(std::chrono::seconds(1));
+    nodeTable->setRequestTimeToLive(chrono::seconds(1));
 
     // socket receiving PING
     TestUDPSocketHost nodeSocketHost;
@@ -691,7 +689,7 @@ BOOST_AUTO_TEST_CASE(pingTimeout)
     auto nodePubKey = nodeKeyPair.pub();
     nodeTable->addNode(Node{nodePubKey, nodeEndpoint});
 
-    this_thread::sleep_for(std::chrono::seconds(6));
+    this_thread::sleep_for(chrono::seconds(6));
 
     BOOST_CHECK(!nodeTable->nodeExists(nodePubKey));
     auto sentPing = nodeTable->nodeValidation(nodePubKey);
@@ -882,7 +880,7 @@ BOOST_AUTO_TEST_CASE(evictionWithOldNodeDropped)
     BOOST_REQUIRE(bucketIndex >= 0);
 
     auto& nodeTable = nodeTableHost.nodeTable;
-    nodeTable->setRequestTimeToLive(std::chrono::seconds(1));
+    nodeTable->setRequestTimeToLive(chrono::seconds(1));
 
     nodeTableHost.start();
 
@@ -903,7 +901,7 @@ BOOST_AUTO_TEST_CASE(evictionWithOldNodeDropped)
     nodeTable->addKnownNode(Node{newNodeId, newNodeEndpoint});
 
     // wait for PING time out
-    this_thread::sleep_for(std::chrono::seconds(6));
+    this_thread::sleep_for(chrono::seconds(6));
 
     // check that old node is evicted
     BOOST_CHECK(!nodeTable->nodeExists(oldNodeId));
@@ -1132,7 +1130,7 @@ BOOST_FIXTURE_TEST_SUITE(netTypes, TestOutputHelperFixture)
     ba::deadline_timer t(io);
     bool start = false;
     boost::system::error_code ec;
-    std::atomic<unsigned> fired(0);
+    atomic<unsigned> fired(0);
 
     thread thread([&](){ while(!start) this_thread::sleep_for(chrono::milliseconds(10)); io.run();
 }); t.expires_from_now(boost::posix_time::milliseconds(200)); start = true;


### PR DESCRIPTION
Fix #5495 

Fix the boost deadline timer race condition which was causing the discovery process to terminate (in some cases extremely) prematurely. The race condition occurred because `DeadlineOps` would check for timer expiration (`deadline_timer::expires_from_now() < 0`) and delete expired timers (see `DeadlineOps::reap()`), but their handlers may not have executed yet which means that when they finally executed their boost error code would indicate operation aborted and the handler would return before executing any of its core logic.

To fix this, I created 2 dedicated deadline timers in `NodeTable` - 1 for the discovery process and 1 for the node eviction process. I think this makes sense since these are 2 algorithms which are supposed to be running for as long as the node table is running…additionally, having dedicated timers here makes the code easier to understand. I also only check the boost error code in these timer handlers since the timers are cancelled in `NodeTable::stop()` (which is executed on both network shutdown and on `NodeTable `destruction), meaning that the error code is guaranteed to indicate timer cancellation when a handler is executed after network shutdown or node table destruction.

I've also removed the `DeadlineOps `class since it's no longer needed.
