### PR TITLE
add timeout to test_mineBlocks(_number, _timeout)

### DIFF
--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -50,9 +50,10 @@ public:
     void rewindToBlock(unsigned _number);
     h256 importRawBlock(std::string const& _blockRLP);
     bool completeSync();
+    void setTestMiningBlockTimeout(unsigned _timeout) { m_singleBlockMaxMiningTimeInSeconds = _timeout; }
 
 protected:
-    unsigned const m_singleBlockMaxMiningTimeInSeconds = 5;
+    unsigned m_singleBlockMaxMiningTimeInSeconds = 5;
 };
 
 ClientTest& asClientTest(Interface& _c);

--- a/libweb3jsonrpc/Test.cpp
+++ b/libweb3jsonrpc/Test.cpp
@@ -97,8 +97,9 @@ bool Test::test_setChainParams(Json::Value const& param1)
     }
 }
 
-bool Test::test_mineBlocks(int _number)
+bool Test::test_mineBlocks(int _number, int _timeout)
 {
+    asClientTest(m_eth).setTestMiningBlockTimeout(_timeout);
     if (!asClientTest(m_eth).mineBlocks(_number))  // Synchronous
         throw JsonRpcException("Mining failed.");
     return true;

--- a/libweb3jsonrpc/Test.h
+++ b/libweb3jsonrpc/Test.h
@@ -45,7 +45,7 @@ public:
     virtual std::string test_getLogHash(std::string const& _param1) override;
     virtual std::string test_importRawBlock(std::string const& _blockRLP) override;
     virtual bool test_setChainParams(const Json::Value& _param1) override;
-    virtual bool test_mineBlocks(int _number) override;
+    virtual bool test_mineBlocks(int _number, int _timeout) override;
     virtual bool test_modifyTimestamp(int _timestamp) override;
     virtual bool test_rewindToBlock(int _number) override;
 

--- a/libweb3jsonrpc/TestFace.h
+++ b/libweb3jsonrpc/TestFace.h
@@ -17,7 +17,7 @@ namespace dev {
                     this->bindAndAddMethod(jsonrpc::Procedure("test_getLogHash", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_STRING, NULL), &dev::rpc::TestFace::test_getLogHashI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_importRawBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING, "param1", jsonrpc::JSON_STRING, NULL), &dev::rpc::TestFace::test_importRawBlockI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_setChainParams", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_OBJECT, NULL), &dev::rpc::TestFace::test_setChainParamsI);
-                    this->bindAndAddMethod(jsonrpc::Procedure("test_mineBlocks", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_mineBlocksI);
+                    this->bindAndAddMethod(jsonrpc::Procedure("test_mineBlocks", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, "param2", jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_mineBlocksI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_modifyTimestamp", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_modifyTimestampI);
                     this->bindAndAddMethod(jsonrpc::Procedure("test_rewindToBlock", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::TestFace::test_rewindToBlockI);
                 }
@@ -35,7 +35,7 @@ namespace dev {
                 }
                 inline virtual void test_mineBlocksI(const Json::Value &request, Json::Value &response)
                 {
-                    response = this->test_mineBlocks(request[0u].asInt());
+                    response = this->test_mineBlocks(request[0u].asInt(), request[1u].asInt());
                 }
                 inline virtual void test_modifyTimestampI(const Json::Value &request, Json::Value &response)
                 {
@@ -48,7 +48,7 @@ namespace dev {
                 virtual std::string test_getLogHash(const std::string& param1) = 0;
                 virtual std::string test_importRawBlock(const std::string& param1) = 0;
                 virtual bool test_setChainParams(const Json::Value& param1) = 0;
-                virtual bool test_mineBlocks(int param1) = 0;
+                virtual bool test_mineBlocks(int param1, int param2) = 0;
                 virtual bool test_modifyTimestamp(int param1) = 0;
                 virtual bool test_rewindToBlock(int param1) = 0;
         };

--- a/libweb3jsonrpc/test.json
+++ b/libweb3jsonrpc/test.json
@@ -2,7 +2,7 @@
 { "name": "test_getLogHash", "params": [""], "order": [], "returns": ""},
 { "name": "test_importRawBlock", "params": [""], "order": [], "returns": ""},
 { "name": "test_setChainParams", "params": [{}], "order": [], "returns": false},
-{ "name": "test_mineBlocks", "params": [0], "returns": false },
+{ "name": "test_mineBlocks", "params": [0, 0], "returns": false },
 { "name": "test_modifyTimestamp", "params": [0], "returns": false },
 { "name": "test_rewindToBlock", "params": [0], "returns": false }
 ]


### PR DESCRIPTION
Some test blocks might take a lot of time to mine (heavy transactions) 
Thus it would be good to have the mining timeout option to be configurable in the client. 

Changing this method will affect 
* Solidity rpc tests
* Requrie retesteth test rpc change