### PR TITLE
Upgrade EVMC to 6.2.2

### DIFF
--- a/libevm/EVMC.cpp
+++ b/libevm/EVMC.cpp
@@ -15,7 +15,7 @@ namespace
 evmc_revision toRevision(EVMSchedule const& _schedule) noexcept
 {
     if (_schedule.haveCreate2 && !_schedule.eip1283Mode)
-        return EVMC_CONSTANTINOPLE2;
+        return EVMC_PETERSBURG;
     if (_schedule.haveCreate2 && _schedule.eip1283Mode)
         return EVMC_CONSTANTINOPLE;
     if (_schedule.haveRevert)


### PR DESCRIPTION
Hi,
I am not sure if it was exactly your intention @chfast, so please verify it. 

Summary:
- EVMC updated to master
- deprecated EVMC_CONSTANTINOPLE2 changed to EVMC_PETERSBURG

issue: https://github.com/ethereum/aleth/issues/5583