### PR TITLE
Network logging bugfixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added: [#5564](https://github.com/ethereum/aleth/pull/5564) Improved help output of Aleth by adding list of channels.
 - Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.
 - Added: [#5580](https://github.com/ethereum/aleth/pull/5580) Enable syncing from ETC nodes for blocks < dao hard fork block.
+- Added: [#5591](https://github.com/ethereum/aleth/pull/5591) Network logging bugfixes and improvements.
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
 - Changed: [#5576](https://github.com/ethereum/aleth/pull/5576) Moved sstore_combinations and static_Call50000_sha256 tests to stTimeConsuming test suite. (testeth runs them only with `--all` flag)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added: [#5564](https://github.com/ethereum/aleth/pull/5564) Improved help output of Aleth by adding list of channels.
 - Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.
 - Added: [#5580](https://github.com/ethereum/aleth/pull/5580) Enable syncing from ETC nodes for blocks < dao hard fork block.
-- Added: [#5591](https://github.com/ethereum/aleth/pull/5591) Network logging bugfixes and improvements.
+- Added: [#5591](https://github.com/ethereum/aleth/pull/5591) Network logging bugfixes and improvements and add p2pcap log channel.
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
 - Changed: [#5576](https://github.com/ethereum/aleth/pull/5576) Moved sstore_combinations and static_Call50000_sha256 tests to stTimeConsuming test suite. (testeth runs them only with `--all` flag)

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -323,7 +323,7 @@ int main(int argc, char** argv)
 
     std::string const logChannels =
         "block blockhdr bq chain client debug discov error ethcap exec host impolite info net "
-        "overlaydb peer rlpx rpc snap statedb sync timer tq trace vmtrace warn watch";
+        "overlaydb p2pcap peer rlpx rpc snap statedb sync timer tq trace vmtrace warn watch";
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
         createLoggingProgramOptions(c_lineWidth, loggingOptions, logChannels));

--- a/libethereum/CommonNet.cpp
+++ b/libethereum/CommonNet.cpp
@@ -24,5 +24,48 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
+namespace dev
+{
+namespace eth
+{
 #pragma GCC diagnostic ignored "-Wunused-variable"
-namespace { char dummy; }
+namespace
+{
+char dummy;
+}
+
+
+char const* ethPacketTypeToString(EthSubprotocolPacketType _packetType)
+{
+    switch (_packetType)
+    {
+    case StatusPacket:
+        return "Status";
+    case NewBlockHashesPacket:
+        return "NewBlockHashes";
+    case TransactionsPacket:
+        return "Transactions";
+    case GetBlockHeadersPacket:
+        return "GetBlockHeaders";
+    case BlockHeadersPacket:
+        return "BlockHeaders";
+    case GetBlockBodiesPacket:
+        return "GetBlockBodies";
+    case BlockBodiesPacket:
+        return "BlockBodies";
+    case NewBlockPacket:
+        return "NewBlock";
+    case GetNodeDataPacket:
+        return "GetNodeData";
+    case NodeDataPacket:
+        return "NodeData";
+    case GetReceiptsPacket:
+        return "GetReceipts";
+    case ReceiptsPacket:
+        return "Receipts";
+    default:
+        return "UnknownEthPacket";
+    }
+}
+}  // namespace eth
+}  // namespace dev

--- a/libethereum/CommonNet.h
+++ b/libethereum/CommonNet.h
@@ -50,7 +50,7 @@ class TransactionQueue;
 class EthereumCapability;
 class EthereumPeer;
 
-enum SubprotocolPacketType: byte
+enum EthSubprotocolPacketType : byte
 {
     StatusPacket = 0x00,
     NewBlockHashesPacket = 0x01,
@@ -68,6 +68,8 @@ enum SubprotocolPacketType: byte
 
     PacketCount
 };
+
+char const* ethPacketTypeToString(EthSubprotocolPacketType _packetType);
 
 enum class Asking
 {

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -92,6 +92,10 @@ public:
     unsigned version() const override { return c_protocolVersion; }
     p2p::CapDesc descriptor() const override { return {name(), version()}; }
     unsigned messageCount() const override { return PacketCount; }
+    char const* packetTypeToString(unsigned _packetType) const override
+    {
+        return ethPacketTypeToString(static_cast<EthSubprotocolPacketType>(_packetType));
+    }
     std::chrono::milliseconds backgroundWorkInterval() const override;
 
     unsigned protocolVersion() const { return c_protocolVersion; }

--- a/libethereum/EthereumPeer.cpp
+++ b/libethereum/EthereumPeer.cpp
@@ -134,7 +134,7 @@ void EthereumPeer::requestReceipts(h256s const& _blocks)
 }
 
 void EthereumPeer::requestByHashes(
-    h256s const& _hashes, Asking _asking, SubprotocolPacketType _packetType)
+    h256s const& _hashes, Asking _asking, EthSubprotocolPacketType _packetType)
 {
     if (m_asking != Asking::Nothing)
     {

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -91,7 +91,8 @@ public:
 
 private:
     // Request of type _packetType with _hashes as input parameters
-    void requestByHashes(h256s const& _hashes, Asking _asking, SubprotocolPacketType _packetType);
+    void requestByHashes(
+        h256s const& _hashes, Asking _asking, EthSubprotocolPacketType _packetType);
 
     std::shared_ptr<p2p::CapabilityHostFace> m_host;
 

--- a/libethereum/WarpCapability.h
+++ b/libethereum/WarpCapability.h
@@ -14,18 +14,20 @@ namespace eth
 {
 class SnapshotStorageFace;
 
-unsigned const c_WarpProtocolVersion = 1;
+constexpr unsigned c_WarpProtocolVersion = 1;
 
 enum WarpSubprotocolPacketType : byte
 {
     WarpStatusPacket = 0x00,
-    GetSnapshotManifest = 0x11,
-    SnapshotManifest = 0x12,
-    GetSnapshotData = 0x13,
-    SnapshotData = 0x14,
+    GetSnapshotManifestPacket = 0x11,
+    SnapshotManifestPacket = 0x12,
+    GetSnapshotDataPacket = 0x13,
+    SnapshotDataPacket = 0x14,
 
     WarpSubprotocolPacketCount
 };
+
+char const* warpPacketTypeToString(WarpSubprotocolPacketType _packetType);
 
 struct WarpPeerStatus
 {
@@ -77,6 +79,10 @@ public:
     unsigned version() const override { return c_WarpProtocolVersion; }
     p2p::CapDesc descriptor() const override { return {name(), version()}; }
     unsigned messageCount() const override { return WarpSubprotocolPacketCount; }
+    char const* packetTypeToString(unsigned _packetType) const override
+    {
+        return warpPacketTypeToString(static_cast<WarpSubprotocolPacketType>(_packetType));
+    }
     std::chrono::milliseconds backgroundWorkInterval() const override;
 
     u256 networkId() const { return m_networkId; }

--- a/libp2p/Capability.h
+++ b/libp2p/Capability.h
@@ -29,6 +29,8 @@ public:
     virtual CapDesc descriptor() const = 0;
     /// Number of messages supported by the subprotocol version.
     virtual unsigned messageCount() const = 0;
+    /// Convert supplied packet type to string - used for logging purposes
+    virtual char const* packetTypeToString(unsigned _packetType) const = 0;
     /// Time interval to run the background work loop at
     virtual std::chrono::milliseconds backgroundWorkInterval() const = 0;
     /// Called by the Host when new peer is connected.

--- a/libp2p/Common.cpp
+++ b/libp2p/Common.cpp
@@ -15,24 +15,20 @@ using namespace std;
 const NodeIPEndpoint UnspecifiedNodeIPEndpoint = NodeIPEndpoint{{}, 0, 0};
 const Node UnspecifiedNode = Node{{}, UnspecifiedNodeIPEndpoint};
 
-char const* packetTypeToString(PacketType _packetType)
+char const* p2pPacketTypeToString(P2pPacketType _packetType)
 {
     switch (_packetType)
     {
     case HelloPacket:
-        return "HelloPacket";
+        return "Hello";
     case DisconnectPacket:
-        return "DisconnectPacket";
+        return "Disconnect";
     case PingPacket:
-        return "PingPacket";
+        return "Ping";
     case PongPacket:
-        return "PongPacket";
-    case GetPeersPacket:
-        return "GetPeersPacket";
-    case PeersPacket:
-        return "PeersPacket";
+        return "Pong";
     default:
-        return "UnknownPacket";
+        return "Unknown";
     }
 }
 

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -78,18 +78,16 @@ NET_GLOBAL_LOGGER(netlog, VerbosityDebug)
 NET_GLOBAL_LOGGER(netdetails, VerbosityTrace)
 #define cnetdetails LOG(dev::p2p::g_netdetailsLogger::get())
 
-enum PacketType
+enum P2pPacketType
 {
     HelloPacket = 0,
     DisconnectPacket,
     PingPacket,
     PongPacket,
-    GetPeersPacket,
-    PeersPacket,
     UserPacket = 0x10
 };
 
-char const* packetTypeToString(PacketType _packetType);
+char const* p2pPacketTypeToString(P2pPacketType _packetType);
 
 enum DisconnectReason
 {

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -371,7 +371,8 @@ void Host::startPeerSession(Public const& _id, RLP const& _helloRlp,
             auto capability = itCap->second.capability;
             session->registerCapability(capDesc, offset, capability);
 
-            cnetlog << "New session for capability " << capDesc.first << "; idOffset: " << offset;
+            cnetlog << "New session for capability " << capDesc.first << "; idOffset: " << offset
+                    << " with " << _id << "@" << _s->remoteEndpoint();
 
             capability->onConnect(_id, capDesc.second);
 
@@ -661,7 +662,7 @@ void Host::connect(shared_ptr<Peer> const& _p)
     _p->m_lastAttempted = chrono::system_clock::now();
     
     bi::tcp::endpoint ep(_p->endpoint);
-    cnetdetails << "Attempting connection to node " << _p->id << "@" << ep << " from " << id();
+    cnetdetails << "Attempting connection to " << _p->id << "@" << ep << " from " << id();
     auto socket = make_shared<RLPXSocket>(m_ioService);
     socket->ref().async_connect(ep, [=](boost::system::error_code const& ec)
     {
@@ -677,7 +678,7 @@ void Host::connect(shared_ptr<Peer> const& _p)
         }
         else
         {
-            cnetdetails << "Connecting to " << _p->id << "@" << ep;
+            cnetdetails << "Starting RLPX handshake with " << _p->id << "@" << ep;
             auto handshake = make_shared<RLPXHandshake>(this, socket, _p->id);
             {
                 Guard l(x_connecting);

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -261,8 +261,10 @@ void Host::doneWorking()
     m_sessions.clear();
 }
 
-// called after successful handshake
-void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXFrameCoder>&& _io, shared_ptr<RLPXSocket> const& _s)
+// Starts a new peer session after a successful handshake - agree on mutually-supported capablities,
+// start each mutually-supported capability, and send a ping to the node.
+void Host::startPeerSession(Public const& _id, RLP const& _helloRlp,
+    unique_ptr<RLPXFrameCoder>&& _io, shared_ptr<RLPXSocket> const& _s)
 {
     // session maybe ingress or egress so m_peers and node table entries may not exist
     shared_ptr<Peer> peer;
@@ -287,11 +289,11 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
         peer->m_lastConnected = chrono::system_clock::now();
     peer->endpoint.setAddress(_s->remoteEndpoint().address());
 
-    auto protocolVersion = _rlp[0].toInt<unsigned>();
-    auto clientVersion = _rlp[1].toString();
-    auto caps = _rlp[2].toVector<CapDesc>();
-    auto listenPort = _rlp[3].toInt<unsigned short>();
-    auto pub = _rlp[4].toHash<Public>();
+    auto const protocolVersion = _helloRlp[0].toInt<unsigned>();
+    auto const clientVersion = _helloRlp[1].toString();
+    auto caps = _helloRlp[2].toVector<CapDesc>();
+    auto const listenPort = _helloRlp[3].toInt<unsigned short>();
+    auto const pub = _helloRlp[4].toHash<Public>();
 
     if (pub != _id)
     {
@@ -309,13 +311,14 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
     for (auto cap: caps)
         capslog << "(" << cap.first << "," << dec << cap.second << ")";
 
-    cnetlog << "Hello: " << clientVersion << " V[" << protocolVersion << "]"
+    cnetlog << "Starting peer session with " << clientVersion << " V[" << protocolVersion << "]"
             << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
 
     // create session so disconnects are managed
     shared_ptr<SessionFace> session = make_shared<Session>(this, move(_io), _s, peer,
         PeerSessionInfo({_id, clientVersion, peer->endpoint.address().to_string(), listenPort,
-            chrono::steady_clock::duration(), _rlp[2].toSet<CapDesc>(), map<string, string>()}));
+            chrono::steady_clock::duration(), _helloRlp[2].toSet<CapDesc>(),
+            map<string, string>()}));
     if (protocolVersion < dev::p2p::c_protocolVersion - 1)
     {
         session->disconnect(IncompatibleProtocol);
@@ -377,8 +380,9 @@ void Host::startPeerSession(Public const& _id, RLP const& _rlp, unique_ptr<RLPXF
 
         session->start();
     }
-    
-    LOG(m_logger) << "p2p.host.peer.register " << _id;
+
+    LOG(m_logger) << "Peer connection successfully established with " << _id << "@"
+                  << _s->remoteEndpoint();
 }
 
 void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -263,7 +263,7 @@ void Host::doneWorking()
 
 // Starts a new peer session after a successful handshake - agree on mutually-supported capablities,
 // start each mutually-supported capability, and send a ping to the node.
-void Host::startPeerSession(Public const& _id, RLP const& _helloRlp,
+void Host::startPeerSession(Public const& _id, RLP const& _hello,
     unique_ptr<RLPXFrameCoder>&& _io, shared_ptr<RLPXSocket> const& _s)
 {
     // session maybe ingress or egress so m_peers and node table entries may not exist
@@ -289,11 +289,11 @@ void Host::startPeerSession(Public const& _id, RLP const& _helloRlp,
         peer->m_lastConnected = chrono::system_clock::now();
     peer->endpoint.setAddress(_s->remoteEndpoint().address());
 
-    auto const protocolVersion = _helloRlp[0].toInt<unsigned>();
-    auto const clientVersion = _helloRlp[1].toString();
-    auto caps = _helloRlp[2].toVector<CapDesc>();
-    auto const listenPort = _helloRlp[3].toInt<unsigned short>();
-    auto const pub = _helloRlp[4].toHash<Public>();
+    auto const protocolVersion = _hello[0].toInt<unsigned>();
+    auto const clientVersion = _hello[1].toString();
+    auto caps = _hello[2].toVector<CapDesc>();
+    auto const listenPort = _hello[3].toInt<unsigned short>();
+    auto const pub = _hello[4].toHash<Public>();
 
     if (pub != _id)
     {
@@ -317,7 +317,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _helloRlp,
     // create session so disconnects are managed
     shared_ptr<SessionFace> session = make_shared<Session>(this, move(_io), _s, peer,
         PeerSessionInfo({_id, clientVersion, peer->endpoint.address().to_string(), listenPort,
-            chrono::steady_clock::duration(), _helloRlp[2].toSet<CapDesc>(),
+            chrono::steady_clock::duration(), _hello[2].toSet<CapDesc>(),
             map<string, string>()}));
     if (protocolVersion < dev::p2p::c_protocolVersion - 1)
     {

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -204,7 +204,7 @@ public:
     bool haveNetwork() const { return m_run; }
     
     /// Validates and starts peer session, taking ownership of _io. Disconnects and returns false upon error.
-    void startPeerSession(Public const& _id, RLP const& _helloRlp,
+    void startPeerSession(Public const& _id, RLP const& _hello,
         std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
 
     /// Get session by id

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -204,7 +204,8 @@ public:
     bool haveNetwork() const { return m_run; }
     
     /// Validates and starts peer session, taking ownership of _io. Disconnects and returns false upon error.
-    void startPeerSession(Public const& _id, RLP const& _hello, std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
+    void startPeerSession(Public const& _id, RLP const& _helloRlp,
+        std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
 
     /// Get session by id
     std::shared_ptr<SessionFace> peerSession(NodeID const& _id) const

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -578,7 +578,8 @@ shared_ptr<NodeEntry> NodeTable::handleNeighbours(
     });
     if (!expected)
     {
-        cnetdetails << "Dropping unsolicited neighbours packet from " << _from.address();
+        LOG(m_logger) << "Dropping unsolicited neighbours packet from " << _packet.sourceid << "@"
+                      << _from.address();
         return sourceNodeEntry;
     }
 

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -437,7 +437,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                                 }
 
                                 P2pPacketType packetType =
-                                    frame[0] == 0x80 ? HelloPacket : (P2pPacketType)frame[0];
+                                    frame[0] == 0x80 ? HelloPacket : static_cast<P2pPacketType>(frame[0]);
                                 if (packetType != HelloPacket)
                                 {
                                     LOG(m_logger)

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -312,7 +312,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
     else if (m_nextState == WriteHello)
     {
         // Send the p2p capability Hello frame
-        LOG(m_logger) << packetTypeToString(HelloPacket) << " to " << m_remote << "@"
+        LOG(m_logger) << p2pPacketTypeToString(HelloPacket) << " to " << m_remote << "@"
                       << m_socket->remoteEndpoint();
 
         m_nextState = ReadHello;
@@ -436,21 +436,22 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
                                     return;
                                 }
 
-                                PacketType packetType =
-                                    frame[0] == 0x80 ? HelloPacket : (PacketType)frame[0];
+                                P2pPacketType packetType =
+                                    frame[0] == 0x80 ? HelloPacket : (P2pPacketType)frame[0];
                                 if (packetType != HelloPacket)
                                 {
                                     LOG(m_logger)
                                         << "Invalid packet type. Expected: "
-                                        << packetTypeToString(HelloPacket)
-                                        << ", received: " << packetTypeToString(packetType) << " ("
-                                        << m_remote << "@" << m_socket->remoteEndpoint() << ")";
+                                        << p2pPacketTypeToString(HelloPacket)
+                                        << ", received: " << p2pPacketTypeToString(packetType)
+                                        << " (" << m_remote << "@" << m_socket->remoteEndpoint()
+                                        << ")";
                                     m_nextState = Error;
                                     transition();
                                     return;
                                 }
 
-                                LOG(m_logger) << packetTypeToString(HelloPacket)
+                                LOG(m_logger) << p2pPacketTypeToString(HelloPacket)
                                               << " verified. Starting session with " << m_remote
                                               << "@" << m_socket->remoteEndpoint();
                                 try

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -125,11 +125,12 @@ bool Session::readPacket(uint16_t _capId, unsigned _packetType, RLP const& _r)
 
 bool Session::interpret(P2pPacketType _t, RLP const& _r)
 {
+    clog(VerbosityTrace, "p2pcap")
+        << p2pPacketTypeToString(_t) << " from " << m_info.id << "@" << m_socket->remoteEndpoint();
     switch (_t)
     {
     case DisconnectPacket:
     {
-        clog(VerbosityTrace, "p2pcap") << p2pPacketTypeToString(DisconnectPacket) << " from " << m_info.id << "@" << m_socket->remoteEndpoint();
         string reason = "Unspecified";
         auto r = (DisconnectReason)_r[0].toInt<int>();
         if (!_r[0].isInt())
@@ -145,14 +146,12 @@ bool Session::interpret(P2pPacketType _t, RLP const& _r)
     }
     case PingPacket:
     {
-        clog(VerbosityTrace, "p2pcap") << "Ping from " << m_info.id << "@" << m_socket->remoteEndpoint();
         clog(VerbosityTrace, "p2pcap") << "Pong to " << m_info.id << "@" << m_socket->remoteEndpoint();
         RLPStream s;
         sealAndSend(prep(s, PongPacket));
         break;
     }
     case PongPacket:
-        clog(VerbosityTrace, "p2pcap") << "Pong from " << m_info.id << "@" << m_socket->remoteEndpoint();
         DEV_GUARDED(x_info)
         {
             m_info.lastPing = std::chrono::steady_clock::now() - m_ping;
@@ -199,6 +198,8 @@ bool Session::checkPacket(bytesConstRef _msg)
 void Session::send(bytes&& _msg)
 {
     bytesConstRef msg(&_msg);
+    clog(VerbosityTrace, "net") << "Sending " << capabilityPacketTypeToString(_msg[0]) << " to "
+                                << m_info.id << "@" << m_socket->remoteEndpoint();
     if (!checkPacket(msg))
         cnetlog << "INVALID PACKET CONSTRUCTED!";
 

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -375,7 +375,7 @@ void Session::doRead()
                     }
                     else
                     {
-                        auto packetType = (P2pPacketType)RLP(frame.cropped(0, 1)).toInt<unsigned>();
+                        auto packetType = static_cast<P2pPacketType>(RLP(frame.cropped(0, 1)).toInt<unsigned>());
                         RLP r(frame.cropped(1));
                         bool ok = readPacket(hProtocolId, packetType, r);
                         if (!ok)
@@ -451,7 +451,6 @@ char const* Session::capabilityPacketTypeToString(unsigned _packetType) const
     for (auto capIter : m_capabilities)
     {
         auto const& capName = capIter.first.first;
-        auto const& capVersion = capIter.first.second;
         auto cap = capIter.second;
         if (canHandle(capName, cap->messageCount(), _packetType))
         {

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -1,24 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file Session.cpp
- * @author Gav Wood <i@gavwood.com>
- * @author Alex Leverington <nessence@gmail.com>
- * @date 2014
- */
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include "Session.h"
 

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -129,6 +129,7 @@ bool Session::interpret(P2pPacketType _t, RLP const& _r)
     {
     case DisconnectPacket:
     {
+        clog(VerbosityTrace, "p2pcap") << p2pPacketTypeToString(DisconnectPacket) << " from " << m_info.id << "@" << m_socket->remoteEndpoint();
         string reason = "Unspecified";
         auto r = (DisconnectReason)_r[0].toInt<int>();
         if (!_r[0].isInt())
@@ -136,7 +137,7 @@ bool Session::interpret(P2pPacketType _t, RLP const& _r)
         else
         {
             reason = reasonOf(r);
-            cnetlog << "Disconnect (reason: " << reason << ") from " << m_info.id << "@"
+            clog(VerbosityDebug, "p2pcap") << "Disconnect (reason: " << reason << ") from " << m_info.id << "@"
                     << m_socket->remoteEndpoint();
             drop(DisconnectRequested);
         }
@@ -144,16 +145,18 @@ bool Session::interpret(P2pPacketType _t, RLP const& _r)
     }
     case PingPacket:
     {
-        cnetdetails << "Pong to " << m_info.id << "@" << m_socket->remoteEndpoint();
+        clog(VerbosityTrace, "p2pcap") << "Ping from " << m_info.id << "@" << m_socket->remoteEndpoint();
+        clog(VerbosityTrace, "p2pcap") << "Pong to " << m_info.id << "@" << m_socket->remoteEndpoint();
         RLPStream s;
         sealAndSend(prep(s, PongPacket));
         break;
     }
     case PongPacket:
+        clog(VerbosityTrace, "p2pcap") << "Pong from " << m_info.id << "@" << m_socket->remoteEndpoint();
         DEV_GUARDED(x_info)
         {
             m_info.lastPing = std::chrono::steady_clock::now() - m_ping;
-            cnetdetails << "Ping latency: "
+            clog(VerbosityTrace, "p2pcap") << "Ping latency: "
                         << chrono::duration_cast<chrono::milliseconds>(m_info.lastPing).count()
                         << " ms";
         }
@@ -166,7 +169,7 @@ bool Session::interpret(P2pPacketType _t, RLP const& _r)
 
 void Session::ping()
 {
-    cnetdetails << "Ping to " << m_info.id << "@" << m_socket->remoteEndpoint();
+    clog(VerbosityTrace, "p2pcap") << "Ping to " << m_info.id << "@" << m_socket->remoteEndpoint();
     RLPStream s;
     sealAndSend(prep(s, PingPacket));
     m_ping = std::chrono::steady_clock::now();

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -115,7 +115,7 @@ public:
     boost::optional<unsigned> capabilityOffset(std::string const& _capabilityName) const override;
 
 private:
-    static RLPStream& prep(RLPStream& _s, PacketType _t, unsigned _args = 0);
+    static RLPStream& prep(RLPStream& _s, P2pPacketType _t, unsigned _args = 0);
 
     void send(bytes&& _msg);
 
@@ -132,11 +132,11 @@ private:
     void write();
 
     /// Deliver RLPX packet to Session or PeerCapability for interpretation.
-    bool readPacket(uint16_t _capId, PacketType _t, RLP const& _r);
+    bool readPacket(uint16_t _capId, unsigned _t, RLP const& _r);
 
     /// Interpret an incoming Session packet.
-    bool interpret(PacketType _t, RLP const& _r);
-    
+    bool interpret(P2pPacketType _t, RLP const& _r);
+
     /// @returns true iff the _msg forms a valid message for sending or receiving on the network.
     static bool checkPacket(bytesConstRef _msg);
 
@@ -147,6 +147,8 @@ private:
 
     bool canHandle(
         std::string const& _capability, unsigned _messageCount, unsigned _packetType) const;
+
+    char const* capabilityPacketTypeToString(unsigned _packetType) const;
 
     Host* m_server;							///< The host that owns us. Never null.
 

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -1,24 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file Session.h
- * @author Gav Wood <i@gavwood.com>
- * @author Alex Leverington <nessence@gmail.com>
- * @date 2014
- */
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #pragma once
 

--- a/test/unittests/libp2p/capability.cpp
+++ b/test/unittests/libp2p/capability.cpp
@@ -24,6 +24,10 @@ public:
     unsigned version() const override { return 2; }
     CapDesc descriptor() const override { return {name(), version()}; }
     unsigned messageCount() const override { return UserPacket + 1; }
+    char const* packetTypeToString(unsigned) const override
+    {
+        return "UserPacket";
+    }
     chrono::milliseconds backgroundWorkInterval() const override
     {
         return c_backgroundWorkInterval;

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -22,6 +22,10 @@ public:
     unsigned version() const override { return 2; }
     CapDesc descriptor() const override { return {name(), version()}; }
     unsigned messageCount() const override { return UserPacket + 1; }
+    char const* packetTypeToString(unsigned) const override
+    {
+        return "p2pTestCapabilityPacketType";
+    }
 
     chrono::milliseconds backgroundWorkInterval() const override
     {


### PR DESCRIPTION
Various network logging bugfixes and changes. Bugfixes:
* Move "unsolicited neighbours packet" message from "net" to "discov" log channel since that's the channel that the rest of the discovery messages are logged to
* Fix log message that we write when we send a p2p capability pong (we incorrectly say we're sending a ping)

Other logging changes:
* Log messages related to p2p capability messaging to a new "p2pcap" log channel
* Log incoming capability packet type string
* Add node id and endpoint information to some network log messages
* Remove redundant "Packet" from p2p capability packet type strings
* Remove logging of RLP payloads in Session (this adds clutter to the log output and makes it harder to visually parse - I think it's safe to remove this information since I can't see us ever using it for debugging, if it turns out we need it we can always add it back)