### PR TITLE
Clean up RLPX handshake logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added: [#5557](https://github.com/ethereum/aleth/pull/5557) Improved debug logging of full sync.
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
+- Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
 
 ## [1.6.0] - Unreleased
 

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -15,7 +15,7 @@ using namespace std;
 const NodeIPEndpoint UnspecifiedNodeIPEndpoint = NodeIPEndpoint{{}, 0, 0};
 const Node UnspecifiedNode = Node{{}, UnspecifiedNodeIPEndpoint};
 
-const char* packetTypeToString(PacketType _packetType)
+char const* packetTypeToString(PacketType _packetType)
 {
     switch (_packetType)
     {

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -15,6 +15,27 @@ using namespace std;
 const NodeIPEndpoint UnspecifiedNodeIPEndpoint = NodeIPEndpoint{{}, 0, 0};
 const Node UnspecifiedNode = Node{{}, UnspecifiedNodeIPEndpoint};
 
+const char* packetTypeToString(PacketType _packetType)
+{
+    switch (_packetType)
+    {
+    case HelloPacket:
+        return "HelloPacket";
+    case DisconnectPacket:
+        return "DisconnectPacket";
+    case PingPacket:
+        return "PingPacket";
+    case PongPacket:
+        return "PongPacket";
+    case GetPeersPacket:
+        return "GetPeersPacket";
+    case PeersPacket:
+        return "PeersPacket";
+    default:
+        return "UnknownPacket";
+    }
+}
+
 bool isPublicAddress(string const& _addressToCheck)
 {
     return _addressToCheck.empty() ? false :

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -89,7 +89,7 @@ enum PacketType
     UserPacket = 0x10
 };
 
-const char* packetTypeToString(PacketType _packetType);
+char const* packetTypeToString(PacketType _packetType);
 
 enum DisconnectReason
 {

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -261,6 +261,11 @@ inline boost::log::formatting_ostream& operator<<(
     return _strm;
 }
 
+inline std::ostream& operator<<(std::ostream& _strm, NodeID const& _id)
+{
+    _strm << "##" << _id.abridged();
+    return _strm;
+}
 
 /// Simple stream output for a NodeIPEndpoint.
 std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep);

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -89,6 +89,8 @@ enum PacketType
     UserPacket = 0x10
 };
 
+const char* packetTypeToString(PacketType _packetType);
+
 enum DisconnectReason
 {
     DisconnectRequested = 0,

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -367,9 +367,9 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                                   << m_socket->remoteEndpoint() << ". Validating contents...";
 
                     /// check frame size
-                    bytes& header = m_handshakeInBuffer;
-                    uint32_t frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1]) << 8 |
-                                         (uint32_t)(header[0]) << 16;
+                    bytes const& header = m_handshakeInBuffer;
+                    uint32_t const frameSize = (uint32_t)(header[2]) | (uint32_t)(header[1]) << 8 |
+                                               (uint32_t)(header[0]) << 16;
                     constexpr size_t expectedFrameSizeBytes = 1024;
                     if (frameSize > expectedFrameSizeBytes)
                     {
@@ -470,14 +470,6 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                 }
             });
     }
-}
-
-const char* RLPXHandshake::connectionDirectionString() const
-{
-    if (m_originated)
-        return "p2p.connect.egress: ";
-    else
-        return "p2p.connect.ingress: ";
 }
 
 bool RLPXHandshake::remoteSocketConnected() const

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -239,7 +239,13 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
     
     if (_ech || m_nextState == Error || m_cancel)
     {
-        LOG(m_errorLogger) << "Handshake Failed (I/O Error: " << _ech.message() << ")";
+        stringstream errorStream;
+        errorStream << "Handshake Failed";
+        if (_ech)
+        {
+            errorStream << " (I/O Error: " << _ech.message() << ")";
+        }
+        LOG(m_errorLogger) << errorStream.str();
         return error();
     }
     
