### PR TITLE
Log active peer count and peer list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
+- Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.
 
 ## [1.6.0] - 2019-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 - Added: [#5537](https://github.com/ethereum/aleth/pull/5537) Creating Ethereum Node Record (ENR) at program start.
 - Added: [#5557](https://github.com/ethereum/aleth/pull/5557) Improved debug logging of full sync.
 - Added: [#5564](https://github.com/ethereum/aleth/pull/5564) Improved help output of Aleth by adding list of channels.
+- Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
-- Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.
 
 ## [1.6.0] - 2019-04-16
 

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -267,6 +267,16 @@ inline std::ostream& operator<<(std::ostream& _strm, NodeID const& _id)
     return _strm;
 }
 
+inline boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _strm, PeerSessionInfo const& _peerSessionInfo)
+{
+    _strm << _peerSessionInfo.id << "|" << _peerSessionInfo.clientVersion << "|"
+          << _peerSessionInfo.host << "|" << _peerSessionInfo.port << "|";
+    for (auto cap : _peerSessionInfo.caps)
+        _strm << "(" << cap.first << "," << cap.second << ")";
+    return _strm;
+}
+
 /// Simple stream output for a NodeIPEndpoint.
 std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _ep);
 

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -272,7 +272,7 @@ inline boost::log::formatting_ostream& operator<<(
 {
     _strm << _peerSessionInfo.id << "|" << _peerSessionInfo.clientVersion << "|"
           << _peerSessionInfo.host << "|" << _peerSessionInfo.port << "|";
-    for (auto cap : _peerSessionInfo.caps)
+    for (auto const& cap : _peerSessionInfo.caps)
         _strm << "(" << cap.first << "," << cap.second << ")";
     return _strm;
 }

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -869,7 +869,7 @@ void Host::logActivePeers()
     if (m_netConfig.discovery)
         LOG(m_infoLogger) << "Looking for peers...";
 
-    LOG(m_detailsLogger) << peerSessionInfos();
+    LOG(m_detailsLogger) << "Peers: " << peerSessionInfos();
     m_lastPeerLogMessage = chrono::steady_clock::now();
 }
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -98,8 +98,8 @@ Host::Host(
     m_alias{_secretAndENR.first},
     m_enr{_secretAndENR.second},
     m_lastPing(chrono::steady_clock::time_point::min()),
-    m_lastPeerLogMessage(chrono::steady_clock::time_point::min()),
-    m_capabilityHost(createCapabilityHost(*this))
+    m_capabilityHost(createCapabilityHost(*this)),
+    m_lastPeerLogMessage(chrono::steady_clock::time_point::min())
 {
     cnetnote << "Id: " << id();
     cnetnote << "ENR: " << m_enr;

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -371,7 +371,12 @@ private:
 
     std::shared_ptr<CapabilityHostFace> m_capabilityHost;
 
+    /// When the last "active peers" message was logged - used to throttle
+    /// logging to once every c_logActivePeersInterval seconds
+    std::chrono::steady_clock::time_point m_lastPeerLogMessage;
+
     Logger m_logger{createLogger(VerbosityDebug, "net")};
+    Logger m_detailsLogger{createLogger(VerbosityTrace, "net")};
 };
 
 }

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -168,7 +168,7 @@ public:
     void setPeerStretch(unsigned _n) { m_stretchPeers = _n; }
     
     /// Get peer information.
-    PeerSessionInfos peerSessionInfo() const;
+    PeerSessionInfos peerSessionInfos() const;
 
     /// Get number of peers connected.
     size_t peerCount() const;
@@ -269,6 +269,9 @@ private:
     
     /// Ping the peers to update the latency information and disconnect peers which have timed out.
     void keepAlivePeers();
+
+    /// Log count of active peers and information about each peer
+    void logActivePeers();
 
     /// Disconnect peers which didn't respond to keepAlivePeers ping prior to c_keepAliveTimeOut.
     void disconnectLatePeers();
@@ -377,6 +380,7 @@ private:
 
     Logger m_logger{createLogger(VerbosityDebug, "net")};
     Logger m_detailsLogger{createLogger(VerbosityTrace, "net")};
+    Logger m_infoLogger{createLogger(VerbosityInfo, "net")};
 };
 
 }

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -80,7 +80,7 @@ std::string WebThreeDirect::composeClientVersion(std::string const& _client)
 
 std::vector<PeerSessionInfo> WebThreeDirect::peers()
 {
-    return m_net.peerSessionInfo();
+    return m_net.peerSessionInfos();
 }
 
 size_t WebThreeDirect::peerCount() const

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -274,8 +274,8 @@ BOOST_AUTO_TEST_CASE(requirePeer)
     BOOST_REQUIRE_EQUAL(host1peerCount, 1);
     BOOST_REQUIRE_EQUAL(host2peerCount, 1);
 
-    PeerSessionInfos sis1 = host1.peerSessionInfo();
-    PeerSessionInfos sis2 = host2.peerSessionInfo();
+    PeerSessionInfos sis1 = host1.peerSessionInfos();
+    PeerSessionInfos sis2 = host2.peerSessionInfos();
 
     BOOST_REQUIRE_EQUAL(sis1.size(), 1);
     BOOST_REQUIRE_EQUAL(sis2.size(), 1);


### PR DESCRIPTION
Fix #5151 

Log the active peer count and peer list to the "net" channel every 30 seconds. The peer count is logged with debug verbosity whereas the peer list is logged with trace verbosity.

