### PR TITLE
Fix logic used to determine if Aleth should request dao fork block header from potential peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@
 - Fixed: [#5519](https://github.com/ethereum/aleth/pull/5519) Correctly handle Discovery messages with known public key but unknown endpoint.
 - Fixed: [#5523](https://github.com/ethereum/aleth/pull/5523) [#5533](https://github.com/ethereum/aleth/pull/5533) Fix syncing terminating prematurely because of race condition.
 - Added: [#5526](https://github.com/ethereum/aleth/pull/5526) Improved logging when loading chain config json containing syntax error.
+- Fixed: [#5539](https://github.com/ethereum/aleth/pull/5539) Fix logic for determining if dao hard fork block header should be requested
 
 [1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...master

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -63,7 +63,7 @@ private:
     u256 m_startingBlock = 0;
 };
 
-static constexpr int64_t c_infiniteBlockNumber = std::numeric_limits<int64_t>::max();
+constexpr int64_t c_infiniteBlockNumber = std::numeric_limits<int64_t>::max();
 
 struct ChainOperationParams
 {

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -63,7 +63,7 @@ private:
     u256 m_startingBlock = 0;
 };
 
-static constexpr int64_t c_infiniteBlockNumer = std::numeric_limits<int64_t>::max();
+static constexpr int64_t c_infiniteBlockNumber = std::numeric_limits<int64_t>::max();
 
 struct ChainOperationParams
 {
@@ -87,15 +87,15 @@ public:
     u256 minGasLimit;
     u256 maxGasLimit;
     u256 gasLimitBoundDivisor;
-    u256 homesteadForkBlock = c_infiniteBlockNumer;
-    u256 EIP150ForkBlock = c_infiniteBlockNumer;
-    u256 EIP158ForkBlock = c_infiniteBlockNumer;
-    u256 byzantiumForkBlock = c_infiniteBlockNumer;
-    u256 eWASMForkBlock = c_infiniteBlockNumer;
-    u256 constantinopleForkBlock = c_infiniteBlockNumer;
-    u256 constantinopleFixForkBlock = c_infiniteBlockNumer;
-    u256 daoHardforkBlock = c_infiniteBlockNumer;
-    u256 experimentalForkBlock = c_infiniteBlockNumer;
+    u256 homesteadForkBlock = c_infiniteBlockNumber;
+    u256 EIP150ForkBlock = c_infiniteBlockNumber;
+    u256 EIP158ForkBlock = c_infiniteBlockNumber;
+    u256 byzantiumForkBlock = c_infiniteBlockNumber;
+    u256 eWASMForkBlock = c_infiniteBlockNumber;
+    u256 constantinopleForkBlock = c_infiniteBlockNumber;
+    u256 constantinopleFixForkBlock = c_infiniteBlockNumber;
+    u256 daoHardforkBlock = c_infiniteBlockNumber;
+    u256 experimentalForkBlock = c_infiniteBlockNumber;
     int chainID = 0;    // Distinguishes different chains (mainnet, Ropsten, etc).
     int networkID = 0;  // Distinguishes different sub protocols.
 

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -30,9 +30,9 @@ std::ostream& dev::eth::operator<<(std::ostream& _out, SyncStatus const& _sync)
 namespace  // Helper functions.
 {
 
-unsigned constexpr c_maxPeerUknownNewBlocks = 1024; /// Max number of unknown new blocks peer can give us
-unsigned constexpr c_maxRequestHeaders = 1024;
-unsigned constexpr c_maxRequestBodies = 1024;
+constexpr unsigned c_maxPeerUknownNewBlocks = 1024; /// Max number of unknown new blocks peer can give us
+constexpr unsigned c_maxRequestHeaders = 1024;
+constexpr unsigned c_maxRequestBodies = 1024;
 
 template<typename T> bool haveItem(std::map<unsigned, T>& _container, unsigned _number)
 {

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -213,7 +213,7 @@ bool BlockChainSync::requestDaoForkBlockHeader(NodeID const& _peerID)
 {
     // DAO challenge
     u256 const daoHardfork = host().chain().sealEngine()->chainParams().daoHardforkBlock;
-    if (daoHardfork == 0 || daoHardfork == c_infiniteBlockNumer)
+    if (daoHardfork == 0 || daoHardfork == c_infiniteBlockNumber)
         return false;
 
     m_daoChallengedPeers.insert(_peerID);

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -230,8 +230,8 @@ void BlockChainSync::onPeerStatus(EthereumPeer const& _peer)
 bool BlockChainSync::requestDaoForkBlockHeader(NodeID const& _peerID)
 {
     // DAO challenge
-    unsigned const daoHardfork = static_cast<unsigned>(host().chain().sealEngine()->chainParams().daoHardforkBlock);
-    if (daoHardfork == 0)
+    u256 const daoHardfork = host().chain().sealEngine()->chainParams().daoHardforkBlock;
+    if (daoHardfork == 0 || daoHardfork == c_infiniteBlockNumer)
         return false;
 
     m_daoChallengedPeers.insert(_peerID);

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -1,23 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file BlockChainSync.cpp
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
+/// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include "BlockChainSync.h"
 
@@ -35,11 +18,6 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-unsigned const c_maxPeerUknownNewBlocks = 1024; /// Max number of unknown new blocks peer can give us
-unsigned const c_maxRequestHeaders = 1024;
-unsigned const c_maxRequestBodies = 1024;
-
-
 std::ostream& dev::eth::operator<<(std::ostream& _out, SyncStatus const& _sync)
 {
     _out << "protocol: " << _sync.protocolVersion << endl;
@@ -51,6 +29,10 @@ std::ostream& dev::eth::operator<<(std::ostream& _out, SyncStatus const& _sync)
 
 namespace  // Helper functions.
 {
+
+unsigned constexpr c_maxPeerUknownNewBlocks = 1024; /// Max number of unknown new blocks peer can give us
+unsigned constexpr c_maxRequestHeaders = 1024;
+unsigned constexpr c_maxRequestBodies = 1024;
 
 template<typename T> bool haveItem(std::map<unsigned, T>& _container, unsigned _number)
 {

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -1,23 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file BlockChainSync.h
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #pragma once
 


### PR DESCRIPTION
Fix #5271 

Update the logic which Aleth uses to determine if it should request the DAO fork block header from a peer before starting a sync based on the value of the `daoHardFork ` chain configuration parameter. Aleth needs to check for 0 or `c_infiniteBlockNumber ` (rather than just 0) because Aleth initializes the  `daoHardFork `configuration parameter to `c_infiniteBlockNumber ` by default.

The impact of these changes is that one doesn't have to explicitly specify `daoHardFork `= 0x0 in any `config.json` that they wish to use with Aleth.