### PR TITLE
Upgrade Hunter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ option(HUNTER_RUN_UPLOAD "Upload binaries to the cache server" ${run_upload})
 
 include(HunterGate)
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.44.tar.gz"
-    SHA1 "c4cfcc0cd39fdae8de08f6205b7f34cab4a7ba79"
+    URL "https://github.com/ruslo/hunter/archive/v0.23.178.tar.gz"
+    SHA1 "3511e5f2382d43cfa92b7f2a6f316fbdd1b81a92"
     LOCAL
 )
 
@@ -82,6 +82,8 @@ find_package(libscrypt CONFIG REQUIRED)
 
 hunter_add_package(ethash)
 find_package(ethash CONFIG REQUIRED)
+
+message("Crypto++: ${HUNTER_cryptopp_VERSION}")
 
 include(ProjectSecp256k1)
 include(ProjectLibFF)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -18,8 +18,3 @@ hunter_config(
 )
 
 hunter_config(Boost VERSION 1.65.1)
-
-hunter_config(ethash VERSION 0.4.4
-    URL https://github.com/chfast/ethash/archive/v0.4.4.tar.gz
-    SHA1 d09e4560cf7e5ea9ce9e3c1f35a98edeb46e6bb6
-)

--- a/libdevcrypto/CryptoPP.cpp
+++ b/libdevcrypto/CryptoPP.cpp
@@ -27,7 +27,7 @@
 #include <libdevcore/Assertions.h>
 #include <libdevcore/SHA3.h>
 
-static_assert(CRYPTOPP_VERSION == 565, "Wrong Crypto++ version");
+static_assert(CRYPTOPP_VERSION == 820, "Wrong Crypto++ version");
 
 using namespace dev;
 using namespace dev::crypto;

--- a/libp2p/RLPXFrameCoder.cpp
+++ b/libp2p/RLPXFrameCoder.cpp
@@ -28,8 +28,6 @@
 #include "RLPxHandshake.h"
 #include "RLPXPacket.h"
 
-static_assert(CRYPTOPP_VERSION == 565, "Wrong Crypto++ version");
-
 using namespace std;
 using namespace dev;
 using namespace dev::p2p;


### PR DESCRIPTION
Upgrades Hunter to v0.23.178.
This upgrades following packages:
- leveldb to 1.22, it now builds natively on Windows,
- Crypto++ to 8.2.0.

The ethash stays at version 0.4.4, the current default version in Hunter.