### PR TITLE
ENR record for host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.0] - Unreleased
+
+- Added: [#5537](https://github.com/ethereum/aleth/pull/5537) Creating Ethereum Node Record (ENR) at program start.
+
+[1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...master
+
 ## [1.6.0] - Unreleased
 
 - Added: [#5485](https://github.com/ethereum/aleth/pull/5485) aleth-bootnode now by default connects to official Ethereum bootnodes. This can be disabled with `--no-bootstrap` flag.
@@ -17,4 +23,5 @@
 - Fixed: [#5539](https://github.com/ethereum/aleth/pull/5539) Fix logic for determining if dao hard fork block header should be requested.
 - Fixed: [#5547](https://github.com/ethereum/aleth/pull/5547) Fix unnecessary slow-down of eth_flush RPC method.
 
-[1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...master
+[1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...release/1.6
+[1.7.0]: https://github.com/ethereum/aleth/compare/release/1.6...master

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -343,4 +343,10 @@ bool contains(std::set<V> const& _set, V const& _v)
 {
     return _set.find(_v) != _set.end();
 }
+
+template <class K, class V>
+bool contains(std::map<K, V> const& _map, K const& _k)
+{
+    return _map.find(_k) != _map.end();
+}
 }

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -92,7 +92,7 @@ ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint
         // dev::sign returns 65 bytes signature containing r,s,v values
         Signature s = dev::sign(_secret, sha3(_data)); 
         // The resulting 64-byte signature is encoded as the concatenation of the r and s signature values.
-        return bytes(s.data(), s.data() + 64);
+        return bytes(&s[0], &s[64]);
     };
 
     PublicCompressed const publicKey = toPublicCompressed(_secret);

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -5,20 +5,21 @@
 #include "ENR.h"
 #include <libdevcore/SHA3.h>
 
-static std::string const c_keyID = "id";
-static std::string const c_keySec256k1 = "secp256k1";
-static std::string const c_keyIP = "ip";
-static std::string const c_keyTCP = "tcp";
-static std::string const c_keyUDP = "udp";
-static dev::bytes const c_IDV4 = {'v', '4'};
-static size_t const c_ENRMaxSize = 300;
-
 namespace dev
 {
 namespace p2p
 {
 namespace
 {
+constexpr char c_keyID[] = "id";
+constexpr char c_keySec256k1[] = "secp256k1";
+constexpr char c_keyIP[] = "ip";
+constexpr char c_keyTCP[] = "tcp";
+constexpr char c_keyUDP[] = "udp";
+constexpr char c_IDV4[] = "v4";
+constexpr size_t c_ENRMaxSize = 300;
+
+
 // Address can be either boost::asio::ip::address_v4 or boost::asio::ip::address_v6
 template <class Address>
 bytes addressToBytes(Address const& _address)
@@ -115,7 +116,7 @@ ENR parseV4ENR(RLP _rlp)
         auto itID = _keyValues.find(c_keyID);
         if (itID == _keyValues.end())
             return false;
-        auto id = RLP(itID->second).toBytes(RLP::VeryStrict);
+        auto id = RLP(itID->second).toString(RLP::VeryStrict);
         if (id != c_IDV4)
             return false;
 

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -6,7 +6,7 @@
 #include <libdevcore/SHA3.h>
 
 static std::string const c_keyID = "id";
-static std::string const c_keySec256k1 = "sec256k1";
+static std::string const c_keySec256k1 = "secp256k1";
 static std::string const c_keyIP = "ip";
 static std::string const c_keyTCP = "tcp";
 static std::string const c_keyUDP = "udp";
@@ -48,8 +48,8 @@ ENR::ENR(RLP _rlp, VerifyFunction _verifyFunction)
     // transfer to map, this will order them
     m_map.insert(keyValues.begin(), keyValues.end());
 
-    if (!std::equal(m_map.begin(), m_map.end(), keyValues.begin()))
-        BOOST_THROW_EXCEPTION(ENRKeysAreNotSorted());
+    if (!std::equal(keyValues.begin(), keyValues.end(), m_map.begin()))
+        BOOST_THROW_EXCEPTION(ENRKeysAreNotUniqueSorted());
 
     if (!_verifyFunction(m_map, dev::ref(m_signature), dev::ref(content())))
         BOOST_THROW_EXCEPTION(ENRSignatureIsInvalid());

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -130,10 +130,13 @@ ENR parseV4ENR(RLP _rlp)
 
 std::ostream& operator<<(std::ostream& _out, ENR const& _enr)
 {
-    RLPStream s;
-    _enr.streamRLP(s);
-
-    _out << RLP(s.out());
+    _out << "[ " << toHexPrefixed(_enr.signature()) << " seq=" << _enr.sequenceNumber() << " ";
+    for (auto const keyValue : _enr.keyValues())
+    {
+        _out << keyValue.first << "=";
+        _out << toHexPrefixed(RLP(keyValue.second).toBytes()) << " ";
+    }
+    _out << "]";
     return _out;
 }
 

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -1,0 +1,105 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#include "ENR.h"
+#include <libdevcore/SHA3.h>
+
+namespace dev
+{
+namespace p2p
+{
+namespace
+{
+    template<class Address>
+    bytes addressToBytes(Address const& _address)
+    {
+        auto const addressBytes = _address.to_bytes();
+        return bytes(addressBytes.begin(), addressBytes.end());
+    }    
+}  // namespace
+
+ENR::ENR(RLP _rlp)
+{
+    m_signature = _rlp[0].toBytes();
+
+    m_seq = _rlp[1].toInt<uint64_t>();
+    for (size_t i = 2; i < _rlp.itemCount(); i+= 2)
+    {
+        auto key = _rlp[i].toString();
+        auto value = _rlp[i + 1].toBytes();
+        m_map.insert({key, value});
+    }
+    // TODO check signature
+    // TODO fail if > 300 bytes
+}
+
+ENR::ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues, SignFunction _signFunction)
+    : m_seq(_seq),
+    m_map(_keyValues),
+    m_signature(_signFunction(dev::ref(contentRlpList())))
+{
+}
+
+std::vector<bytes> ENR::content() const
+{
+    std::vector<bytes> result{rlp(m_seq)};
+    for (auto const keyValue : m_map)
+    {
+        result.push_back(bytes(keyValue.first.begin(), keyValue.first.end()));
+        result.push_back(keyValue.second);
+    }
+    return result;
+}
+
+bytes ENR::contentRlpList() const
+{
+    RLPStream stream;
+    stream.appendVector(content());
+    return stream.out();
+}
+
+void ENR::streamRLP(RLPStream& _s) const
+{
+    _s.appendList(m_map.size() * 2 + 2);
+    _s << m_signature;
+    
+    auto const contentItems = content();
+    for (auto const& contentItem : contentItems)
+        _s << contentItem;
+}
+
+ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint16_t _tcpPort,  uint16_t _udpPort)
+{
+    ENR::SignFunction signFunction = [&_secret](bytesConstRef _data) { 
+        Signature s = dev::sign(_secret, sha3(_data)); 
+        // The resulting 64-byte signature is encoded as the concatenation of the r and s signature values.
+        return bytes(s.data(), s.data() + 64);
+    };
+
+    PublicCompressed publicKey = toPublicCompressed(_secret);
+    
+    auto const address = _ip.is_v4() ? addressToBytes(_ip.to_v4()) : addressToBytes(_ip.to_v6());
+    
+    std::map<std::string, bytes> keyValues = {
+        { "id", bytes{ 'v', '4' } },
+        { "sec256k1", publicKey.asBytes() },
+        { "ip", address },
+        { "tcp", rlp(_tcpPort) },
+        { "udp", rlp(_udpPort) }
+    };
+
+    return ENR{0, keyValues, signFunction};
+}
+
+std::ostream& operator<<(std::ostream& _out, ENR const& _enr)
+{
+    RLPStream s;
+    _enr.streamRLP(s);
+
+    _out << RLP(s.out());
+    return _out;
+}
+
+}  // namespace p2p
+}  // namespace dev

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -12,7 +12,7 @@ namespace p2p
 {
 DEV_SIMPLE_EXCEPTION(ENRIsTooBig);
 DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
-DEV_SIMPLE_EXCEPTION(ENRKeysAreNotSorted);
+DEV_SIMPLE_EXCEPTION(ENRKeysAreNotUniqueSorted);
 
 class ENR
 {

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -22,6 +22,9 @@ public:
     // create with given sign function
     ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues, SignFunction _signFunction);
 
+    uint64_t sequenceNumber() const { return m_seq; }
+    std::map<std::string, bytes> const& keyValues() const { return m_map; }
+
     void streamRLP(RLPStream& _s) const;
 
 private:
@@ -29,8 +32,9 @@ private:
     std::map<std::string, bytes> m_map;
     bytes m_signature;
 
-    std::vector<bytes> content() const;
-    bytes contentRlpList() const;
+    bytes content() const;
+    size_t contentListSize() const { return m_map.size() * 2 + 1; }
+    void streamContent(RLPStream& _s) const;
 };
 
 ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint16_t _tcpPort,  uint16_t _udpPort);

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -11,19 +11,24 @@ namespace dev
 namespace p2p
 {
 
+DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
+
+
 class ENR
 {
 public:
-    // return bytes, Signature is EC-specific
     using SignFunction = std::function<bytes(bytesConstRef)>;
+    using VerifyFunction =
+        std::function<bool(std::map<std::string, bytes> const&, bytesConstRef, bytesConstRef)>;
 
-    // parse from RLP
-    explicit ENR(RLP _rlp);
+    // parse from RLP with given signature verification function
+    ENR(RLP _rlp, VerifyFunction _verifyFunction);
     // create with given sign function
     ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues, SignFunction _signFunction);
 
     uint64_t sequenceNumber() const { return m_seq; }
     std::map<std::string, bytes> const& keyValues() const { return m_map; }
+    bytes const& signature() const { return m_signature; }
 
     void streamRLP(RLPStream& _s) const;
 
@@ -37,7 +42,10 @@ private:
     void streamContent(RLPStream& _s) const;
 };
 
+
 ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint16_t _tcpPort,  uint16_t _udpPort);
+
+ENR parseV4ENR(RLP _rlp);
 
 std::ostream& operator<<(std::ostream& _out, ENR const& _enr);
 

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -1,0 +1,41 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#pragma once
+
+#include "Common.h"
+
+namespace dev
+{
+namespace p2p
+{
+
+class ENR
+{
+public:
+    // return bytes, Signature is EC-specific
+    using SignFunction = std::function<bytes(bytesConstRef)>;
+
+    // parse from RLP
+    explicit ENR(RLP _rlp);
+    // create with given sign function
+    ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues, SignFunction _signFunction);
+
+    void streamRLP(RLPStream& _s) const;
+
+private:
+    uint64_t m_seq = 0;
+    std::map<std::string, bytes> m_map;
+    bytes m_signature;
+
+    std::vector<bytes> content() const;
+    bytes contentRlpList() const;
+};
+
+ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint16_t _tcpPort,  uint16_t _udpPort);
+
+std::ostream& operator<<(std::ostream& _out, ENR const& _enr);
+
+}
+}

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -14,22 +14,30 @@ DEV_SIMPLE_EXCEPTION(ENRIsTooBig);
 DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
 DEV_SIMPLE_EXCEPTION(ENRKeysAreNotUniqueSorted);
 
+/// Class representing Ethereum Node Record - see EIP-778 for the spec
 class ENR
 {
 public:
+    // ENR class implementation is independent of Identity Scheme.
+    // Identity Scheme specifics are passed to ENR as functions.
+
+    // Sign function gets serialized ENR contents and signs it according to some Identity Scheme
     using SignFunction = std::function<bytes(bytesConstRef)>;
+    // Verify function gets serialized ENR contents, signature and contents and validates the
+    // signature according to some Identity Scheme
     using VerifyFunction =
         std::function<bool(std::map<std::string, bytes> const&, bytesConstRef, bytesConstRef)>;
 
-    // parse from RLP with given signature verification function
+    // Parse from RLP with given signature verification function
     ENR(RLP _rlp, VerifyFunction _verifyFunction);
-    // create with given sign function
+    // Create with given sign function
     ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues, SignFunction _signFunction);
 
     uint64_t sequenceNumber() const { return m_seq; }
     std::map<std::string, bytes> const& keyValues() const { return m_map; }
     bytes const& signature() const { return m_signature; }
 
+    // Serialize to given RLP stream
     void streamRLP(RLPStream& _s) const;
 
 private:

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -14,7 +14,7 @@ DEV_SIMPLE_EXCEPTION(ENRIsTooBig);
 DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
 DEV_SIMPLE_EXCEPTION(ENRKeysAreNotUniqueSorted);
 
-/// Class representing Ethereum Node Record - see EIP-778 for the spec
+/// Class representing Ethereum Node Record - see EIP-778
 class ENR
 {
 public:
@@ -23,18 +23,19 @@ public:
 
     // Sign function gets serialized ENR contents and signs it according to some Identity Scheme
     using SignFunction = std::function<bytes(bytesConstRef)>;
-    // Verify function gets serialized ENR contents, signature and contents and validates the
+    // Verify function gets ENR key-value pairs, signature, and serialized content and validates the
     // signature according to some Identity Scheme
     using VerifyFunction =
         std::function<bool(std::map<std::string, bytes> const&, bytesConstRef, bytesConstRef)>;
 
     // Parse from RLP with given signature verification function
-    ENR(RLP _rlp, VerifyFunction _verifyFunction);
+    ENR(RLP _rlp, VerifyFunction const& _verifyFunction);
     // Create with given sign function
-    ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues, SignFunction _signFunction);
+    ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues,
+        SignFunction const& _signFunction);
 
     uint64_t sequenceNumber() const { return m_seq; }
-    std::map<std::string, bytes> const& keyValues() const { return m_map; }
+    std::map<std::string, bytes> const& keyValuePairs() const { return m_map; }
     bytes const& signature() const { return m_signature; }
 
     // Serialize to given RLP stream
@@ -46,7 +47,7 @@ private:
     bytes m_signature;
 
     bytes content() const;
-    size_t contentListSize() const { return m_map.size() * 2 + 1; }
+    size_t contentRlpListItemCount() const { return m_map.size() * 2 + 1; }
     void streamContent(RLPStream& _s) const;
 };
 

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -10,7 +10,7 @@ namespace dev
 {
 namespace p2p
 {
-
+DEV_SIMPLE_EXCEPTION(ENRIsTooBig);
 DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
 
 

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -12,7 +12,7 @@ namespace p2p
 {
 DEV_SIMPLE_EXCEPTION(ENRIsTooBig);
 DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
-
+DEV_SIMPLE_EXCEPTION(ENRKeysAreNotSorted);
 
 class ENR
 {

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -92,8 +92,8 @@ Host::Host(
                      // simultaneously
     m_tcp4Acceptor(m_ioService),
     m_runTimer(m_ioService),
-    m_alias(_secretAndENR.first),
-    m_enr(_secretAndENR.second),
+    m_alias{_secretAndENR.first},
+    m_enr{_secretAndENR.second},
     m_lastPing(chrono::steady_clock::time_point::min()),
     m_capabilityHost(createCapabilityHost(*this))
 {
@@ -1012,7 +1012,7 @@ std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _
         }
 
         // Support for older format without ENR
-        secret = Secret{Secret(r[1].toBytes())};
+        secret = Secret{r[1].toBytes()};
     }
     else
     {
@@ -1021,6 +1021,7 @@ std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _
     }
 
     // TODO(gumb0): update ENR in case new address given in config
+    // https://github.com/ethereum/aleth/issues/5551
     auto const address = _netConfig.publicIPAddress.empty() ?
                              bi::address{} :
                              bi::address::from_string(_netConfig.publicIPAddress);

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -1005,7 +1005,7 @@ std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _
     {
         if (r[1].isList())
         {
-            auto const secret = Secret{r[1][0].toBytes()};
+            secret = Secret{r[1][0].toBytes()};
             auto enrRlp = r[1][1];
 
             return make_pair(secret, parseV4ENR(enrRlp));
@@ -1020,6 +1020,7 @@ std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _
         secret = KeyPair::create().secret();
     }
 
+    // TODO(gumb0): update ENR in case new address given in config
     auto const address = _netConfig.publicIPAddress.empty() ?
                              bi::address{} :
                              bi::address::from_string(_netConfig.publicIPAddress);

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -82,7 +82,8 @@ bytes ReputationManager::data(SessionFace const& _s, string const& _sub) const
     return bytes();
 }
 
-Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkConfig const& _n)
+Host::Host(
+    string const& _clientVersion, pair<Secret, ENR> const& _secretAndENR, NetworkConfig const& _n)
   : Worker("p2p", 0),
     m_clientVersion(_clientVersion),
     m_netConfig(_n),
@@ -91,15 +92,17 @@ Host::Host(string const& _clientVersion, KeyPair const& _alias, NetworkConfig co
                      // simultaneously
     m_tcp4Acceptor(m_ioService),
     m_runTimer(m_ioService),
-    m_alias(_alias),
+    m_alias(_secretAndENR.first),
+    m_enr(_secretAndENR.second),
     m_lastPing(chrono::steady_clock::time_point::min()),
     m_capabilityHost(createCapabilityHost(*this))
 {
     cnetnote << "Id: " << id();
+    cnetnote << "ENR: " << m_enr;
 }
 
-Host::Host(string const& _clientVersion, NetworkConfig const& _n, bytesConstRef _restoreNetwork):
-    Host(_clientVersion, networkAlias(_restoreNetwork), _n)
+Host::Host(string const& _clientVersion, NetworkConfig const& _n, bytesConstRef _restoreNetwork)
+  : Host(_clientVersion, restoreENR(_restoreNetwork, _n), _n)
 {
     m_restoreNetwork = _restoreNetwork.toBytes();
 }
@@ -919,7 +922,12 @@ bytes Host::saveNetwork() const
     }
 
     RLPStream ret(3);
-    ret << dev::p2p::c_protocolVersion << m_alias.secret().ref();
+    ret << dev::p2p::c_protocolVersion;
+
+    ret.appendList(2);
+    ret << m_alias.secret().ref();
+    m_enr.streamRLP(ret);
+
     ret.appendList(count);
     if (!!count)
         ret.appendRaw(network.out(), count);
@@ -989,13 +997,34 @@ bool Host::peerSlotsAvailable(Host::PeerSlotType _type /*= Ingress*/)
     return peerCount() + m_pendingPeerConns.size() < peerSlots(_type);
 }
 
-KeyPair Host::networkAlias(bytesConstRef _b)
+std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _netConfig)
 {
     RLP r(_b);
+    Secret secret;
     if (r.itemCount() == 3 && r[0].isInt() && r[0].toInt<unsigned>() >= 3)
-        return KeyPair(Secret(r[1].toBytes()));
+    {
+        if (r[1].isList())
+        {
+            auto const secret = Secret{r[1][0].toBytes()};
+            auto enrRlp = r[1][1];
+
+            return make_pair(secret, ENR{enrRlp});
+        }
+
+        // Support for older format without ENR
+        secret = Secret{Secret(r[1].toBytes())};
+    }
     else
-        return KeyPair::create();
+    {
+        // no private key found, create new one
+        secret = KeyPair::create().secret();
+    }
+
+    auto const address = _netConfig.publicIPAddress.empty() ?
+                             bi::address{} :
+                             bi::address::from_string(_netConfig.publicIPAddress);
+    return make_pair(
+        secret, createV4ENR(secret, address, _netConfig.listenPort, _netConfig.listenPort));
 }
 
 bool Host::nodeTableHasNode(Public const& _id) const

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -1008,7 +1008,7 @@ std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _
             auto const secret = Secret{r[1][0].toBytes()};
             auto enrRlp = r[1][1];
 
-            return make_pair(secret, ENR{enrRlp});
+            return make_pair(secret, parseV4ENR(enrRlp));
         }
 
         // Support for older format without ENR

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -225,6 +225,9 @@ public:
     /// Get the node information.
     p2p::NodeInfo nodeInfo() const { return NodeInfo(id(), (networkConfig().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkConfig().publicIPAddress), m_tcpPublic.port(), m_clientVersion); }
 
