### PR TITLE
Split NodeTable::onPacketReceived into separate handler methods

### DIFF
--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -64,6 +64,7 @@ class NodeTable;
 inline std::ostream& operator<<(std::ostream& _out, NodeTable const& _nodeTable);
 
 struct NodeEntry;
+struct DiscoveryDatagram;
 
 /**
  * NodeTable using modified kademlia for node discovery and preference.
@@ -276,6 +277,15 @@ protected:
     /// Called by m_socket when packet is received.
     void onPacketReceived(
         UDPSocketFace*, bi::udp::endpoint const& _from, bytesConstRef _packet) override;
+
+    std::shared_ptr<NodeEntry> handlePong(
+        bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
+    std::shared_ptr<NodeEntry> handleNeighbours(
+        bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
+    std::shared_ptr<NodeEntry> handleFindNode(
+        bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
+    std::shared_ptr<NodeEntry> handlePingNode(
+        bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
 
     /// Called by m_socket when socket is disconnected.
     void onSocketDisconnected(UDPSocketFace*) override {}


### PR DESCRIPTION
`NodeTable::onPacketReceived` is too big, and more packet types will be added for ENR extension support.