### PR TITLE
Converting private key to compressed public key

### DIFF
--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -52,6 +52,20 @@ secp256k1_context const* getCtx()
     return s_ctx.get();
 }
 
+template <std::size_t KeySize>
+bool toPublicKey(Secret const& _secret, unsigned _flags, array<byte, KeySize>& o_serializedPubkey)
+{
+    auto* ctx = getCtx();
+    secp256k1_pubkey rawPubkey;
+    // Creation will fail if the secret key is invalid.
+    if (!secp256k1_ec_pubkey_create(ctx, &rawPubkey, _secret.data()))
+        return false;
+    size_t serializedPubkeySize = o_serializedPubkey.size();
+    secp256k1_ec_pubkey_serialize(
+        ctx, o_serializedPubkey.data(), &serializedPubkeySize, &rawPubkey, _flags);
+    assert(serializedPubkeySize == o_serializedPubkey.size());
+    return true;
+}
 }
 
 bool dev::SignatureStruct::isValid() const noexcept
@@ -64,22 +78,27 @@ bool dev::SignatureStruct::isValid() const noexcept
 
 Public dev::toPublic(Secret const& _secret)
 {
-    auto* ctx = getCtx();
-    secp256k1_pubkey rawPubkey;
-    // Creation will fail if the secret key is invalid.
-    if (!secp256k1_ec_pubkey_create(ctx, &rawPubkey, _secret.data()))
-        return {};
     std::array<byte, 65> serializedPubkey;
-    size_t serializedPubkeySize = serializedPubkey.size();
-    secp256k1_ec_pubkey_serialize(
-            ctx, serializedPubkey.data(), &serializedPubkeySize,
-            &rawPubkey, SECP256K1_EC_UNCOMPRESSED
-    );
-    assert(serializedPubkeySize == serializedPubkey.size());
+    if (!toPublicKey(_secret, SECP256K1_EC_UNCOMPRESSED, serializedPubkey))
+        return {};
+
     // Expect single byte header of value 0x04 -- uncompressed public key.
     assert(serializedPubkey[0] == 0x04);
+
     // Create the Public skipping the header.
     return Public{&serializedPubkey[1], Public::ConstructFromPointer};
+}
+
+PublicCompressed dev::toPublicCompressed(Secret const& _secret)
+{
+    PublicCompressed serializedPubkey;
+    if (!toPublicKey(_secret, SECP256K1_EC_COMPRESSED, serializedPubkey.asArray()))
+        return {};
+
+    // Expect single byte header of value 0x02 or 0x03 -- compressed public key.
+    assert(serializedPubkey[0] == 0x02 || serializedPubkey[0] == 0x03);
+
+    return serializedPubkey;
 }
 
 Address dev::toAddress(Public const& _public)

--- a/libdevcrypto/Common.h
+++ b/libdevcrypto/Common.h
@@ -39,6 +39,10 @@ using Secret = SecureFixedHash<32>;
 /// @NOTE This is not endian-specific; it's just a bunch of bytes.
 using Public = h512;
 
+/// A public key in compressed format: 33 bytes.
+/// @NOTE This is not endian-specific; it's just a bunch of bytes.
+using PublicCompressed = FixedHash<33>;
+
 /// A signature: 65 bytes: r: [0, 32), s: [32, 64), v: 64.
 /// @NOTE This is not endian-specific; it's just a bunch of bytes.
 using Signature = h520;
@@ -63,6 +67,9 @@ using Secrets = std::vector<Secret>;
 
 /// Convert a secret key into the public key equivalent.
 Public toPublic(Secret const& _secret);
+
+/// Convert a secret key into the public key in compressed format.
+PublicCompressed toPublicCompressed(Secret const& _secret);
 
 /// Convert a public key to address.
 Address toAddress(Public const& _public);

--- a/test/unittests/libdevcrypto/crypto.cpp
+++ b/test/unittests/libdevcrypto/crypto.cpp
@@ -111,8 +111,13 @@ BOOST_AUTO_TEST_CASE(keypairs)
 	KeyPair p(Secret(fromHex("3ecb44df2159c26e0f995712d4f39b6f6e499b40749b1cf1246c37f9516cb6a4")));
 	BOOST_REQUIRE(p.pub() == Public(fromHex("97466f2b32bc3bb76d4741ae51cd1d8578b48d3f1e68da206d47321aec267ce78549b514e4453d74ef11b0cd5e4e4c364effddac8b51bcfc8de80682f952896f")));
 	BOOST_REQUIRE(p.address() == Address(fromHex("8a40bfaa73256b60764c1bf40675a99083efb075")));
-	eth::Transaction t(1000, 0, 0, h160(fromHex("944400f4b88ac9589a0f17ed4671da26bddb668b")), {}, 0, p.secret());
-	auto rlp = t.rlp(eth::WithoutSignature);
+    BOOST_REQUIRE(toPublicCompressed(p.secret()) ==
+                  PublicCompressed(fromHex(
+                      "0397466f2b32bc3bb76d4741ae51cd1d8578b48d3f1e68da206d47321aec267ce7")));
+
+    eth::Transaction t(
+        1000, 0, 0, h160(fromHex("944400f4b88ac9589a0f17ed4671da26bddb668b")), {}, 0, p.secret());
+    auto rlp = t.rlp(eth::WithoutSignature);
 	auto expectedRlp = "dc80808094944400f4b88ac9589a0f17ed4671da26bddb668b8203e880";
 	BOOST_CHECK_EQUAL(toHex(rlp), expectedRlp);
 	rlp = t.rlp(eth::WithSignature);


### PR DESCRIPTION
Compressed public key is used in the ENR spec https://eips.ethereum.org/EIPS/eip-778