+    /// Get Ethereum Node Record of the host
+    ENR enr() const { return m_enr; }
+
     /// Apply function to each session
     void forEachPeer(
         std::string const& _capabilityName, std::function<bool(NodeID const&)> _f) const;

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -287,7 +287,7 @@ private:
     /// Shutdown network. Not thread-safe; to be called only by worker.
     virtual void doneWorking();
 
-    /// Get or create host Ethereum Node record.
+    /// Get or create host's Ethereum Node record.
     std::pair<Secret, ENR> restoreENR(bytesConstRef _b, NetworkConfig const& _networkConfig);
 
     bool nodeTableHasNode(Public const& _id) const;

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common.h"
+#include "ENR.h"
 #include "Network.h"
 #include "NodeTable.h"
 #include "Peer.h"
@@ -123,11 +124,8 @@ public:
 
     /// Alternative constructor that allows providing the node key directly
     /// without restoring the network.
-    Host(
-        std::string const& _clientVersion,
-        KeyPair const& _alias,
-        NetworkConfig const& _n = NetworkConfig{}
-    );
+    Host(std::string const& _clientVersion, std::pair<Secret, ENR> const& _secretAndENR,
+        NetworkConfig const& _n = NetworkConfig{});
 
     /// Will block on network process events.
     virtual ~Host();
