### PR TITLE
build(scripts/docker/aleth.dockerfile): switchable build type

### DIFF
--- a/scripts/docker/aleth.dockerfile
+++ b/scripts/docker/aleth.dockerfile
@@ -7,6 +7,7 @@
 # Build stage
 
 FROM alpine:latest AS builder
+ARG BuildType=Release
 RUN apk add --no-cache \
         linux-headers \
         g++ \
@@ -15,7 +16,7 @@ RUN apk add --no-cache \
         git
 ADD . /source
 WORKDIR /build
-RUN cmake /source -DVMTRACE=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DHUNTER_JOBS_NUMBER=$(nproc)
+RUN cmake /source -DVMTRACE=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${BuildType} -DHUNTER_JOBS_NUMBER=$(nproc)
 RUN make -j $(nproc) && make install
 
 # Target: testeth


### PR DESCRIPTION
Now, we can set build type (`Release` or `Debug`) via Docker build-time argument `BuildType`.

Related to https://github.com/ethereum/aleth/issues/5565 (a potential solution to it, might not be the best).