### PR TITLE
testeth check for unused folders in test fillers

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -1008,16 +1008,19 @@ public:
     bcTestFixture()
     {
         test::BlockchainTestSuite suite;
-        string const& casename = boost::unit_test::framework::current_test_case().p_name;
+        string const casename = boost::unit_test::framework::current_test_case().p_name;
+        boost::filesystem::path suiteFillerPath = suite.getFullPathFiller(casename).parent_path();
 
         //skip wallet test as it takes too much time (250 blocks) run it with --all flag
         if (casename == "bcWalletTest" && !test::Options::get().all)
         {
             cnote << "Skipping " << casename << " because --all option is not specified.\n";
+            test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
             return;
         }
 
         suite.runAllTestsInFolder(casename);
+        test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
     }
 };
 
@@ -1026,8 +1029,10 @@ public:
     bcTransitionFixture()
     {
         test::TransitionTestsSuite suite;
-        string const& casename = boost::unit_test::framework::current_test_case().p_name;
+        string const casename = boost::unit_test::framework::current_test_case().p_name;
+        boost::filesystem::path suiteFillerPath = suite.getFullPathFiller(casename).parent_path();
         suite.runAllTestsInFolder(casename);
+        test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
     }
 };
 
@@ -1037,14 +1042,18 @@ public:
     bcGeneralTestsFixture()
     {
         test::BCGeneralStateTestsSuite suite;
-        string const& casename = boost::unit_test::framework::current_test_case().p_name;
+        string const casename = boost::unit_test::framework::current_test_case().p_name;
+        boost::filesystem::path suiteFillerPath = suite.getFullPathFiller(casename).parent_path();
+
         //skip this test suite if not run with --all flag (cases are already tested in state tests)
         if (!test::Options::get().all)
         {
             cnote << "Skipping hive test " << casename << ". Use --all to run it.\n";
+            test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
             return;
         }
         suite.runAllTestsInFolder(casename);
+        test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
     }
 };
 

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -142,16 +142,23 @@ class GeneralTestFixture
 public:
 	GeneralTestFixture()
 	{
-		test::StateTestSuite suite;
-		string casename = boost::unit_test::framework::current_test_case().p_name;
-		if (casename == "stQuadraticComplexityTest" && !test::Options::get().all)
-		{
-			std::cout << "Skipping " << casename << " because --all option is not specified.\n";
-			return;
-		}
-		suite.runAllTestsInFolder(casename);
-	}
+        test::StateTestSuite suite;
+        string casename = boost::unit_test::framework::current_test_case().p_name;
+        boost::filesystem::path suiteFillerPath = suite.getFullPathFiller(casename).parent_path();
+
+        // Check specific test cases
+        static vector<string> timeConsumingTestSuites{string{"stQuadraticComplexityTest"}};
+        if (test::inArray(timeConsumingTestSuites, casename) && !test::Options::get().all)
+        {
+            std::cout << "Skipping " << casename << " because --all option is not specified.\n";
+            test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
+            return;
+        }
+        suite.runAllTestsInFolder(casename);
+        test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
+    }
 };
+
 
 BOOST_FIXTURE_TEST_SUITE(GeneralStateTests, GeneralTestFixture)
 

--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -219,9 +219,11 @@ class TransactionTestFixture
 public:
     TransactionTestFixture()
     {
-        string const& casename = boost::unit_test::framework::current_test_case().p_name;
         test::TransactionTestSuite suite;
+        string const casename = boost::unit_test::framework::current_test_case().p_name;
+        boost::filesystem::path suiteFillerPath = suite.getFullPathFiller(casename).parent_path();
         suite.runAllTestsInFolder(casename);
+        test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
     }
 };
 

--- a/test/tools/jsontests/vm.cpp
+++ b/test/tools/jsontests/vm.cpp
@@ -488,13 +488,16 @@ public:
     VmTestFixture()
     {
         test::VmTestSuite suite;
-        string const& casename = boost::unit_test::framework::current_test_case().p_name;
+        string const casename = boost::unit_test::framework::current_test_case().p_name;
+        boost::filesystem::path suiteFillerPath = suite.getFullPathFiller(casename).parent_path();
         if (casename == "vmPerformance" && !Options::get().all)
         {
             std::cout << "Skipping " << casename << " because --all option is not specified.\n";
+            test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
             return;
         }
         suite.runAllTestsInFolder(casename);
+        test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
     }
 };
 

--- a/test/tools/libtesteth/TestOutputHelper.h
+++ b/test/tools/libtesteth/TestOutputHelper.h
@@ -52,9 +52,15 @@ public:
 	boost::filesystem::path const& testFile() { return m_currentTestFileName; }
 	void printTestExecStats();
 
+    // Mark the _folderName as executed for a given _suitePath (to filler files)
+    void markTestFolderAsFinished(
+        boost::filesystem::path const& _suitePath, std::string const& _folderName);
+
 private:
 	TestOutputHelper() {}
-	Timer m_timer;
+    void checkUnfinishedTestFolders();  // Checkup that all test folders are active during the test
+                                        // run
+    Timer m_timer;
 	size_t m_currTest;
 	size_t m_maxTests;
 	std::string m_currentTestName;
@@ -62,6 +68,8 @@ private:
 	boost::filesystem::path m_currentTestFileName;
 	typedef std::pair<double, std::string> execTimeName;
 	std::vector<execTimeName> m_execTimeResults;
+    typedef std::set<std::string> FolderNameSet;
+    std::map<boost::filesystem::path, FolderNameSet> m_finishedTestFoldersMap;
 };
 
 class TestOutputHelperFixture


### PR DESCRIPTION
example on StateTests

I noticed that sometimes test suites are forgotten when copying boost test suite declarations from `GeneralStateTests` into `BCGeneralStateTests`. It seems to be unable to define the list of test cases at one place one time and copy, so then testeth could check if there are unused folders in test fillers. 

Also checking for unused test folders in other test suites would be nice. 
