### PR TITLE
Discovery ENR extension - server part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.7.0] - Unreleased
 
 - Added: [#5537](https://github.com/ethereum/aleth/pull/5537) Creating Ethereum Node Record (ENR) at program start.
+- Added: [#5571](https://github.com/ethereum/aleth/pull/5571) Support Discovery v4 ENR Extension messages.
 - Added: [#5557](https://github.com/ethereum/aleth/pull/5557) Improved debug logging of full sync.
 - Added: [#5564](https://github.com/ethereum/aleth/pull/5564) Improved help output of Aleth by adding list of channels.
 - Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
     setDefaultOrCLocale();
 
     // Init secp256k1 context by calling one of the functions.
-    toPublic({});
+    toPublic(Secret{});
 
     // Init defaults
     Ethash::init();

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -99,7 +99,7 @@ Public dev::toPublic(PublicCompressed const& _publicCompressed)
         return {};
 
     std::array<byte, 65> serializedPubkey;
-    size_t serializedPubkeySize = serializedPubkey.size();
+    auto serializedPubkeySize = serializedPubkey.size();
     secp256k1_ec_pubkey_serialize(
         ctx, serializedPubkey.data(), &serializedPubkeySize, &rawPubkey, SECP256K1_EC_UNCOMPRESSED);
     assert(serializedPubkeySize == serializedPubkey.size());

--- a/libdevcrypto/Common.h
+++ b/libdevcrypto/Common.h
@@ -68,6 +68,9 @@ using Secrets = std::vector<Secret>;
 /// Convert a secret key into the public key equivalent.
 Public toPublic(Secret const& _secret);
 
+/// Convert a compressed public key into the uncompressed equivalent.
+Public toPublic(PublicCompressed const& _publicCompressed);
+
 /// Convert a secret key into the public key in compressed format.
 PublicCompressed toPublicCompressed(Secret const& _secret);
 

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -29,7 +29,7 @@ bytes addressToBytes(Address const& _address)
 }
 }  // namespace
 
-ENR::ENR(RLP _rlp, VerifyFunction const& _verifyFunction)
+ENR::ENR(RLP const& _rlp, VerifyFunction const& _verifyFunction)
 {
     if (_rlp.data().size() > c_ENRMaxSizeBytes)
         BOOST_THROW_EXCEPTION(ENRIsTooBig());
@@ -110,7 +110,7 @@ ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint
     return ENR{0 /* sequence number */, keyValuePairs, signFunction};
 }
 
-ENR parseV4ENR(RLP _rlp)
+ENR parseV4ENR(RLP const& _rlp)
 {
     ENR::VerifyFunction verifyFunction = [](std::map<std::string, bytes> const& _keyValuePairs,
                                              bytesConstRef _signature, bytesConstRef _data) {

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -29,7 +29,7 @@ public:
         std::function<bool(std::map<std::string, bytes> const&, bytesConstRef, bytesConstRef)>;
 
     // Parse from RLP with given signature verification function
-    ENR(RLP _rlp, VerifyFunction const& _verifyFunction);
+    ENR(RLP const& _rlp, VerifyFunction const& _verifyFunction);
     // Create with given sign function
     ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues,
         SignFunction const& _signFunction);
@@ -54,7 +54,7 @@ private:
 
 ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint16_t _tcpPort,  uint16_t _udpPort);
 
-ENR parseV4ENR(RLP _rlp);
+ENR parseV4ENR(RLP const& _rlp);
 
 std::ostream& operator<<(std::ostream& _out, ENR const& _enr);
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -800,13 +800,9 @@ void Host::startedWorking()
         m_listenPort = m_netConfig.listenPort;
 
     determinePublic();
-    auto nodeTable = make_shared<NodeTable>(
-        m_ioService,
-        m_alias,
+    auto nodeTable = make_shared<NodeTable>(m_ioService, m_alias,
         NodeIPEndpoint(bi::address::from_string(listenAddress()), listenPort(), listenPort()),
-        m_netConfig.discovery,
-        m_netConfig.allowLocalDiscovery
-    );
+        m_enr, m_netConfig.discovery, m_netConfig.allowLocalDiscovery);
 
     // Don't set an event handler if we don't have capabilities, because no capabilities
     // means there's no host state to update in response to node table events

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -687,7 +687,7 @@ std::shared_ptr<NodeEntry> NodeTable::handleENRRequest(
 
     auto const& in = dynamic_cast<ENRRequest const&>(_packet);
 
-    ENRResponse response(_from, m_hostENR);
+    ENRResponse response{_from, m_hostENR};
     LOG(m_logger) << response.typeName() << " to " << in.sourceid << "@" << _from;
     response.timestamp = nextRequestExpirationTime();
     response.echo = in.echo;
@@ -704,7 +704,7 @@ std::shared_ptr<NodeEntry> NodeTable::handleENRResponse(
     if (!sourceNodeEntry)
     {
         LOG(m_logger) << "Source node (" << _packet.sourceid << "@" << _from
-                      << ") not found in node table. Ignoring Neighbours packet.";
+                      << ") not found in node table. Ignoring ENRResponse packet.";
         return {};
     }
     if (sourceNodeEntry->endpoint() != _from)

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -221,7 +221,7 @@ void NodeTable::doDiscoveryRound(
             }
 
             FindNode p(nodeEntry->endpoint(), _node);
-            p.timestamp = nextRequestExpirationTime();
+            p.expiration = nextRequestExpirationTime();
             p.sign(m_secret);
             m_sentFindNodes.emplace_back(nodeEntry->id(), chrono::steady_clock::now());
             LOG(m_logger) << p.typeName() << " to " << nodeEntry->node << " (target: " << _node
@@ -303,7 +303,7 @@ void NodeTable::ping(Node const& _node, shared_ptr<NodeEntry> _replacementNodeEn
     }
 
     PingNode p{m_hostNodeEndpoint, _node.endpoint};
-    p.timestamp = nextRequestExpirationTime();
+    p.expiration = nextRequestExpirationTime();
     p.seq = m_hostENR.sequenceNumber();
     auto const pingHash = p.sign(m_secret);
     LOG(m_logger) << p.typeName() << " to " << _node;
@@ -618,7 +618,7 @@ std::shared_ptr<NodeEntry> NodeTable::handleFindNode(
     for (unsigned offset = 0; offset < nearest.size(); offset += nlimit)
     {
         Neighbours out(_from, nearest, offset, nlimit);
-        out.timestamp = nextRequestExpirationTime();
+        out.expiration = nextRequestExpirationTime();
         LOG(m_logger) << out.typeName() << " to " << in.sourceid << "@" << _from;
         out.sign(m_secret);
         if (out.data.size() > 1280)
@@ -641,7 +641,7 @@ std::shared_ptr<NodeEntry> NodeTable::handlePingNode(
     // Send PONG response.
     Pong p(sourceEndpoint);
     LOG(m_logger) << p.typeName() << " to " << in.sourceid << "@" << _from;
-    p.timestamp = nextRequestExpirationTime();
+    p.expiration = nextRequestExpirationTime();
     p.echo = in.echo;
     p.seq = m_hostENR.sequenceNumber();
     p.sign(m_secret);
@@ -689,7 +689,7 @@ std::shared_ptr<NodeEntry> NodeTable::handleENRRequest(
 
     ENRResponse response{_from, m_hostENR};
     LOG(m_logger) << response.typeName() << " to " << in.sourceid << "@" << _from;
-    response.timestamp = nextRequestExpirationTime();
+    response.expiration = nextRequestExpirationTime();
     response.echo = in.echo;
     response.sign(m_secret);
     m_socket->send(response);

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -32,9 +32,10 @@ inline bool operator==(weak_ptr<NodeEntry> const& _weak, shared_ptr<NodeEntry> c
 }
 
 NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint,
-    bool _enabled, bool _allowLocalDiscovery)
+    ENR const& _enr, bool _enabled, bool _allowLocalDiscovery)
   : m_hostNodeID{_alias.pub()},
     m_hostNodeEndpoint{_endpoint},
+    m_hostENR{_enr},
     m_secret{_alias.secret()},
     m_socket{make_shared<NodeSocket>(
         _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)m_hostNodeEndpoint)},
@@ -220,7 +221,7 @@ void NodeTable::doDiscoveryRound(
             }
 
             FindNode p(nodeEntry->endpoint(), _node);
-            p.ts = nextRequestExpirationTime();
+            p.timestamp = nextRequestExpirationTime();
             p.sign(m_secret);
             m_sentFindNodes.emplace_back(nodeEntry->id(), chrono::steady_clock::now());
             LOG(m_logger) << p.typeName() << " to " << nodeEntry->node << " (target: " << _node
@@ -302,7 +303,8 @@ void NodeTable::ping(Node const& _node, shared_ptr<NodeEntry> _replacementNodeEn
     }
 
     PingNode p{m_hostNodeEndpoint, _node.endpoint};
-    p.ts = nextRequestExpirationTime();
+    p.timestamp = nextRequestExpirationTime();
+    p.seq = m_hostENR.sequenceNumber();
     auto const pingHash = p.sign(m_secret);
     LOG(m_logger) << p.typeName() << " to " << _node;
     m_socket->send(p);
@@ -453,6 +455,14 @@ void NodeTable::onPacketReceived(
 
         case PingNode::type:
             sourceNodeEntry = handlePingNode(_from, *packet);
+            break;
+
+        case ENRRequest::type:
+            sourceNodeEntry = handleENRRequest(_from, *packet);
+            break;
+
+        case ENRResponse::type:
+            sourceNodeEntry = handleENRResponse(_from, *packet);
             break;
         }
 
@@ -608,7 +618,7 @@ std::shared_ptr<NodeEntry> NodeTable::handleFindNode(
     for (unsigned offset = 0; offset < nearest.size(); offset += nlimit)
     {
         Neighbours out(_from, nearest, offset, nlimit);
-        out.ts = nextRequestExpirationTime();
+        out.timestamp = nextRequestExpirationTime();
         LOG(m_logger) << out.typeName() << " to " << in.sourceid << "@" << _from;
         out.sign(m_secret);
         if (out.data.size() > 1280)
@@ -631,8 +641,9 @@ std::shared_ptr<NodeEntry> NodeTable::handlePingNode(
     // Send PONG response.
     Pong p(sourceEndpoint);
     LOG(m_logger) << p.typeName() << " to " << in.sourceid << "@" << _from;
-    p.ts = nextRequestExpirationTime();
+    p.timestamp = nextRequestExpirationTime();
     p.echo = in.echo;
+    p.seq = m_hostENR.sequenceNumber();
     p.sign(m_secret);
     m_socket->send(p);
 
@@ -646,6 +657,69 @@ std::shared_ptr<NodeEntry> NodeTable::handlePingNode(
 
     return sourceNodeEntry;
 }
+
+std::shared_ptr<NodeEntry> NodeTable::handleENRRequest(
+    bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet)
+{
+    std::shared_ptr<NodeEntry> sourceNodeEntry = nodeEntry(_packet.sourceid);
+    if (!sourceNodeEntry)
+    {
+        LOG(m_logger) << "Source node (" << _packet.sourceid << "@" << _from
+                      << ") not found in node table. Ignoring ENRRequest request.";
+        return {};
+    }
+    if (sourceNodeEntry->endpoint() != _from)
+    {
+        LOG(m_logger) << "ENRRequest packet from unexpected endpoint " << _from << " instead of "
+                      << sourceNodeEntry->endpoint();
+        return {};
+    }
+    if (!sourceNodeEntry->lastPongReceivedTime)
+    {
+        LOG(m_logger) << "Unexpected ENRRequest packet! Endpoint proof hasn't been performed yet.";
+        return {};
+    }
+    if (!sourceNodeEntry->hasValidEndpointProof())
+    {
+        LOG(m_logger) << "Unexpected ENRRequest packet! Endpoint proof has expired.";
+        return {};
+    }
+
+    auto const& in = dynamic_cast<ENRRequest const&>(_packet);
+
+    ENRResponse response(_from, m_hostENR);
+    LOG(m_logger) << response.typeName() << " to " << in.sourceid << "@" << _from;
+    response.timestamp = nextRequestExpirationTime();
+    response.echo = in.echo;
+    response.sign(m_secret);
+    m_socket->send(response);
+
+    return sourceNodeEntry;
+}
+
+std::shared_ptr<NodeEntry> NodeTable::handleENRResponse(
+    bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet)
+{
+    std::shared_ptr<NodeEntry> sourceNodeEntry = nodeEntry(_packet.sourceid);
+    if (!sourceNodeEntry)
+    {
+        LOG(m_logger) << "Source node (" << _packet.sourceid << "@" << _from
+                      << ") not found in node table. Ignoring Neighbours packet.";
+        return {};
+    }
+    if (sourceNodeEntry->endpoint() != _from)
+    {
+        LOG(m_logger) << "ENRResponse packet from unexpected endpoint " << _from << " instead of "
+                      << sourceNodeEntry->endpoint();
+        return {};
+    }
+
+    auto const& in = dynamic_cast<ENRResponse const&>(_packet);
+    LOG(m_logger) << "Received ENR: " << *in.enr;
+
+    return sourceNodeEntry;
+}
+
 
 void NodeTable::doDiscovery()
 {
@@ -765,6 +839,12 @@ unique_ptr<DiscoveryDatagram> DiscoveryDatagram::interpretUDP(bi::udp::endpoint 
         break;
     case Neighbours::type:
         decoded.reset(new Neighbours(_from, sourceid, echo));
+        break;
+    case ENRRequest::type:
+        decoded.reset(new ENRRequest(_from, sourceid, echo));
+        break;
+    case ENRResponse::type:
+        decoded.reset(new ENRResponse(_from, sourceid, echo));
         break;
     default:
         LOG(g_discoveryWarnLogger::get()) << "Invalid packet (unknown packet type) from "

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -8,8 +8,9 @@
 
 #include <boost/integer/static_log2.hpp>
 
-#include <libp2p/UDP.h>
 #include "Common.h"
+#include "ENR.h"
+#include <libp2p/UDP.h>
 
 namespace dev
 {
@@ -109,7 +110,7 @@ public:
 
     /// Constructor requiring host for I/O, credentials, and IP Address and port to listen on.
     NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint const& _endpoint,
-        bool _enabled = true, bool _allowLocalDiscovery = false);
+        ENR const& _enr, bool _enabled = true, bool _allowLocalDiscovery = false);
 
     /// Returns distance based on xor metric two node ids. Used by NodeEntry and NodeTable.
     static int distance(NodeID const& _a, NodeID const& _b) { u256 d = sha3(_a) ^ sha3(_b); unsigned ret; for (ret = 0; d >>= 1; ++ret) {}; return ret; }
@@ -286,6 +287,10 @@ protected:
         bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
     std::shared_ptr<NodeEntry> handlePingNode(
         bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
+    std::shared_ptr<NodeEntry> handleENRRequest(
+        bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
+    std::shared_ptr<NodeEntry> handleENRResponse(
+        bi::udp::endpoint const& _from, DiscoveryDatagram const& _packet);
 
     /// Called by m_socket when socket is disconnected.
     void onSocketDisconnected(UDPSocketFace*) override {}
@@ -316,6 +321,7 @@ protected:
 
     NodeID const m_hostNodeID;
     NodeIPEndpoint m_hostNodeEndpoint;
+    ENR const m_hostENR;
     Secret m_secret;												///< This nodes secret key.
 
     mutable Mutex x_nodes;											///< LOCK x_state first if both locks are required. Mutable for thread-safe copy in nodes() const.
@@ -394,7 +400,7 @@ struct DiscoveryDatagram: public RLPXDatagramFace
 
     /// Constructor used for sending.
     DiscoveryDatagram(bi::udp::endpoint const& _to)
-      : RLPXDatagramFace(_to), ts(futureFromEpoch(c_timeToLiveS))
+      : RLPXDatagramFace(_to), timestamp(futureFromEpoch(c_timeToLiveS))
     {}
 
     /// Constructor used for parsing inbound packets.
@@ -404,10 +410,13 @@ struct DiscoveryDatagram: public RLPXDatagramFace
     NodeID sourceid; // sender public key (from signature)
     h256 echo;       // hash of encoded packet, for reply tracking
 
-    // All discovery packets carry a timestamp, which must be greater
+    // Most discovery packets carry a timestamp, which must be greater
     // than the current local time. This prevents replay attacks.
-    uint32_t ts = 0;
-    bool isExpired() const { return secondsSinceEpoch() > ts; }
+    boost::optional<uint32_t> timestamp;
+    bool isExpired() const
+    {
+        return timestamp.is_initialized() && secondsSinceEpoch() > *timestamp;
+    }
 
     /// Decodes UDP packets.
     static std::unique_ptr<DiscoveryDatagram> interpretUDP(bi::udp::endpoint const& _from, bytesConstRef _packet);
@@ -415,7 +424,7 @@ struct DiscoveryDatagram: public RLPXDatagramFace
 
 /**
  * Ping packet: Sent to check if node is alive.
- * PingNode is cached and regenerated after ts + t, where t is timeout.
+ * PingNode is cached and regenerated after timestamp + t, where t is timeout.
  *
  * Ping is used to implement evict. When a new node is seen for
  * a given bucket which is full, the least-responsive node is pinged.
@@ -434,14 +443,17 @@ struct PingNode: DiscoveryDatagram
     unsigned version = 0;
     NodeIPEndpoint source;
     NodeIPEndpoint destination;
+    boost::optional<uint64_t> seq;
 
     void streamRLP(RLPStream& _s) const override
     {
-        _s.appendList(4);
+        _s.appendList(seq.is_initialized() ? 5 : 4);
         _s << dev::p2p::c_protocolVersion;
         source.streamRLP(_s);
         destination.streamRLP(_s);
-        _s << ts;
+        _s << *timestamp;
+        if (seq.is_initialized())
+            _s << *seq;
     }
     void interpretRLP(bytesConstRef _bytes) override
     {
@@ -449,7 +461,9 @@ struct PingNode: DiscoveryDatagram
         version = r[0].toInt<unsigned>();
         source.interpretRLP(r[1]);
         destination.interpretRLP(r[2]);
-        ts = r[3].toInt<uint32_t>();
+        timestamp = r[3].toInt<uint32_t>();
+        if (r.itemCount() > 4)
+            seq = r[4].toInt<uint64_t>();
     }
 
     std::string typeName() const override { return "Ping"; }
@@ -467,20 +481,25 @@ struct Pong: DiscoveryDatagram
     uint8_t packetType() const override { return type; }
 
     NodeIPEndpoint destination;
+    boost::optional<uint64_t> seq;
 
     void streamRLP(RLPStream& _s) const override
     {
-        _s.appendList(3);
+        _s.appendList(seq.is_initialized() ? 4 : 3);
         destination.streamRLP(_s);
         _s << echo;
-        _s << ts;
+        _s << *timestamp;
+        if (seq.is_initialized())
+            _s << *seq;
     }
     void interpretRLP(bytesConstRef _bytes) override
     {
         RLP r(_bytes, RLP::AllowNonCanon|RLP::ThrowOnFail);
         destination.interpretRLP(r[0]);
         echo = (h256)r[1];
-        ts = r[2].toInt<uint32_t>();
+        timestamp = r[2].toInt<uint32_t>();
+        if (r.itemCount() > 3)
+            seq = r[3].toInt<uint64_t>();
     }
 
     std::string typeName() const override { return "Pong"; }
@@ -488,7 +507,7 @@ struct Pong: DiscoveryDatagram
 
 /**
  * FindNode Packet: Request k-nodes, closest to the target.
- * FindNode is cached and regenerated after ts + t, where t is timeout.
+ * FindNode is cached and regenerated after timestamp + t, where t is timeout.
  * FindNode implicitly results in finding neighbours of a given node.
  *
  * RLP Encoded Items: 2
@@ -510,13 +529,14 @@ struct FindNode: DiscoveryDatagram
 
     void streamRLP(RLPStream& _s) const override
     {
-        _s.appendList(2); _s << target << ts;
+        _s.appendList(2);
+        _s << target << *timestamp;
     }
     void interpretRLP(bytesConstRef _bytes) override
     {
         RLP r(_bytes, RLP::AllowNonCanon|RLP::ThrowOnFail);
         target = r[0].toHash<h512>();
-        ts = r[1].toInt<uint32_t>();
+        timestamp = r[1].toInt<uint32_t>();
     }
 
     std::string typeName() const override { return "FindNode"; }
@@ -556,18 +576,75 @@ struct Neighbours: DiscoveryDatagram
         _s.appendList(neighbours.size());
         for (auto const& n: neighbours)
             n.streamRLP(_s);
-        _s << ts;
+        _s << *timestamp;
     }
     void interpretRLP(bytesConstRef _bytes) override
     {
         RLP r(_bytes, RLP::AllowNonCanon|RLP::ThrowOnFail);
         for (auto const& n: r[0])
             neighbours.emplace_back(n);
-        ts = r[1].toInt<uint32_t>();
+        timestamp = r[1].toInt<uint32_t>();
     }
 
     std::string typeName() const override { return "Neighbours"; }
 };
 
+struct ENRRequest : DiscoveryDatagram
+{
+    // Constructor for outgoing packets
+    ENRRequest(bi::udp::endpoint _to) : DiscoveryDatagram{_to} {}
+    // Constructor for incoming packets
+    ENRRequest(bi::udp::endpoint const& _from, NodeID const& _fromid, h256 const& _echo)
+      : DiscoveryDatagram{_from, _fromid, _echo}
+    {}
+
+    static uint8_t const type = 5;
+    uint8_t packetType() const override { return type; }
+
+    void streamRLP(RLPStream& _s) const override
+    {
+        _s.appendList(1);
+        _s << *timestamp;
+    }
+    void interpretRLP(bytesConstRef _bytes) override
+    {
+        RLP r(_bytes, RLP::AllowNonCanon | RLP::ThrowOnFail);
+        timestamp = r[0].toInt<uint32_t>();
+    }
+
+    std::string typeName() const override { return "ENRRequest"; }
+};
+
+struct ENRResponse : DiscoveryDatagram
+{
+    // Constructor for outgoing packets
+    ENRResponse(bi::udp::endpoint const& _dest, ENR const& _enr)
+      : DiscoveryDatagram{_dest}, enr{_enr}
+    {}
+    // Constructor for incoming packets
+    ENRResponse(bi::udp::endpoint const& _from, NodeID const& _fromid, h256 const& _echo)
+      : DiscoveryDatagram{_from, _fromid, _echo}
+    {}
+
+    static uint8_t const type = 6;
+    uint8_t packetType() const override { return type; }
+
+    boost::optional<ENR> enr;
+
+    void streamRLP(RLPStream& _s) const override
+    {
+        _s.appendList(2);
+        _s << echo;
+        enr->streamRLP(_s);
+    }
+    void interpretRLP(bytesConstRef _bytes) override
+    {
+        RLP r(_bytes, RLP::ThrowOnFail);
+        echo = (h256)r[0];
+        enr = parseV4ENR(r[1]);
+    }
+
+    std::string typeName() const override { return "ENRResponse"; }
+};
 }
 }

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -462,7 +462,7 @@ struct PingNode: DiscoveryDatagram
         source.interpretRLP(r[1]);
         destination.interpretRLP(r[2]);
         timestamp = r[3].toInt<uint32_t>();
-        if (r.itemCount() > 4)
+        if (r.itemCount() > 4 && r[4].isInt())
             seq = r[4].toInt<uint64_t>();
     }
 
@@ -498,7 +498,7 @@ struct Pong: DiscoveryDatagram
         destination.interpretRLP(r[0]);
         echo = (h256)r[1];
         timestamp = r[2].toInt<uint32_t>();
-        if (r.itemCount() > 3)
+        if (r.itemCount() > 3 && r[3].isInt())
             seq = r[3].toInt<uint64_t>();
     }
 
@@ -639,7 +639,7 @@ struct ENRResponse : DiscoveryDatagram
     }
     void interpretRLP(bytesConstRef _bytes) override
     {
-        RLP r(_bytes, RLP::ThrowOnFail);
+        RLP r(_bytes, RLP::AllowNonCanon | RLP::ThrowOnFail);
         echo = (h256)r[0];
         enr = parseV4ENR(r[1]);
     }

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -595,8 +595,8 @@ struct ENRRequest : DiscoveryDatagram
     // Constructor for outgoing packets
     ENRRequest(bi::udp::endpoint const& _to) : DiscoveryDatagram{_to} {}
     // Constructor for incoming packets
-    ENRRequest(bi::udp::endpoint const& _from, NodeID const& _fromid, h256 const& _echo)
-      : DiscoveryDatagram{_from, _fromid, _echo}
+    ENRRequest(bi::udp::endpoint const& _from, NodeID const& _fromID, h256 const& _echo)
+      : DiscoveryDatagram{_from, _fromID, _echo}
     {}
 
     static constexpr uint8_t type = 5;

--- a/test/unittests/libdevcrypto/crypto.cpp
+++ b/test/unittests/libdevcrypto/crypto.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(emptySHA3Types)
 
 BOOST_AUTO_TEST_CASE(pubkeyOfZero)
 {
-    auto pub = toPublic({});
+    auto pub = toPublic(Secret{});
     BOOST_REQUIRE_EQUAL(pub, Public{});
 }
 
@@ -207,6 +207,14 @@ BOOST_AUTO_TEST_CASE(signAndVerify)
     h512 const sigWithoutV{sig};
 
     BOOST_REQUIRE(verify(pubCompressed, sigWithoutV, msg));
+}
+
+BOOST_AUTO_TEST_CASE(compressedToUncompressed)
+{
+    auto const kp = KeyPair::create();
+    auto const pubCompressed = toPublicCompressed(kp.secret());
+
+    BOOST_REQUIRE(toPublic(pubCompressed) == kp.pub());
 }
 
 BOOST_AUTO_TEST_CASE(common_encrypt_decrypt)

--- a/test/unittests/libp2p/eip-8.cpp
+++ b/test/unittests/libp2p/eip-8.cpp
@@ -28,7 +28,7 @@ TEST(eip8, test_discovery_packets)
     auto ping1 =
         dynamic_cast<PingNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
     EXPECT_EQ(ping1.version, 4);
-    EXPECT_EQ(ping1.ts, 1136239445);
+    EXPECT_EQ(*ping1.timestamp, 1136239445);
     EXPECT_EQ(ping1.source, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), 3322, 5544));
     EXPECT_EQ(ping1.destination, NodeIPEndpoint(bi::address::from_string("::1"), 2222, 3333));
 
@@ -49,7 +49,7 @@ TEST(eip8, test_discovery_packets)
     EXPECT_EQ(ping2.destination,
         NodeIPEndpoint(
             bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
-    EXPECT_EQ(ping2.ts, 1136239445);
+    EXPECT_EQ(*ping2.timestamp, 1136239445);
 
     packet = fromHex(
         "09b2428d83348d27cdf7064ad9024f526cebc19e4958f0fdad87c15eb598dd61d08423e0bf66b206"
@@ -63,7 +63,7 @@ TEST(eip8, test_discovery_packets)
         NodeIPEndpoint(
             bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
     EXPECT_EQ(pong.echo, h256("fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c954"));
-    EXPECT_EQ(pong.ts, 1136239445);
+    EXPECT_EQ(*pong.timestamp, 1136239445);
 
     packet = fromHex(
         "c7c44041b9f7c7e41934417ebac9a8e1a4c6298f74553f2fcfdcae6ed6fe53163eb3d2b52e39fe91"
@@ -77,7 +77,7 @@ TEST(eip8, test_discovery_packets)
     EXPECT_EQ(
         findnode.target, Public("ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd313875"
                                 "74077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"));
-    EXPECT_EQ(findnode.ts, 1136239445);
+    EXPECT_EQ(*findnode.timestamp, 1136239445);
 
     packet = fromHex(
         "c679fc8fe0b8b12f06577f2e802d34f6fa257e6137a995f6f4cbfc9ee50ed3710faf6e66f932c4c8"
@@ -116,7 +116,7 @@ TEST(eip8, test_discovery_packets)
     EXPECT_EQ(neighbours.neighbours[3].node,
         Public("8dcab8618c3253b558d459da53bd8fa68935a719aff8b811197101a4b2b47dd2d47295286fc00cc081b"
                "b542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73"));
-    EXPECT_EQ(neighbours.ts, 1136239445);
+    EXPECT_EQ(*neighbours.timestamp, 1136239445);
 }
 
 class TestHandshake : public RLPXHandshake

--- a/test/unittests/libp2p/eip-8.cpp
+++ b/test/unittests/libp2p/eip-8.cpp
@@ -28,7 +28,7 @@ TEST(eip8, test_discovery_packets)
     auto ping1 =
         dynamic_cast<PingNode&>(*DiscoveryDatagram::interpretUDP(ep, bytesConstRef(&packet)));
     EXPECT_EQ(ping1.version, 4);
-    EXPECT_EQ(*ping1.timestamp, 1136239445);
+    EXPECT_EQ(*ping1.expiration, 1136239445);
     EXPECT_EQ(ping1.source, NodeIPEndpoint(bi::address::from_string("127.0.0.1"), 3322, 5544));
     EXPECT_EQ(ping1.destination, NodeIPEndpoint(bi::address::from_string("::1"), 2222, 3333));
 
@@ -49,7 +49,7 @@ TEST(eip8, test_discovery_packets)
     EXPECT_EQ(ping2.destination,
         NodeIPEndpoint(
             bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
-    EXPECT_EQ(*ping2.timestamp, 1136239445);
+    EXPECT_EQ(*ping2.expiration, 1136239445);
 
     packet = fromHex(
         "09b2428d83348d27cdf7064ad9024f526cebc19e4958f0fdad87c15eb598dd61d08423e0bf66b206"
@@ -63,7 +63,7 @@ TEST(eip8, test_discovery_packets)
         NodeIPEndpoint(
             bi::address::from_string("2001:db8:85a3:8d3:1319:8a2e:370:7348"), 2222, 33338));
     EXPECT_EQ(pong.echo, h256("fbc914b16819237dcd8801d7e53f69e9719adecb3cc0e790c57e91ca4461c954"));
-    EXPECT_EQ(*pong.timestamp, 1136239445);
+    EXPECT_EQ(*pong.expiration, 1136239445);
 
     packet = fromHex(
         "c7c44041b9f7c7e41934417ebac9a8e1a4c6298f74553f2fcfdcae6ed6fe53163eb3d2b52e39fe91"
@@ -77,7 +77,7 @@ TEST(eip8, test_discovery_packets)
     EXPECT_EQ(
         findnode.target, Public("ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd313875"
                                 "74077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"));
-    EXPECT_EQ(*findnode.timestamp, 1136239445);
+    EXPECT_EQ(*findnode.expiration, 1136239445);
 
     packet = fromHex(
         "c679fc8fe0b8b12f06577f2e802d34f6fa257e6137a995f6f4cbfc9ee50ed3710faf6e66f932c4c8"
@@ -116,7 +116,7 @@ TEST(eip8, test_discovery_packets)
     EXPECT_EQ(neighbours.neighbours[3].node,
         Public("8dcab8618c3253b558d459da53bd8fa68935a719aff8b811197101a4b2b47dd2d47295286fc00cc081b"
                "b542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73"));
-    EXPECT_EQ(*neighbours.timestamp, 1136239445);
+    EXPECT_EQ(*neighbours.expiration, 1136239445);
 }
 
 class TestHandshake : public RLPXHandshake

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -1246,22 +1246,23 @@ BOOST_AUTO_TEST_CASE(validENRRequest)
     // socket sending ENRRequest
     TestUDPSocketHost nodeSocketHost;
     nodeSocketHost.start();
-    uint16_t nodePort = nodeSocketHost.port;
+    uint16_t const nodePort = nodeSocketHost.port;
 
     // Exchange Ping/Pongs before sending ENRRequest
 
     // add a node to node table, initiating PING
-    auto nodeEndpoint = NodeIPEndpoint{bi::address::from_string(c_localhostIp), nodePort, nodePort};
-    auto nodeKeyPair = KeyPair::create();
-    auto nodePubKey = nodeKeyPair.pub();
+    auto const nodeEndpoint =
+        NodeIPEndpoint{bi::address::from_string(c_localhostIp), nodePort, nodePort};
+    auto const nodeKeyPair = KeyPair::create();
+    auto const nodePubKey = nodeKeyPair.pub();
     nodeTable->addNode(Node{nodePubKey, nodeEndpoint});
 
     // handle received PING
-    auto pingDataReceived = nodeSocketHost.packetsReceived.pop();
-    auto pingDatagram =
+    auto const pingDataReceived = nodeSocketHost.packetsReceived.pop();
+    auto const pingDatagram =
         DiscoveryDatagram::interpretUDP(bi::udp::endpoint{}, dev::ref(pingDataReceived));
     BOOST_REQUIRE_EQUAL(pingDatagram->typeName(), "Ping");
-    auto ping = dynamic_cast<PingNode const&>(*pingDatagram);
+    auto const& ping = dynamic_cast<PingNode const&>(*pingDatagram);
 
     // send PONG
     Pong pong(nodeTable->m_hostNodeEndpoint);
@@ -1270,8 +1271,8 @@ BOOST_AUTO_TEST_CASE(validENRRequest)
     nodeSocketHost.socket->send(pong);
 
     // wait for PONG to be received and handled
-    auto pongDataReceived = nodeTable->packetsReceived.pop(chrono::seconds(5));
-    auto pongDatagram =
+    auto const pongDataReceived = nodeTable->packetsReceived.pop(chrono::seconds(5));
+    auto const pongDatagram =
         DiscoveryDatagram::interpretUDP(bi::udp::endpoint{}, dev::ref(pongDataReceived));
     BOOST_REQUIRE_EQUAL(pongDatagram->typeName(), "Pong");
 
@@ -1283,12 +1284,12 @@ BOOST_AUTO_TEST_CASE(validENRRequest)
     // wait for ENRRequest to be received and handled
     nodeTable->packetsReceived.pop(chrono::seconds(5));
 
-    auto enrResponsePacket = nodeSocketHost.packetsReceived.pop(chrono::seconds(5));
-    auto datagram =
+    auto const enrResponsePacket = nodeSocketHost.packetsReceived.pop(chrono::seconds(5));
+    auto const datagram =
         DiscoveryDatagram::interpretUDP(bi::udp::endpoint{}, dev::ref(enrResponsePacket));
     BOOST_REQUIRE_EQUAL(datagram->typeName(), "ENRResponse");
 
-    auto enrResponse = dynamic_cast<ENRResponse const&>(*datagram);
+    auto const& enrResponse = dynamic_cast<ENRResponse const&>(*datagram);
     auto const& keyValuePairs = enrResponse.enr->keyValuePairs();
     BOOST_REQUIRE_EQUAL(RLP{keyValuePairs.at("id")}.toString(), "v4");
     PublicCompressed publicCompressed{RLP{keyValuePairs.at("secp256k1")}.toBytesConstRef()};

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -47,7 +47,8 @@ struct TestNodeTable: public NodeTable
     /// Constructor
     TestNodeTable(
         ba::io_service& _io, KeyPair _alias, bi::address const& _addr, uint16_t _port = 30311)
-      : NodeTable(_io, _alias, NodeIPEndpoint(_addr, _port, _port), true /* discovery enabled */,
+      : NodeTable(_io, _alias, NodeIPEndpoint(_addr, _port, _port),
+            createV4ENR(_alias.secret(), _addr, _port, _port), true /* discovery enabled */,
             true /* allow local discovery */)
     {}
 
@@ -1421,7 +1422,10 @@ BOOST_AUTO_TEST_CASE(nodeTableReturnsUnspecifiedNode)
 {
     ba::io_service io;
     auto const port = randomPortNumber();
-    NodeTable t(io, KeyPair::create(), NodeIPEndpoint(bi::address::from_string(c_localhostIp), port, port));
+    auto const keyPair = KeyPair::create();
+    auto const addr = bi::address::from_string(c_localhostIp);
+    NodeTable t(io, keyPair, NodeIPEndpoint(addr, port, port),
+        createV4ENR(keyPair.secret(), addr, port, port));
     if (Node n = t.node(NodeID()))
         BOOST_REQUIRE(false);
 }


### PR DESCRIPTION
Support ENRRequest / ENRResponse discovery packets.

This doesn't add any change in the Discovery algorithm itself yet, just adds the ability for the node to return its current ENR to peers.

I've decided not to add CLI option to enable this and have it always enabled, as it should be fully backwards-compatible, nodes not supporting ENR extension shouldn't notice any difference.

Also this adds a function to libdevcrypto for converting compressed public key to uncompressed (used only in test for now)

Also renames `DiscoveryDatagram::ts` => `DiscoveryDatagram::expiration`

cc @fjl 