### PR TITLE
Improve eth_flush performance by disabling wait in Client::doWork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed: [#5452](https://github.com/ethereum/aleth/pull/5452) Correctly handle Discovery messages when the peer changes public key.
 - Fixed: [#5519](https://github.com/ethereum/aleth/pull/5519) Correctly handle Discovery messages with known public key but unknown endpoint.
 - Fixed: [#5523](https://github.com/ethereum/aleth/pull/5523) [#5533](https://github.com/ethereum/aleth/pull/5533) Fix syncing terminating prematurely because of race condition.
-- Fixed: [#5539](https://github.com/ethereum/aleth/pull/5539) Fix logic for determining if dao hard fork block header should be requested
+- Fixed: [#5539](https://github.com/ethereum/aleth/pull/5539) Fix logic for determining if dao hard fork block header should be requested.
+- Fixed: [#5547](https://github.com/ethereum/aleth/pull/5547) Fix unnecessary slow-down of eth_flush RPC method.
 
 [1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...master

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -791,7 +791,7 @@ Block Client::block(h256 const& _blockHash, PopulationStatistics* o_stats) const
 
 void Client::flushTransactions()
 {
-    doWork();
+    doWork(false);
 }
 
 Transactions Client::pending() const


### PR DESCRIPTION
`eth_flush` is a non-standard / not documented method, I don't know for sure why it was created, but it seems to be suitable workaround for the problems Solidity team was having lately running soltest+aleth on CI https://github.com/ethereum/solidity/pull/6457

Their problem basically boils down to `eth_sendTransaction`, followed by `test_mineBlocks(1)` doesn't guarantee that the submitted transaction will end up included in the mined block.
(The reason is the way `Client::doWork` works - it checks for new transactions in the Transaction Queue, then checks whether it should start sealing current pending block. If `eth_sendTransaction` & `test_mineBlocks` calls happen in-between these two checks, the mined block will not contain the transaction)

So quick workaround solution without complicating `Client` logic further could be to call `eth_flush` right after `eth_sendTransaction` but before `test_mineBlocks` - that will run `Client::doWork` once, which should push new transaction from Transaction Queue to the pending block.

This PR disables 1 second sleep in the end of `Client::doWork` (when called from `eth_flush`) which looks unnecessary for this case and is slowing down Solidity tests significantly.