### PR TITLE
Rephrase error messages in EthereumPeer::validate and re-order validation conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.7.0] - Unreleased
 
 - Added: [#5537](https://github.com/ethereum/aleth/pull/5537) Creating Ethereum Node Record (ENR) at program start.
-- Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages
+- Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 
 [1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.7.0] - Unreleased
 
 - Added: [#5537](https://github.com/ethereum/aleth/pull/5537) Creating Ethereum Node Record (ENR) at program start.
+- Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages
 
 [1.6.0]: https://github.com/ethereum/aleth/compare/v1.6.0-alpha.1...master
 

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -1,19 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include "EthereumPeer.h"
 #include <libethcore/Common.h>
@@ -24,10 +11,10 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-static std::string const c_ethCapability = "eth";
-
 namespace
 {
+std::string const c_ethCapability = "eth";
+
 string toString(Asking _a)
 {
     switch (_a)

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -67,17 +67,20 @@ void EthereumPeer::setStatus(unsigned _protocolVersion, u256 const& _networkId,
 std::string EthereumPeer::validate(
     h256 const& _hostGenesisHash, unsigned _hostProtocolVersion, u256 const& _hostNetworkId) const
 {
-    std::string error;
-    if (m_genesisHash != _hostGenesisHash)
-        error = "Invalid genesis hash.";
+    std::stringstream error;
+    if (m_networkId != _hostNetworkId)
+        error << "Network identifier mismatch. Host network id: " << _hostNetworkId
+              << ", peer network id: " << m_networkId;
     else if (m_protocolVersion != _hostProtocolVersion)
-        error = "Invalid protocol version.";
-    else if (m_networkId != _hostNetworkId)
-        error = "Invalid network identifier.";
+        error << "Protocol version mismatch. Host protocol version: " << _hostProtocolVersion
+              << ", peer protocol version: " << m_protocolVersion;
+    else if (m_genesisHash != _hostGenesisHash)
+        error << "Genesis hash mismatch. Host genesis hash: " << _hostGenesisHash
+              << ", peer genesis hash: " << m_genesisHash;
     else if (m_asking != Asking::State && m_asking != Asking::Nothing)
-        error = "Peer banned for unexpected status message.";
+        error << "Peer banned for unexpected status message.";
 
-    return error;
+    return error.str();
 }
 
 void EthereumPeer::requestStatus(


### PR DESCRIPTION
Fix #5554

Rephrase the error messages in EthereumPeer::validate so that they are more descriptive and contain the peer and host values. Also order the validation conditions from broadest (network ID) to most targeted (unexpected status message) so that the sync logs are easier to read.
