### PR TITLE
Make log output always line-buffered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
 - Changed: [#5576](https://github.com/ethereum/aleth/pull/5576) Moved sstore_combinations and static_Call50000_sha256 tests to stTimeConsuming test suite. (testeth runs them only with `--all` flag)
+- Changed: [#5589](https://github.com/ethereum/aleth/pull/5589) Make aleth output always line-buffered even when redirected to file or pipe.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
 

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -133,6 +133,9 @@ void setupLogging(LoggingOptions const& _options)
 
     boost::shared_ptr<std::ostream> stream{&std::cout, boost::null_deleter{}};
     sink->locked_backend()->add_stream(stream);
+    // Enable auto-flushing after each log record written
+    sink->locked_backend()->auto_flush(true);
+
     sink->set_filter([_options](boost::log::attribute_value_set const& _set) {
         if (_set[severity] > _options.verbosity)
             return false;


### PR DESCRIPTION
Grid team reports that when reading log output from a client process through a pipe,  other clients make it line-buffered (non-default behavior for stdout, which is line-buffered only when attached to tty)

Here I enable flushing after each line in boost.log.

The difference is noticeable when running commands like
```
>aleth/aleth >aleth.log &
>tail -f aleth.log
```

cc @evertonfraga
