### PR TITLE
Fix failing Discovery tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
 - Changed: [#5576](https://github.com/ethereum/aleth/pull/5576) Moved sstore_combinations and static_Call50000_sha256 tests to stTimeConsuming test suite. (testeth runs them only with `--all` flag)
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
+- Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
 
 ## [1.6.0] - 2019-04-16
 

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -270,7 +270,7 @@ vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID const& _targe
         return _node1.first < _node2.first;
     };
 
-    std::set<pair<int, shared_ptr<NodeEntry>>, decltype(distanceToTargetLess)>
+    std::multiset<pair<int, shared_ptr<NodeEntry>>, decltype(distanceToTargetLess)>
         nodesByDistanceToTarget(distanceToTargetLess);
     for (auto const& bucket : m_buckets)
         for (auto const& nodeWeakPtr : bucket.nodes)
@@ -279,7 +279,7 @@ vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID const& _targe
                 nodesByDistanceToTarget.emplace(distance(_target, node->id()), node);
 
                 if (nodesByDistanceToTarget.size() > s_bucketSize)
-                    nodesByDistanceToTarget.erase(nodesByDistanceToTarget.rbegin().base());
+                    nodesByDistanceToTarget.erase(--nodesByDistanceToTarget.end());
             }
 
     vector<shared_ptr<NodeEntry>> ret;

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -203,6 +203,7 @@ void NodeTable::doDiscoveryRound(
     if (!m_socket->isOpen())
         return;
 
+    // send s_alpha FindNode packets to nodes we know, closest to target
     auto const nearestNodes = nearestNodeEntries(_node);
     auto newTriedCount = 0;
     for (auto const& nodeEntry : nearestNodes)
@@ -262,57 +263,33 @@ void NodeTable::doDiscoveryRound(
         });
 }
 
-vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID _target)
+vector<shared_ptr<NodeEntry>> NodeTable::nearestNodeEntries(NodeID const& _target)
 {
-    // send s_alpha FindNode packets to nodes we know, closest to target
-    static unsigned lastBin = s_bins - 1;
-    unsigned head = distance(m_hostNodeID, _target);
-    unsigned tail = head == 0 ? lastBin : (head - 1) % s_bins;
+    vector<pair<int, shared_ptr<NodeEntry>>> nodesByDistanceToTarget;
+    for (auto const& bucket : m_buckets)
+        for (auto const& nodeWeakPtr : bucket.nodes)
+            if (auto node = nodeWeakPtr.lock())
+                nodesByDistanceToTarget.emplace_back(distance(_target, node->id()), node);
 
-    map<unsigned, list<shared_ptr<NodeEntry>>> found;
+    auto const distanceToTargetLess = [](pair<int, shared_ptr<NodeEntry>> const& _node1,
+                                          pair<int, shared_ptr<NodeEntry>> const& _node2) {
+        return _node1.first < _node2.first;
+    };
 
-    // if d is 0, then we roll look forward, if last, we reverse, else, spread from d
-    if (head > 1 && tail != lastBin)
-        while (head != tail && head < s_bins)
-        {
-            Guard l(x_state);
-            for (auto const& n : m_buckets[head].nodes)
-                if (auto p = n.lock())
-                    found[distance(_target, p->id())].push_back(p);
-
-            if (tail)
-                for (auto const& n : m_buckets[tail].nodes)
-                    if (auto p = n.lock())
-                        found[distance(_target, p->id())].push_back(p);
-
-            head++;
-            if (tail)
-                tail--;
-        }
-    else if (head < 2)
-        while (head < s_bins)
-        {
-            Guard l(x_state);
-            for (auto const& n : m_buckets[head].nodes)
-                if (auto p = n.lock())
-                    found[distance(_target, p->id())].push_back(p);
-            head++;
-        }
+    if (nodesByDistanceToTarget.size() <= s_bucketSize)
+        sort(nodesByDistanceToTarget.begin(), nodesByDistanceToTarget.end(), distanceToTargetLess);
     else
-        while (tail > 0)
-        {
-            Guard l(x_state);
-            for (auto const& n : m_buckets[tail].nodes)
-                if (auto p = n.lock())
-                    found[distance(_target, p->id())].push_back(p);
-            tail--;
-        }
+        partial_sort(nodesByDistanceToTarget.begin(),
+            nodesByDistanceToTarget.begin() + s_bucketSize, nodesByDistanceToTarget.end(),
+            distanceToTargetLess);
 
     vector<shared_ptr<NodeEntry>> ret;
-    for (auto& nodes : found)
-        for (auto const& n : nodes.second)
-            if (ret.size() < s_bucketSize && n->endpoint() && isAllowedEndpoint(n->endpoint()))
-                ret.push_back(n);
+    for (auto it = nodesByDistanceToTarget.begin();
+         it != nodesByDistanceToTarget.end() &&
+         it != nodesByDistanceToTarget.begin() + s_bucketSize;
+         ++it)
+        ret.emplace_back(move(it->second));
+
     return ret;
 }
 

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -253,8 +253,8 @@ protected:
     void doDiscoveryRound(NodeID _target, unsigned _round,
         std::shared_ptr<std::set<std::shared_ptr<NodeEntry>>> _tried);
 
