### PR TITLE
Don't manually poll the ioservice after stopping capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@
 - Fixed: [#5502](https://github.com/ethereum/aleth/pull/5502) Fix Discovery terminating prematurely because of race condition.
 - Fixed: [#5452](https://github.com/ethereum/aleth/pull/5452) Correctly handle Discovery messages when the peer changes public key.
 - Fixed: [#5519](https://github.com/ethereum/aleth/pull/5519) Correctly handle Discovery messages with known public key but unknown endpoint.
+- Fixed: [#5523](https://github.com/ethereum/aleth/pull/5523) [#5533](https://github.com/ethereum/aleth/pull/5533) Fix syncing terminating prematurely because of race condition.
 
 [1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...master

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -212,10 +212,9 @@ void Host::doneWorking()
     while (m_accepting)
         m_ioService.poll();
 
-    // (eth: stops syncing or block / tx broadcast). Poll the io service so we can process
-    // capability cancellations
+    // (eth: stops syncing or block / tx broadcast). Capabilities will be cancelled when ioservice
+    // is polled on pending handshake / peer disconnect
     stopCapabilities();
-    m_ioService.poll();
 
     // disconnect pending handshake, before peers, as a handshake may create a peer
     for (unsigned n = 0;; n = 0)


### PR DESCRIPTION
Manually polling the ioservice on shutdown is redundant. The motivation behind doing this was to ensure that the posted capability timer cancellations (see Host::stopCapabilities) were processed during host shutdown (see #5523 for details). However, it turns out that there's no need to do this because the capability timers only need to be cancelled if more capability work loops are being scheduled, but more capability work loops are only scheduled during shutdown if we are disconnecting pending handshakes and/or peers, each of which result in the io service being polled anyway.