### PR TITLE
Skip dao challenge if top block < hard fork block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added: [#5557](https://github.com/ethereum/aleth/pull/5557) Improved debug logging of full sync.
 - Added: [#5564](https://github.com/ethereum/aleth/pull/5564) Improved help output of Aleth by adding list of channels.
 - Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.
+- Added: [#5580](https://github.com/ethereum/aleth/pull/5580) Enable syncing from ETC nodes for blocks < dao hard fork block.
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -213,7 +213,7 @@ bool BlockChainSync::requestDaoForkBlockHeader(NodeID const& _peerID)
 {
     // DAO challenge
     u256 const daoHardfork = host().chain().sealEngine()->chainParams().daoHardforkBlock;
-    if (daoHardfork == 0 || daoHardfork == c_infiniteBlockNumber)
+    if (daoHardfork == 0 || daoHardfork == c_infiniteBlockNumber || host().chain().number() < daoHardfork)
         return false;
 
     m_daoChallengedPeers.insert(_peerID);


### PR DESCRIPTION
Fix #5579 

As a syncing optimization, skip performing the dao hard fork challenge if our top block < dao hard fork block since we can still successfully sync these blocks from ETC nodes. Note that sync from these peers will fail starting with the dao hard fork block because we validate that the dao balance is refunded in `Block::performIrregularModifications` so we don't run the risk of syncing on an ETC chain after the dao fork block: https://github.com/ethereum/aleth/blob/60fbc2f6eba6b160824953b72f02a079364d02fe/libethereum/Block.cpp#L690-L701 