-    /// Returns nodes from node table which are closest to target.
-    std::vector<std::shared_ptr<NodeEntry>> nearestNodeEntries(NodeID _target);
+    /// Returns s_bucketSize nodes from node table which are closest to target.
+    std::vector<std::shared_ptr<NodeEntry>> nearestNodeEntries(NodeID const& _target);
 
     /// Asynchronously drops _leastSeen node if it doesn't reply and adds _replacement node,
     /// otherwise _replacement is thrown away.

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -54,7 +54,7 @@ struct TestNodeTable: public NodeTable
     static vector<pair<Public, uint16_t>> createTestNodes(unsigned _count)
     {
         vector<pair<Public, uint16_t>> ret;
-        asserts(_count <= 1000);
+        asserts(_count <= 2000);
         
         ret.clear();
         for (unsigned i = 0; i < _count; i++)
@@ -829,7 +829,7 @@ BOOST_AUTO_TEST_CASE(unexpectedFindNode)
 
 BOOST_AUTO_TEST_CASE(evictionWithOldNodeAnswering)
 {
-    TestNodeTableHost nodeTableHost(1000);
+    TestNodeTableHost nodeTableHost(2000);
     auto& nodeTable = nodeTableHost.nodeTable;
 
     // socket receiving PING


### PR DESCRIPTION
Fixes `network/net` tests failures mentioned in https://github.com/ethereum/aleth/issues/5544

The reason for some of the network test failires was incorrect implementation of `NodeTable::nearestNodeEntries` method (finding the nodes from the node table closest to some target node)

The old implementation tried to utilize the ordering of the nodes in the node table (they are ordered in buckets by distance to the host node) to efficiently find the nodes closest to target. It first looked for the bucket where the target node would fall, and then assumed the nodes in that bucket and around would be close to the target. However I don't think the idea was completely correct, and the implementation definitely was buggy and difficult to understand.

I ended up rewriting it in another, I think simpler, manner using `std::multiset` ordered by the distance to target and keeping only 16 closest nodes.

Go-ethereum uses the similar apporach of iterating over all nodes and putting them into a data structure which keeps only 16 nodes closest to target. 
https://github.com/ethereum/go-ethereum/blob/4c90efdf57ce87edf0d855c8cec10525875a6ab1/p2p/discover/table.go#L521-L536
https://github.com/ethereum/go-ethereum/blob/4c90efdf57ce87edf0d855c8cec10525875a6ab1/p2p/discover/table.go#L757-L781

Parity uses another, much trickier (and presumably more efficient) approach, but I decided not to complicate it like this. Also it's very different from our original approach.
https://github.com/paritytech/parity-ethereum/blob/b30b54e446981dc57835b74d550b40b36385742a/util/network-devp2p/src/discovery.rs#L422-L471