@@ -285,8 +291,8 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
     {
         m_nextState = ReadHello;
         LOG(m_logger) << (m_originated ? "p2p.connect.egress" : "p2p.connect.ingress")
-                      << " capabilities \"Hello\" packet to " << m_remote << "@"
-                      << m_socket->remoteEndpoint();
+                      << " capabilities " << packetTypeToString(HelloPacket) << " to " << m_remote
+                      << "@" << m_socket->remoteEndpoint();
 
         /// This pointer will be freed if there is an error otherwise
         /// it will be passed to Host which will take ownership.
@@ -410,7 +416,8 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                                         << (m_originated ? "p2p.connect.egress" :
                                                            "p2p.connect.ingress")
                                         << " hello frame: invalid packet type. Expected: "
-                                        << HelloPacket << ", received: " << packetType;
+                                        << packetTypeToString(HelloPacket)
+                                        << ", received: " << packetTypeToString(packetType);
                                     m_nextState = Error;
                                     transition();
                                     return;

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -226,10 +226,11 @@ void RLPXHandshake::error()
 {
     auto connected = m_socket->isConnected();
     if (connected && !m_socket->remoteEndpoint().address().is_unspecified())
-        LOG(m_errorLogger) << "Disconnecting " << m_remote << "@" << m_socket->remoteEndpoint()
-                           << " (Handshake Failed)";
+        LOG(m_errorLogger) << connectionDirectionString() << "Disconnecting " << m_remote << "@"
+                           << m_socket->remoteEndpoint() << " (Handshake Failed)";
     else
-        LOG(m_errorLogger) << "Handshake Failed (Connection reset by peer)";
+        LOG(m_errorLogger) << connectionDirectionString()
+                           << "Handshake Failed (Connection reset by peer)";
 
     cancel();
 }
@@ -242,11 +243,12 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
     if (_ech || m_nextState == Error || m_cancel)
     {
         stringstream errorStream;
-        errorStream << "Handshake Failed";
+        errorStream << connectionDirectionString() << "Handshake Failed";
         if (_ech)
         {
             errorStream << " (I/O Error: " << _ech.message() << ")";
         }
+        errorStream << " (" << m_remote << "@" << m_socket->remoteEndpoint() << ")";
         LOG(m_errorLogger) << errorStream.str();
         return error();
     }
@@ -259,8 +261,8 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
         if (!_ec)
         {
             if (!m_socket->remoteEndpoint().address().is_unspecified())
-                LOG(m_errorLogger) << "Disconnecting " << m_remote << "@"
-                                   << m_socket->remoteEndpoint() << " (Handshake Timeout)";
+                LOG(m_errorLogger) << connectionDirectionString() << "Disconnecting " << m_remote
+                                   << "@" << m_socket->remoteEndpoint() << " (Handshake Timeout)";
             cancel();
         }
     });