@@ -286,8 +284,8 @@ private:
     /// Shutdown network. Not thread-safe; to be called only by worker.
     virtual void doneWorking();
 
-    /// Get or create host identifier (KeyPair).
-    static KeyPair networkAlias(bytesConstRef _b);
+    /// Get or create host Ethereum Node record.
+    std::pair<Secret, ENR> restoreENR(bytesConstRef _b, NetworkConfig const& _networkConfig);
 
     bool nodeTableHasNode(Public const& _id) const;
     Node nodeFromNodeTable(Public const& _id) const;
@@ -334,7 +332,9 @@ private:
     std::set<Peer*> m_pendingPeerConns;									/// Used only by connect(Peer&) to limit concurrently connecting to same node. See connect(shared_ptr<Peer>const&).
 
     bi::tcp::endpoint m_tcpPublic;											///< Our public listening endpoint.
-    KeyPair m_alias;															///< Alias for network communication. Network address is k*G. k is key material. TODO: Replace KeyPair.
+    /// Alias for network communication.
+    KeyPair m_alias;
+    ENR m_enr;
     std::shared_ptr<NodeTable> m_nodeTable;									///< Node table (uses kademlia-like discovery).
     mutable std::mutex x_nodeTable;
     std::shared_ptr<NodeTable> nodeTable() const { Guard l(x_nodeTable); return m_nodeTable; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(unittest_sources
 
     unittests/libp2p/capability.cpp
     unittests/libp2p/eip-8.cpp
+    unittests/libp2p/ENRTest.cpp
     unittests/libp2p/rlpx.cpp
 
     unittests/libweb3core/memorydb.cpp

--- a/test/unittests/libp2p/ENRTest.cpp
+++ b/test/unittests/libp2p/ENRTest.cpp
@@ -157,9 +157,12 @@ TEST(enr, createV4)
     auto keyValuePairs = enr.keyValuePairs();
 
     EXPECT_TRUE(contains(keyValuePairs, std::string("id")));
+    EXPECT_EQ(keyValuePairs["id"], rlp("v4"));
     EXPECT_TRUE(contains(keyValuePairs, std::string("secp256k1")));
     EXPECT_TRUE(contains(keyValuePairs, std::string("ip")));
     EXPECT_EQ(keyValuePairs["ip"], rlp(bytes{127, 0, 0, 1}));
     EXPECT_TRUE(contains(keyValuePairs, std::string("tcp")));
+    EXPECT_EQ(keyValuePairs["tcp"], rlp(3322));
     EXPECT_TRUE(contains(keyValuePairs, std::string("udp")));
+    EXPECT_EQ(keyValuePairs["udp"], rlp(5544));
 }

--- a/test/unittests/libp2p/ENRTest.cpp
+++ b/test/unittests/libp2p/ENRTest.cpp
@@ -1,0 +1,163 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#include <libp2p/ENR.h>
+#include <gtest/gtest.h>
+
+using namespace dev;
+using namespace dev::p2p;
+
+namespace
+{
+bytes dummySignFunction(bytesConstRef)
+{
+    return {};
+}
+bool dummyVerifyFunction(std::map<std::string, bytes> const&, bytesConstRef, bytesConstRef)
+{
+    return true;
+};
+}  // namespace
+
+TEST(enr, parse)
+{
+    // Test ENR from EIP-778
+    bytes rlp = fromHex(
+        "f884b8407098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f3"
+        "0813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c01826964827634826970847f00000189736563703235"
+        "366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31388375647082765f");
+    ENR enr = parseV4ENR(RLP{rlp});
+
+    EXPECT_EQ(enr.signature(),
+        fromHex("7098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f3"
+                "0813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c"));
+    EXPECT_EQ(enr.sequenceNumber(), 1);
+    auto keyValues = enr.keyValues();
+    EXPECT_EQ(RLP(keyValues["id"]).toString(), "v4");
+    EXPECT_EQ(RLP(keyValues["ip"]).toBytes(), fromHex("7f000001"));
+    EXPECT_EQ(RLP(keyValues["secp256k1"]).toBytes(),
+        fromHex("03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138"));
+    EXPECT_EQ(RLP(keyValues["udp"]).toInt<uint64_t>(), 0x765f);
+}
+
+TEST(enr, createAndParse)
+{
+    auto keyPair = KeyPair::create();
+
+    ENR enr1 = createV4ENR(keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+
+    RLPStream s;
+    enr1.streamRLP(s);
+    bytes rlp = s.out();
+
+    ENR enr2 = parseV4ENR(RLP{rlp});
+
+    EXPECT_EQ(enr1.signature(), enr2.signature());
+    EXPECT_EQ(enr1.sequenceNumber(), enr2.sequenceNumber());
+    EXPECT_EQ(enr1.keyValues(), enr2.keyValues());
+}
+
+TEST(enr, parseTooBigRlp)
+{
+    std::map<std::string, bytes> keyValues = {{"key", rlp(bytes(300, 'a'))}};
+
+    ENR enr1{0, keyValues, dummySignFunction};
+
+    RLPStream s;
+    enr1.streamRLP(s);
+    bytes rlp = s.out();
+
+    EXPECT_THROW(ENR(RLP(rlp), dummyVerifyFunction), ENRIsTooBig);
+}
+
+TEST(enr, parseKeysNotSorted)
+{
+    std::vector<std::pair<std::string, bytes>> keyValues = {{"keyB", RLPNull}, {"keyA", RLPNull}};
+
+    RLPStream s((keyValues.size() * 2 + 2));
+    s << bytes{};  // signature
+    s << 0;        // sequence number
+    for (auto const keyValue : keyValues)
+    {
+        s << keyValue.first;
+        s.appendRaw(keyValue.second);
+    }
+    bytes rlp = s.out();
+
+    EXPECT_THROW(ENR(RLP(rlp), dummyVerifyFunction), ENRKeysAreNotUniqueSorted);
+}
+
+TEST(enr, parseKeysNotUnique)
+{
+    std::vector<std::pair<std::string, bytes>> keyValues = {{"key", RLPNull}, {"key", RLPNull}};
+
+    RLPStream s((keyValues.size() * 2 + 2));
+    s << bytes{};  // signature
+    s << 0;        // sequence number
+    for (auto const keyValue : keyValues)
+    {
+        s << keyValue.first;
+        s.appendRaw(keyValue.second);
+    }
+    bytes rlp = s.out();
+
+    EXPECT_THROW(ENR(RLP(rlp), dummyVerifyFunction), ENRKeysAreNotUniqueSorted);
+}
+
+TEST(enr, parseInvalidSignature)
+{
+    auto keyPair = KeyPair::create();
+
+    ENR enr1 = createV4ENR(keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+
+    RLPStream s;
+    enr1.streamRLP(s);
+    bytes rlp = s.out();
+
+    // change one byte of a signature
+    auto signatureOffset = RLP{rlp}[0].payload().data() - rlp.data();
+    rlp[signatureOffset]++;
+
+    EXPECT_THROW(parseV4ENR(RLP{rlp}), ENRSignatureIsInvalid);
+}
+
+TEST(enr, parseV4WithInvalidID)
+{
+    std::map<std::string, bytes> keyValues = {{"id", rlp("v5")}};
+
+    ENR enr1{0, keyValues, dummySignFunction};
+
+    RLPStream s;
+    enr1.streamRLP(s);
+    bytes rlp = s.out();
+
+    EXPECT_THROW(parseV4ENR(RLP{rlp}), ENRSignatureIsInvalid);
+}
+
+TEST(enr, parseV4WithNoPublicKey)
+{
+    std::map<std::string, bytes> keyValues = {{"id", rlp("v4")}};
+
+    ENR enr1{0, keyValues, dummySignFunction};
+
+    RLPStream s;
+    enr1.streamRLP(s);
+    bytes rlp = s.out();
+
+    EXPECT_THROW(parseV4ENR(RLP{rlp}), ENRSignatureIsInvalid);
+}
+
+TEST(enr, createV4)
+{
+    auto keyPair = KeyPair::create();
+    ENR enr = createV4ENR(keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+
+    auto keyValues = enr.keyValues();
+
+    EXPECT_TRUE(contains(keyValues, std::string("id")));
+    EXPECT_TRUE(contains(keyValues, std::string("secp256k1")));
+    EXPECT_TRUE(contains(keyValues, std::string("ip")));
+    EXPECT_TRUE(contains(keyValues, std::string("tcp")));
+    EXPECT_TRUE(contains(keyValues, std::string("udp")));
+}

--- a/test/unittests/libp2p/eip-8.cpp
+++ b/test/unittests/libp2p/eip-8.cpp
@@ -378,7 +378,8 @@ shared_ptr<TestHandshake> TestHandshake::runWithInput(
     });
 
     // Spawn a client to execute the handshake.
-    auto host = make_shared<Host>("peer name", KeyPair(_hostAlias));
+    auto host = make_shared<Host>(
+        "peer name", make_pair(_hostAlias, createV4ENR(_hostAlias, endpoint.address(), 0, 0)));
     auto client = make_shared<RLPXSocket>(io);
     shared_ptr<TestHandshake> handshake;
     if (_remoteID == NodeID())

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -200,7 +200,13 @@ BOOST_AUTO_TEST_CASE(saveNodes)
     RLP r(firstHostNetwork);
     BOOST_REQUIRE(r.itemCount() == 3);
     BOOST_REQUIRE(r[0].toInt<unsigned>() == dev::p2p::c_protocolVersion);
-    BOOST_REQUIRE_EQUAL(r[1].toBytes().size(), 32); // secret
+
+    BOOST_REQUIRE(r[1].isList());
+    BOOST_REQUIRE(r[1].itemCount() == 2);
+    BOOST_REQUIRE_EQUAL(r[1][0].toBytes().size(), 32);  // secret
+    BOOST_REQUIRE(r[1][1].isList());                    // ENR
+    cerr << r[1] << "\n";
+
     BOOST_REQUIRE(r[2].itemCount() >= c_nodes);
     
     for (auto i: r[2])

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(saveENR)
     ENR enr2 = host2.enr();
 
     BOOST_REQUIRE_EQUAL(enr1.sequenceNumber(), enr2.sequenceNumber());
-    BOOST_REQUIRE(enr1.keyValues() == enr2.keyValues());
+    BOOST_REQUIRE(enr1.keyValuePairs() == enr2.keyValuePairs());
     BOOST_REQUIRE(enr1.signature() == enr2.signature());
 }
 

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -205,7 +205,6 @@ BOOST_AUTO_TEST_CASE(saveNodes)
     BOOST_REQUIRE(r[1].itemCount() == 2);
     BOOST_REQUIRE_EQUAL(r[1][0].toBytes().size(), 32);  // secret
     BOOST_REQUIRE(r[1][1].isList());                    // ENR
-    cerr << r[1] << "\n";
 
     BOOST_REQUIRE(r[2].itemCount() >= c_nodes);
     
@@ -232,6 +231,7 @@ BOOST_AUTO_TEST_CASE(saveENR)
 
     BOOST_REQUIRE_EQUAL(enr1.sequenceNumber(), enr2.sequenceNumber());
     BOOST_REQUIRE(enr1.keyValues() == enr2.keyValues());
+    BOOST_REQUIRE(enr1.signature() == enr2.signature());
 }
 
 

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -219,6 +219,22 @@ BOOST_AUTO_TEST_CASE(saveNodes)
         delete host;
 }
 
+BOOST_AUTO_TEST_CASE(saveENR)
+{
+    NetworkConfig config("13.74.189.147", "", 30303, false);
+    Host host1("Test", config);
+    ENR enr1 = host1.enr();
+
+    bytes store(host1.saveNetwork());
+
+    Host host2("Test", config, bytesConstRef(&store));
+    ENR enr2 = host2.enr();
+
+    BOOST_REQUIRE_EQUAL(enr1.sequenceNumber(), enr2.sequenceNumber());
+    BOOST_REQUIRE(enr1.keyValues() == enr2.keyValues());
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(p2pPeer, TestOutputHelperFixture)


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-778

This creates ENR record for the host at program start, filling values based on `--public-ip` and `--listen` CLI parameters.

For example `aleth --public-ip 13.74.189.147 --listen 30303` creates ENR like
```
[<signature>, 0, "id", "v4", "ip", 0xD4ABD93, "sec256k1", <compressed public key>, "tcp", 30303, "udp", 30303]
```
(sequence number is always 0 now, updating ENR will be added in later PRs)

At program exit ENR is serialized into `network.rlp` file and restored at the next program start.

cc @fjl 