@@ -390,7 +392,8 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                             {
                                 if (!m_io)
                                 {
-                                    LOG(m_errorLogger) << "Internal error in handshake: "
+                                    LOG(m_errorLogger) << connectionDirectionString()
+                                                       << "Internal error in handshake: "
                                                           "RLPXFrameCoder disappeared.";
                                     m_nextState = Error;
                                     transition();
@@ -432,6 +435,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                                 catch (std::exception const& _e)
                                 {
                                     LOG(m_errorLogger)
+                                        << connectionDirectionString()
                                         << "Handshake causing an exception: " << _e.what();
                                     m_nextState = Error;
                                     transition();

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -11,6 +11,13 @@ using namespace dev;
 using namespace dev::p2p;
 using namespace dev::crypto;
 
+constexpr std::chrono::milliseconds RLPXHandshake::c_timeout;
+
+namespace
+{
+constexpr unsigned c_rlpxVersion = 4;
+}
+
 void RLPXHandshake::writeAuth()
 {
     LOG(m_logger) << "p2p.connect.egress sending auth to " << m_remote << "@"

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -125,6 +125,7 @@ protected:
     ba::steady_timer m_idleTimer;               ///< Timer which enforces c_timeout.
 
     Logger m_logger{createLogger(VerbosityTrace, "rlpx")};
+    Logger m_errorLogger{createLogger(VerbosityError, "rlpx")};
 };
     
 }

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -93,6 +93,9 @@ protected:
     /// Performs transition for m_nextState.
     virtual void transition(boost::system::error_code _ech = boost::system::error_code());
 
+    /// Get a string indicating if the connection is incoming or outgoing
+    const char* connectionDirectionString() const;
+
     State m_nextState = New;		///< Current or expected state of transition.
     bool m_cancel = false;			///< Will be set to true if connection was canceled.
     

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -96,6 +96,9 @@ protected:
     /// Get a string indicating if the connection is incoming or outgoing
     const char* connectionDirectionString() const;
 
+    /// Determine if the remote socket is still connected
+    bool remoteSocketConnected() const;
+
     State m_nextState = New;		///< Current or expected state of transition.
     bool m_cancel = false;			///< Will be set to true if connection was canceled.
     

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -130,7 +130,7 @@ protected:
     std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
     ba::steady_timer m_idleTimer;               ///< Timer which enforces c_timeout.
 
-    Logger m_logger{createLogger(VerbosityTrace, "rlpx")};
+    Logger m_logger{createLogger(VerbosityDebug, "rlpx")};
     Logger m_errorLogger{createLogger(VerbosityError, "rlpx")};
 };
     

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -94,7 +94,10 @@ protected:
     virtual void transition(boost::system::error_code _ech = boost::system::error_code());
 
     /// Get a string indicating if the connection is incoming or outgoing
-    const char* connectionDirectionString() const;
+    inline char const* connectionDirectionString() const
+    {
+        return m_originated ? "egress" : "ingress";
+    }
 
     /// Determine if the remote socket is still connected
     bool remoteSocketConnected() const;
@@ -132,7 +135,7 @@ protected:
     /// Timer which enforces c_timeout. Reset for each stage of the handshake.
     ba::steady_timer m_idleTimer;
 
-    Logger m_logger{createLogger(VerbosityDebug, "rlpx")};
+    Logger m_logger{createLogger(VerbosityTrace, "rlpx")};
     Logger m_errorLogger{createLogger(VerbosityError, "rlpx")};
 };
     

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -125,7 +125,7 @@ protected:
     std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
     boost::asio::deadline_timer m_idleTimer;	///< Timer which enforces c_timeout.
 
-    Logger m_logger{createLogger(VerbosityTrace, "net")};
+    Logger m_logger{createLogger(VerbosityTrace, "rlpx")};
 };
     
 }

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -17,8 +17,6 @@ namespace dev
 namespace p2p
 {
 
-static constexpr unsigned c_rlpxVersion = 4;
-
 /**
  * @brief Setup inbound or outbound connection for communication over RLPXFrameCoder.
  * RLPx Spec: https://github.com/ethereum/devp2p/blob/master/rlpx.md#encrypted-handshake
@@ -49,6 +47,10 @@ public:
     void cancel();
 
 protected:
+    /// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by
+    /// transition().
+    static constexpr std::chrono::milliseconds c_timeout{1800};
+
     /// Sequential states of handshake
     enum State
     {
@@ -91,9 +93,6 @@ protected:
     /// Performs transition for m_nextState.
     virtual void transition(boost::system::error_code _ech = boost::system::error_code());
 
-    /// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by transition().
-    boost::posix_time::milliseconds const c_timeout = boost::posix_time::milliseconds(1800);
-
     State m_nextState = New;		///< Current or expected state of transition.
     bool m_cancel = false;			///< Will be set to true if connection was canceled.
     
@@ -123,7 +122,7 @@ protected:
     std::unique_ptr<RLPXFrameCoder> m_io;
     
     std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
-    boost::asio::deadline_timer m_idleTimer;	///< Timer which enforces c_timeout.
+    ba::steady_timer m_idleTimer;               ///< Timer which enforces c_timeout.
 
     Logger m_logger{createLogger(VerbosityTrace, "rlpx")};
 };

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -47,8 +47,8 @@ public:
     void cancel();
 
 protected:
-    /// Timeout for remote to respond to transition events. Enforced by m_idleTimer and refreshed by
-    /// transition().
+    /// Timeout for a stage in the handshake to complete (the remote to respond to transition
+    /// events). Enforced by m_idleTimer and refreshed by transition().
     static constexpr std::chrono::milliseconds c_timeout{1800};
 
     /// Sequential states of handshake
@@ -126,9 +126,11 @@ protected:
     /// Used to read and write RLPx encrypted frames for last step of handshake authentication.
     /// Passed onto Host which will take ownership.
     std::unique_ptr<RLPXFrameCoder> m_io;
-    
-    std::shared_ptr<RLPXSocket> m_socket;		///< Socket.
-    ba::steady_timer m_idleTimer;               ///< Timer which enforces c_timeout.
+
+    std::shared_ptr<RLPXSocket> m_socket;
+
+    /// Timer which enforces c_timeout. Reset for each stage of the handshake.
+    ba::steady_timer m_idleTimer;
 
     Logger m_logger{createLogger(VerbosityDebug, "rlpx")};
     Logger m_errorLogger{createLogger(VerbosityError, "rlpx")};


### PR DESCRIPTION
Clean up the RLPX handshake logging. I've done the following:
* Move the RLPX handshake logs to a new log channel. They were being logged to the "net" log channel - a lot of p2p logs were written to this channel which made it difficult to wade through the output when debugging (and we couldn't filter logs to just rlpx handshake-specific output). I've created a new "rlpx" channel with 2 verbosities - "error" for internal errors and "debug" for everything else. I considered logging "handshake failed" messages with "warning" verbosity but handshakes fail pretty often for valid reasons and warning logs are displayed with the default Aleth verbosity level (2) so this would result in a lot of log spew that users don't care about in most cases.
* Add remote endpoint information to each log message so that it's easier to track which connection log messages map to.
* Miscellaneous cleanup (e.g. add helper function for determining if current connection is inbound vs outbound, add helper function for mapping a PacketType to string so packet type values can be included in packet type mismatch error messages, only log boost error code in "Handshake Failed" error message if the error code indicates an error, change some literals to constexpr if they're used more than once)

There are still opportunities to clean up the output even more - for example, I think the "Handshake Disconnect" messages can be too verbose (in some cases there are something like 3 messages are logged on a disconnect). However, these changes improve things significantly and further output cleanup isn't critical so I think it can be taken care of in a future PR. 

Here's a log output snippet before the changes:
```
TRACE 04-13 15:33:02 p2p  net    Attempting connection to node ##30b7ab30…@52.176.7.10:30303 from ##02cb92f8…
TRACE 04-13 15:33:02 p2p  net    Attempting connection to node ##94c15d1b…@192.81.208.223:30303 from ##02cb92f8…
TRACE 04-13 15:33:02 p2p  net    Attempting connection to node ##6332792c…@52.232.243.152:30303 from ##02cb92f8…
TRACE 04-13 15:33:02 p2p  net    Connecting to ##aa36fdf3…@13.93.211.84:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 13.93.211.84:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 13.93.211.84:30303
TRACE 04-13 15:33:02 p2p  net    Connecting to ##3f1d1204…@13.93.211.84:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 13.93.211.84:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 13.93.211.84:30303
TRACE 04-13 15:33:02 p2p  net    Connecting to ##30b7ab30…@52.176.7.10:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 52.176.7.10:30303
TRACE 04-13 15:33:02 p2p  net    Connecting to ##865a6325…@52.176.100.77:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 52.176.100.77:30303
TRACE 04-13 15:33:02 p2p  net    Connecting to ##15ac307a…@52.176.7.10:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 52.176.7.10:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 52.176.7.10:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 52.176.100.77:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 52.176.7.10:30303
TRACE 04-13 15:33:02 p2p  net    Connecting to ##6332792c…@52.232.243.152:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 52.232.243.152:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 52.232.243.152:30303
DEBUG 04-13 15:33:02 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##a979fb57…
DEBUG 04-13 15:33:02 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##158f8aab…
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending capabilities handshake
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress recvd hello header
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress hello frame: invalid packet type
TRACE 04-13 15:33:02 p2p  net    Handshake Failed (I/O Error: The operation completed successfully)
TRACE 04-13 15:33:02 p2p  net    Disconnecting 52.176.7.10:30303 (Handshake Failed)
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending capabilities handshake
TRACE 04-13 15:33:02 p2p  net    Connecting to ##a979fb57…@52.16.188.185:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 52.16.188.185:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 52.16.188.185:30303
TRACE 04-13 15:33:02 p2p  net    Connecting to ##158f8aab…@13.75.154.138:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 13.75.154.138:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 13.75.154.138:30303
TRACE 04-13 15:33:02 p2p  net    Connecting to ##78de8a09…@191.235.84.50:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 191.235.84.50:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 191.235.84.50:30303
DEBUG 04-13 15:33:02 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##78de8a09…
TRACE 04-13 15:33:02 p2p  net    Attempting connection to node ##78de8a09…@191.235.84.50:30303 from ##02cb92f8…
DEBUG 04-13 15:33:02 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##669f45b6…
DEBUG 04-13 15:33:02 p2p  net    p2p.host.peers.events.peerAdded ##669f45b6… 52.74.57.123:30303
TRACE 04-13 15:33:02 p2p  net    Attempting connection to node ##669f45b6…@52.74.57.123:30303 from ##02cb92f8…
TRACE 04-13 15:33:02 p2p  net    Connecting to ##1118980b…@52.74.57.123:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress sending auth to 52.74.57.123:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress receiving ack from 52.74.57.123:30303
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress recvd hello header
TRACE 04-13 15:33:02 p2p  net    p2p.connect.egress hello frame: success. starting session.
DEBUG 04-13 15:33:02 p2p  net    Hello: Parity-Ethereum/v2.2.9-stable-5d5b372-20190203/x86_64-linux-gnu/rustc1.31.1 V[5] ##865a6325… (eth,63) 30303
DEBUG 04-13 15:33:02 p2p  net    New session for capability eth; idOffset: 16
TRACE 04-13 15:33:02 p2p  net    <- [ 0x3F, 0x3, 0x28C23CA5E068A, 0x2A3B3B30554F25298E884C1C675BB131A95278C4447301CD55775BC8A2AA030F, 0x41941023680923E0FE4D74A34BD
```


And here's the log output now:

```TRACE 04-14 14:55:57 p2p  net    Attempting connection to node ##94c15d1b…@192.81.208.223:30303 from ##9fd99964…
TRACE 04-14 14:55:57 p2p  net    Attempting connection to node ##6332792c…@52.232.243.152:30303 from ##9fd99964…
TRACE 04-14 14:55:57 p2p  net    Connecting to ##aa36fdf3…@13.93.211.84:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: auth to ##aa36fdf3…@13.93.211.84:30303
TRACE 04-14 14:55:57 p2p  net    Connecting to ##3f1d1204…@13.93.211.84:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: auth to ##3f1d1204…@13.93.211.84:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: ack from ##aa36fdf3…@13.93.211.84:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: ack from ##3f1d1204…@13.93.211.84:30303
TRACE 04-14 14:55:57 p2p  net    Connecting to ##865a6325…@52.176.100.77:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: auth to ##865a6325…@52.176.100.77:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: ack from ##865a6325…@52.176.100.77:30303
TRACE 04-14 14:55:57 p2p  net    Connecting to ##30b7ab30…@52.176.7.10:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: auth to ##30b7ab30…@52.176.7.10:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: ack from ##30b7ab30…@52.176.7.10:30303
TRACE 04-14 14:55:57 p2p  net    Connecting to ##6332792c…@52.232.243.152:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: auth to ##6332792c…@52.232.243.152:30303
DEBUG 04-14 14:55:57 p2p  rlpx   p2p.connect.egress: ack from ##6332792c…@52.232.243.152:30303
DEBUG 04-14 14:55:57 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##15ac307a…
DEBUG 04-14 14:55:57 p2p  net    p2p.host.peers.events.peerAdded ##15ac307a… 52.176.7.10:30303
TRACE 04-14 14:55:57 p2p  net    Attempting connection to node ##15ac307a…@52.176.7.10:30303 from ##9fd99964…
DEBUG 04-14 14:55:57 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##a979fb57…
DEBUG 04-14 14:55:57 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##158f8aab…
TRACE 04-14 14:55:58 p2p  net    Connecting to ##a979fb57…@52.16.188.185:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: auth to ##a979fb57…@52.16.188.185:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: ack from ##a979fb57…@52.16.188.185:30303
TRACE 04-14 14:55:58 p2p  net    Connecting to ##15ac307a…@52.176.7.10:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: auth to ##15ac307a…@52.176.7.10:30303
TRACE 04-14 14:55:58 p2p  net    Connecting to ##158f8aab…@13.75.154.138:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: auth to ##158f8aab…@13.75.154.138:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: ack from ##15ac307a…@52.176.7.10:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: ack from ##158f8aab…@13.75.154.138:30303
TRACE 04-14 14:55:58 p2p  net    Connecting to ##78de8a09…@191.235.84.50:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: auth to ##78de8a09…@191.235.84.50:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: ack from ##78de8a09…@191.235.84.50:30303
TRACE 04-14 14:55:58 p2p  net    Connecting to ##1118980b…@52.74.57.123:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: auth to ##1118980b…@52.74.57.123:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: ack from ##1118980b…@52.74.57.123:30303
DEBUG 04-14 14:55:58 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##78de8a09…
TRACE 04-14 14:55:58 p2p  net    Attempting connection to node ##78de8a09…@191.235.84.50:30303 from ##9fd99964…
DEBUG 04-14 14:55:58 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##669f45b6…
DEBUG 04-14 14:55:58 p2p  net    p2p.host.peers.events.peerAdded ##669f45b6… 52.74.57.123:30303
TRACE 04-14 14:55:58 p2p  net    Attempting connection to node ##669f45b6…@52.74.57.123:30303 from ##9fd99964…
DEBUG 04-14 14:55:58 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##865a6325…
TRACE 04-14 14:55:58 p2p  net    Attempting connection to node ##865a6325…@52.176.100.77:30303 from ##9fd99964…
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: HelloPacket to ##15ac307a…@52.176.7.10:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Frame header from ##15ac307a…@52.176.7.10:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Successfully decrypted frame header from ##15ac307a…@52.176.7.10:30303. Validating contents...
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Frame body from ##15ac307a…@52.176.7.10:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Invalid packet type. Expected: HelloPacket, received: DisconnectPacket (##15ac307a…@52.176.7.10:30303)
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Handshake Failed (##15ac307a…@52.176.7.10:30303)
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Disconnecting ##15ac307a…@52.176.7.10:30303 (Handshake Failed)
TRACE 04-14 14:55:58 p2p  net    Connecting to ##865a6325…@52.176.100.77:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: auth to ##865a6325…@52.176.100.77:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: ack from ##865a6325…@52.176.100.77:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: HelloPacket to ##a979fb57…@52.16.188.185:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Frame header from ##a979fb57…@52.16.188.185:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Successfully decrypted frame header from ##a979fb57…@52.16.188.185:30303. Validating contents...
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Frame body from ##a979fb57…@52.16.188.185:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Invalid packet type. Expected: HelloPacket, received: DisconnectPacket (##a979fb57…@52.16.188.185:30303)
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Handshake Failed (##a979fb57…@52.16.188.185:30303)
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Disconnecting ##a979fb57…@52.16.188.185:30303 (Handshake Failed)
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: HelloPacket to ##158f8aab…@13.75.154.138:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Frame header from ##158f8aab…@13.75.154.138:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Successfully decrypted frame header from ##158f8aab…@13.75.154.138:30303. Validating contents...
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Frame body from ##158f8aab…@13.75.154.138:30303
DEBUG 04-14 14:55:58 p2p  rlpx   p2p.connect.egress: Invalid packet type. Expected: HelloPacket, received: DisconnectPacket (##158f8aab…@13.75.154.138:30303)
```