### PR TITLE
Updating host ENR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added: [#5575](https://github.com/ethereum/aleth/pull/5575) Log active peer count and peer list every 30 seconds.
 - Added: [#5580](https://github.com/ethereum/aleth/pull/5580) Enable syncing from ETC nodes for blocks < dao hard fork block.
 - Added: [#5591](https://github.com/ethereum/aleth/pull/5591) Network logging bugfixes and improvements and add p2pcap log channel.
+- Added: [#5593](https://github.com/ethereum/aleth/pull/5593) Dynamically updating host ENR.
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
 - Changed: [#5576](https://github.com/ethereum/aleth/pull/5576) Moved sstore_combinations and static_Call50000_sha256 tests to stTimeConsuming test suite. (testeth runs them only with `--all` flag)

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -102,7 +102,7 @@ ENR IdentitySchemeV4::createENR(Secret const& _secret, boost::asio::ip::address 
 
     auto const keyValuePairs = createKeyValuePairs(_secret, _ip, _tcpPort, _udpPort);
 
-    return ENR{0 /* sequence number */, keyValuePairs, signFunction};
+    return ENR{1 /* sequence number */, keyValuePairs, signFunction};
 }
 
 bytes IdentitySchemeV4::sign(bytesConstRef _data, Secret const& _secret)

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -128,13 +128,13 @@ boost::asio::ip::address ENR::ip() const
 uint16_t ENR::tcpPort() const
 {
     auto itTCP = m_keyValuePairs.find(c_keyTCP);
-    return itTCP == m_keyValuePairs.end() ? 0 : RLP{itTCP->second}.toInt<uint16_t>();
+    return itTCP == m_keyValuePairs.end() ? 0 : RLP{itTCP->second}.toInt<uint16_t>(RLP::VeryStrict);
 }
 
 uint16_t ENR::udpPort() const
 {
     auto itUDP = m_keyValuePairs.find(c_keyUDP);
-    return itUDP == m_keyValuePairs.end() ? 0 : RLP{itUDP->second}.toInt<uint16_t>();
+    return itUDP == m_keyValuePairs.end() ? 0 : RLP{itUDP->second}.toInt<uint16_t>(RLP::VeryStrict);
 }
 
 ENR IdentitySchemeV4::createENR(Secret const& _secret, boost::asio::ip::address const& _ip,
@@ -229,9 +229,11 @@ std::ostream& operator<<(std::ostream& _out, ENR const& _enr)
     {
         auto const pubKey = IdentitySchemeV4::publicKey(_enr);
         auto const address = _enr.ip();
+        auto const tcp = _enr.tcpPort();
+        auto const udp = _enr.udpPort();
 
-        _out << "key=" << pubKey.abridged() << " ip=" << address << " tcp=" << _enr.tcpPort()
-             << " udp=" << _enr.udpPort();
+        _out << "key=" << pubKey.abridged() << " ip=" << address << " tcp=" << tcp
+             << " udp=" << udp;
     }
     catch (Exception const&)
     {

--- a/libp2p/ENR.cpp
+++ b/libp2p/ENR.cpp
@@ -32,7 +32,7 @@ template <std::size_t N>
 std::array<byte, N> bytesToAddress(bytesConstRef _bytes)
 {
     std::array<byte, N> address;
-    std::copy(_bytes.begin(), _bytes.begin() + N, address.begin());
+    std::copy_n(_bytes.begin(), N, address.begin());
     return address;
 }
 }  // namespace
@@ -99,7 +99,7 @@ void ENR::streamContent(RLPStream& _s) const
 ENR ENR::update(
     std::map<std::string, bytes> const& _keyValuePairs, SignFunction const& _signFunction) const
 {
-    return ENR(m_seq + 1, _keyValuePairs, _signFunction);
+    return ENR{m_seq + 1, _keyValuePairs, _signFunction};
 }
 
 std::string ENR::id() const
@@ -227,8 +227,11 @@ std::ostream& operator<<(std::ostream& _out, ENR const& _enr)
 
     try
     {
-        _out << "key=" << IdentitySchemeV4::publicKey(_enr).abridged() << " ip=" << _enr.ip()
-             << " tcp=" << _enr.tcpPort() << " udp=" << _enr.udpPort();
+        auto const pubKey = IdentitySchemeV4::publicKey(_enr);
+        auto const address = _enr.ip();
+
+        _out << "key=" << pubKey.abridged() << " ip=" << address << " tcp=" << _enr.tcpPort()
+             << " udp=" << _enr.udpPort();
     }
     catch (Exception const&)
     {

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -41,6 +41,10 @@ public:
     // Serialize to given RLP stream
     void streamRLP(RLPStream& _s) const;
 
+    // Create new ENR succeeding current one with updated keyValuePairs
+    ENR update(
+        std::map<std::string, bytes> const& _keyValuePair, SignFunction const& _signFunction) const;
+
 private:
     uint64_t m_seq = 0;
     std::map<std::string, bytes> m_map;
@@ -51,10 +55,22 @@ private:
     void streamContent(RLPStream& _s) const;
 };
 
+class IdentitySchemeV4
+{
+public:
+    static ENR createENR(Secret const& _secret, boost::asio::ip::address const& _ip,
+        uint16_t _tcpPort, uint16_t _udpPort);
 
-ENR createV4ENR(Secret const& _secret, boost::asio::ip::address const& _ip, uint16_t _tcpPort,  uint16_t _udpPort);
+    static ENR updateENR(ENR const& _enr, Secret const& _secret,
+        boost::asio::ip::address const& _ip, uint16_t _tcpPort, uint16_t _udpPort);
 
-ENR parseV4ENR(RLP const& _rlp);
+    static ENR parseENR(RLP const& _rlp);
+
+private:
+    static bytes sign(bytesConstRef _data, Secret const& _secret);
+    static std::map<std::string, bytes> createKeyValuePairs(Secret const& _secret,
+        boost::asio::ip::address const& _ip, uint16_t _tcpPort, uint16_t _udpPort);
+};
 
 std::ostream& operator<<(std::ostream& _out, ENR const& _enr);
 

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -13,6 +13,8 @@ namespace p2p
 DEV_SIMPLE_EXCEPTION(ENRIsTooBig);
 DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
 DEV_SIMPLE_EXCEPTION(ENRKeysAreNotUniqueSorted);
+DEV_SIMPLE_EXCEPTION(ENRUnknownIdentityScheme);
+DEV_SIMPLE_EXCEPTION(ENRUnsupportedIPAddress);
 
 /// Class representing Ethereum Node Record - see EIP-778
 class ENR
@@ -31,7 +33,7 @@ public:
     // Parse from RLP with given signature verification function
     ENR(RLP const& _rlp, VerifyFunction const& _verifyFunction);
     // Create with given sign function
-    ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValues,
+    ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValuePairs,
         SignFunction const& _signFunction);
 
     uint64_t sequenceNumber() const { return m_seq; }
@@ -55,6 +57,14 @@ private:
     void streamContent(RLPStream& _s) const;
 };
 
+struct IdentityV4Info
+{
+    PublicCompressed publicKey;
+    boost::asio::ip::address ip;
+    uint16_t tcpPort = 0;
+    uint16_t udpPort = 0;
+};
+
 class IdentitySchemeV4
 {
 public:
@@ -65,6 +75,8 @@ public:
         boost::asio::ip::address const& _ip, uint16_t _tcpPort, uint16_t _udpPort);
 
     static ENR parseENR(RLP const& _rlp);
+
+    static IdentityV4Info info(ENR const& _enr);
 
 private:
     static bytes sign(bytesConstRef _data, Secret const& _secret);

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -14,6 +14,7 @@ DEV_SIMPLE_EXCEPTION(ENRIsTooBig);
 DEV_SIMPLE_EXCEPTION(ENRSignatureIsInvalid);
 DEV_SIMPLE_EXCEPTION(ENRKeysAreNotUniqueSorted);
 DEV_SIMPLE_EXCEPTION(ENRUnknownIdentityScheme);
+DEV_SIMPLE_EXCEPTION(ENRSecp256k1NotFound);
 DEV_SIMPLE_EXCEPTION(ENRUnsupportedIPAddress);
 
 /// Class representing Ethereum Node Record - see EIP-778
@@ -37,8 +38,15 @@ public:
         SignFunction const& _signFunction);
 
     uint64_t sequenceNumber() const { return m_seq; }
-    std::map<std::string, bytes> const& keyValuePairs() const { return m_map; }
     bytes const& signature() const { return m_signature; }
+
+    std::map<std::string, bytes> const& keyValuePairs() const { return m_keyValuePairs; }
+
+    // Pre-defined keys
+    std::string id() const;
+    boost::asio::ip::address ip() const;
+    uint16_t tcpPort() const;
+    uint16_t udpPort() const;
 
     // Serialize to given RLP stream
     void streamRLP(RLPStream& _s) const;
@@ -49,20 +57,12 @@ public:
 
 private:
     uint64_t m_seq = 0;
-    std::map<std::string, bytes> m_map;
+    std::map<std::string, bytes> m_keyValuePairs;
     bytes m_signature;
 
     bytes content() const;
-    size_t contentRlpListItemCount() const { return m_map.size() * 2 + 1; }
+    size_t contentRlpListItemCount() const { return m_keyValuePairs.size() * 2 + 1; }
     void streamContent(RLPStream& _s) const;
-};
-
-struct IdentityV4Info
-{
-    PublicCompressed publicKey;
-    boost::asio::ip::address ip;
-    uint16_t tcpPort = 0;
-    uint16_t udpPort = 0;
 };
 
 class IdentitySchemeV4
@@ -76,7 +76,7 @@ public:
 
     static ENR parseENR(RLP const& _rlp);
 
-    static IdentityV4Info info(ENR const& _enr);
+    static PublicCompressed publicKey(ENR const& _enr);
 
 private:
     static bytes sign(bytesConstRef _data, Secret const& _secret);

--- a/libp2p/ENR.h
+++ b/libp2p/ENR.h
@@ -24,16 +24,16 @@ public:
     // ENR class implementation is independent of Identity Scheme.
     // Identity Scheme specifics are passed to ENR as functions.
 
-    // Sign function gets serialized ENR contents and signs it according to some Identity Scheme
+    /// Sign function gets serialized ENR contents and signs it according to some Identity Scheme
     using SignFunction = std::function<bytes(bytesConstRef)>;
-    // Verify function gets ENR key-value pairs, signature, and serialized content and validates the
-    // signature according to some Identity Scheme
+    /// Verify function gets ENR key-value pairs, signature, and serialized content and validates the
+    /// signature according to some Identity Scheme
     using VerifyFunction =
         std::function<bool(std::map<std::string, bytes> const&, bytesConstRef, bytesConstRef)>;
 
-    // Parse from RLP with given signature verification function
+    /// Parse from RLP with given signature verification function
     ENR(RLP const& _rlp, VerifyFunction const& _verifyFunction);
-    // Create with given sign function
+    /// Create with given sign function
     ENR(uint64_t _seq, std::map<std::string, bytes> const& _keyValuePairs,
         SignFunction const& _signFunction);
 
@@ -42,16 +42,16 @@ public:
 
     std::map<std::string, bytes> const& keyValuePairs() const { return m_keyValuePairs; }
 
-    // Pre-defined keys
+    /// Pre-defined keys
     std::string id() const;
     boost::asio::ip::address ip() const;
     uint16_t tcpPort() const;
     uint16_t udpPort() const;
 
-    // Serialize to given RLP stream
+    /// Serialize to given RLP stream
     void streamRLP(RLPStream& _s) const;
 
-    // Create new ENR succeeding current one with updated keyValuePairs
+    /// Create new ENR succeeding current one with updated @a _keyValuePairs
     ENR update(
         std::map<std::string, bytes> const& _keyValuePair, SignFunction const& _signFunction) const;
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -1050,7 +1050,7 @@ std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _
             secret = Secret{r[1][0].toBytes()};
             auto enrRlp = r[1][1];
 
-            return make_pair(secret, parseV4ENR(enrRlp));
+            return make_pair(secret, IdentitySchemeV4::parseENR(enrRlp));
         }
 
         // Support for older format without ENR
@@ -1067,8 +1067,8 @@ std::pair<Secret, ENR> Host::restoreENR(bytesConstRef _b, NetworkConfig const& _
     auto const address = _netConfig.publicIPAddress.empty() ?
                              bi::address{} :
                              bi::address::from_string(_netConfig.publicIPAddress);
-    return make_pair(
-        secret, createV4ENR(secret, address, _netConfig.listenPort, _netConfig.listenPort));
+    return make_pair(secret,
+        IdentitySchemeV4::createENR(secret, address, _netConfig.listenPort, _netConfig.listenPort));
 }
 
 bool Host::nodeTableHasNode(Public const& _id) const

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -484,11 +484,11 @@ bi::tcp::endpoint Host::determinePublic() const
 ENR Host::updateENR(
     ENR const& _restoredENR, bi::tcp::endpoint const& _tcpPublic, uint16_t const& _listenPort)
 {
-    IdentityV4Info const info = IdentitySchemeV4::info(m_restoredENR);
+    auto const address =
+        _tcpPublic.address().is_unspecified() ? _restoredENR.ip() : _tcpPublic.address();
 
-    auto const address = _tcpPublic.address().is_unspecified() ? info.ip : _tcpPublic.address();
-
-    if (info.ip == address && info.tcpPort == _listenPort && info.udpPort == _listenPort)
+    if (_restoredENR.ip() == address && _restoredENR.tcpPort() == _listenPort &&
+        _restoredENR.udpPort() == _listenPort)
         return _restoredENR;
 
     ENR const newENR = IdentitySchemeV4::updateENR(

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -244,7 +244,11 @@ public:
     p2p::NodeInfo nodeInfo() const { return NodeInfo(id(), (networkConfig().publicIPAddress.empty() ? m_tcpPublic.address().to_string() : networkConfig().publicIPAddress), m_tcpPublic.port(), m_clientVersion); }
 
     /// Get Ethereum Node Record of the host
-    ENR enr() const { return m_enr; }
+    ENR enr() const
+    {
+        Guard l(x_nodeTable);
+        return m_nodeTable ? m_nodeTable->hostENR() : m_restoredENR;
+    }
 
     /// Apply function to each session
     void forEachPeer(
@@ -279,8 +283,11 @@ private:
 
     bool isHandshaking(NodeID const& _id) const;
 
-    /// Determines and sets m_tcpPublic to publicly advertised address.
-    void determinePublic();
+    /// Determines publicly advertised address.
+    bi::tcp::endpoint determinePublic() const;
+
+    ENR updateENR(
+        ENR const& _restoredENR, bi::tcp::endpoint const& _tcpPublic, uint16_t const& _listenPort);
 
     void connect(std::shared_ptr<Peer> const& _p);
 
@@ -360,7 +367,8 @@ private:
     bi::tcp::endpoint m_tcpPublic;											///< Our public listening endpoint.
     /// Alias for network communication.
     KeyPair m_alias;
-    ENR m_enr;
+    /// Host's Ethereum Node Record restored from network.rlp
+    ENR m_restoredENR;
     std::shared_ptr<NodeTable> m_nodeTable;									///< Node table (uses kademlia-like discovery).
     mutable std::mutex x_nodeTable;
     std::shared_ptr<NodeTable> nodeTable() const { Guard l(x_nodeTable); return m_nodeTable; }

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -368,7 +368,7 @@ private:
     /// Alias for network communication.
     KeyPair m_alias;
     /// Host's Ethereum Node Record restored from network.rlp
-    ENR m_restoredENR;
+    ENR const m_restoredENR;
     std::shared_ptr<NodeTable> m_nodeTable;									///< Node table (uses kademlia-like discovery).
     mutable std::mutex x_nodeTable;
     std::shared_ptr<NodeTable> nodeTable() const { Guard l(x_nodeTable); return m_nodeTable; }

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -42,12 +42,11 @@ NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint 
   : m_hostNodeID{_alias.pub()},
     m_hostNodeIDHash{sha3(m_hostNodeID)},
     m_hostStaticIP{isAllowedEndpoint(_endpoint) ? _endpoint.address() : bi::address{}},
-    m_hostNodeEndpoint{_endpoint},
+    m_hostNodeEndpoint{_enr.ip(), _enr.udpPort(), _enr.tcpPort()},
     m_hostENR{_enr},
-    m_hostENRInfo{IdentitySchemeV4::info(m_hostENR)},
     m_secret{_alias.secret()},
     m_socket{make_shared<NodeSocket>(
-        _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)m_hostNodeEndpoint)},
+        _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)_endpoint)},
     m_requestTimeToLive{DiscoveryDatagram::c_timeToLiveS},
     m_allowLocalDiscovery{_allowLocalDiscovery},
     m_discoveryTimer{make_shared<ba::steady_timer>(_io)},
@@ -556,18 +555,14 @@ shared_ptr<NodeEntry> NodeTable::handlePong(
             newUdpEndpoint.address(m_hostStaticIP);
 
         if (newUdpEndpoint != m_hostNodeEndpoint)
+        {
             m_hostNodeEndpoint = NodeIPEndpoint{
                 newUdpEndpoint.address(), newUdpEndpoint.port(), m_hostNodeEndpoint.tcpPort()};
-        
-        if (m_hostENRInfo.ip != m_hostNodeEndpoint.address() ||
-            m_hostENRInfo.udpPort != pong.destination.udpPort())
-        {
             {
                 Guard l(m_hostENRMutex);
                 m_hostENR =
                     IdentitySchemeV4::updateENR(m_hostENR, m_secret, m_hostNodeEndpoint.address(),
-                        m_hostNodeEndpoint.tcpPort(), pong.destination.udpPort());
-                m_hostENRInfo = IdentitySchemeV4::info(m_hostENR);
+                        m_hostNodeEndpoint.tcpPort(), m_hostNodeEndpoint.udpPort());
             }
             clog(VerbosityInfo, "net") << "ENR updated: " << m_hostENR;
         }        

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -44,6 +44,7 @@ NodeTable::NodeTable(ba::io_service& _io, KeyPair const& _alias, NodeIPEndpoint 
     m_hostStaticIP{isAllowedEndpoint(_endpoint) ? _endpoint.address() : bi::address{}},
     m_hostNodeEndpoint{_endpoint},
     m_hostENR{_enr},
+    m_hostENRInfo{IdentitySchemeV4::info(m_hostENR)},
     m_secret{_alias.secret()},
     m_socket{make_shared<NodeSocket>(
         _io, static_cast<UDPSocketEvents&>(*this), (bi::udp::endpoint)m_hostNodeEndpoint)},

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -660,7 +660,7 @@ struct ENRResponse : DiscoveryDatagram
     {
         RLP r(_bytes, RLP::AllowNonCanon | RLP::ThrowOnFail);
         echo = (h256)r[0];
-        enr.reset(new ENR{parseV4ENR(r[1])});
+        enr.reset(new ENR{IdentitySchemeV4::parseENR(r[1])});
     }
 
     std::string typeName() const override { return "ENRResponse"; }

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -341,7 +341,6 @@ protected:
     NodeIPEndpoint m_hostNodeEndpoint;
     ENR m_hostENR;
     mutable Mutex m_hostENRMutex;
-    IdentityV4Info m_hostENRInfo;
     Secret m_secret;												///< This nodes secret key.
 
     mutable Mutex x_nodes;											///< LOCK x_state first if both locks are required. Mutable for thread-safe copy in nodes() const.

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -176,6 +176,11 @@ public:
     /// Returns the Node to the corresponding node id or the empty Node if that id is not found.
     Node node(NodeID const& _id);
 
+    ENR hostENR() const
+    {
+        Guard l(m_hostENRMutex);
+        return m_hostENR;
+    }
 
     void runBackgroundTask(std::chrono::milliseconds const& _period,
         std::shared_ptr<ba::steady_timer> _timer, std::function<void()> _f);
@@ -334,7 +339,9 @@ protected:
     bi::address const m_hostStaticIP;
     // Dynamically updated host endpoint
     NodeIPEndpoint m_hostNodeEndpoint;
-    ENR const m_hostENR;
+    ENR m_hostENR;
+    mutable Mutex m_hostENRMutex;
+    IdentityV4Info m_hostENRInfo;
     Secret m_secret;												///< This nodes secret key.
 
     mutable Mutex x_nodes;											///< LOCK x_state first if both locks are required. Mutable for thread-safe copy in nodes() const.

--- a/test/unittests/libp2p/ENRTest.cpp
+++ b/test/unittests/libp2p/ENRTest.cpp
@@ -27,7 +27,7 @@ TEST(enr, parse)
         "f884b8407098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f3"
         "0813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c01826964827634826970847f00000189736563703235"
         "366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31388375647082765f");
-    ENR enr = parseV4ENR(RLP{rlp});
+    ENR enr = IdentitySchemeV4::parseENR(RLP{rlp});
 
     EXPECT_EQ(enr.signature(),
         fromHex("7098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f3"
@@ -45,13 +45,14 @@ TEST(enr, createAndParse)
 {
     auto keyPair = KeyPair::create();
 
-    ENR enr1 = createV4ENR(keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+    ENR enr1 = IdentitySchemeV4::createENR(
+        keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
 
     RLPStream s;
     enr1.streamRLP(s);
     bytes rlp = s.out();
 
-    ENR enr2 = parseV4ENR(RLP{rlp});
+    ENR enr2 = IdentitySchemeV4::parseENR(RLP{rlp});
 
     EXPECT_EQ(enr1.signature(), enr2.signature());
     EXPECT_EQ(enr1.sequenceNumber(), enr2.sequenceNumber());
@@ -110,7 +111,8 @@ TEST(enr, parseInvalidSignature)
 {
     auto keyPair = KeyPair::create();
 
-    ENR enr1 = createV4ENR(keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+    ENR enr1 = IdentitySchemeV4::createENR(
+        keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
 
     RLPStream s;
     enr1.streamRLP(s);
@@ -120,7 +122,7 @@ TEST(enr, parseInvalidSignature)
     auto signatureOffset = RLP{rlp}[0].payload().data() - rlp.data();
     rlp[signatureOffset]++;
 
-    EXPECT_THROW(parseV4ENR(RLP{rlp}), ENRSignatureIsInvalid);
+    EXPECT_THROW(IdentitySchemeV4::parseENR(RLP{rlp}), ENRSignatureIsInvalid);
 }
 
 TEST(enr, parseV4WithInvalidID)
@@ -133,7 +135,7 @@ TEST(enr, parseV4WithInvalidID)
     enr1.streamRLP(s);
     bytes rlp = s.out();
 
-    EXPECT_THROW(parseV4ENR(RLP{rlp}), ENRSignatureIsInvalid);
+    EXPECT_THROW(IdentitySchemeV4::parseENR(RLP{rlp}), ENRSignatureIsInvalid);
 }
 
 TEST(enr, parseV4WithNoPublicKey)
@@ -146,13 +148,14 @@ TEST(enr, parseV4WithNoPublicKey)
     enr1.streamRLP(s);
     bytes rlp = s.out();
 
-    EXPECT_THROW(parseV4ENR(RLP{rlp}), ENRSignatureIsInvalid);
+    EXPECT_THROW(IdentitySchemeV4::parseENR(RLP{rlp}), ENRSignatureIsInvalid);
 }
 
 TEST(enr, createV4)
 {
     auto keyPair = KeyPair::create();
-    ENR enr = createV4ENR(keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+    ENR enr = IdentitySchemeV4::createENR(
+        keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
 
     auto keyValuePairs = enr.keyValuePairs();
 

--- a/test/unittests/libp2p/ENRTest.cpp
+++ b/test/unittests/libp2p/ENRTest.cpp
@@ -59,6 +59,31 @@ TEST(enr, createAndParse)
     EXPECT_EQ(enr1.keyValuePairs(), enr2.keyValuePairs());
 }
 
+TEST(enr, update)
+{
+    auto keyPair = KeyPair::create();
+
+    ENR const enr1 = IdentitySchemeV4::createENR(
+        keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+
+    EXPECT_EQ(enr1.sequenceNumber(), 1);
+
+    ENR const enr2 = IdentitySchemeV4::updateENR(
+        enr1, keyPair.secret(), bi::address::from_string("127.0.0.1"), 3323, 5545);
+
+    EXPECT_EQ(enr2.sequenceNumber(), 2);
+
+    RLPStream s;
+    enr2.streamRLP(s);
+    bytes rlp = s.out();
+
+    ENR enrParsed = IdentitySchemeV4::parseENR(RLP{rlp});
+
+    EXPECT_EQ(enrParsed.sequenceNumber(), 2);
+    EXPECT_EQ(enrParsed.tcpPort(), 3323);
+    EXPECT_EQ(enrParsed.udpPort(), 5545);
+}
+
 TEST(enr, parseTooBigRlp)
 {
     std::map<std::string, bytes> keyValuePairs = {{"key", rlp(bytes(300, 'a'))}};
@@ -168,4 +193,25 @@ TEST(enr, createV4)
     EXPECT_EQ(keyValuePairs["tcp"], rlp(3322));
     EXPECT_TRUE(contains(keyValuePairs, std::string("udp")));
     EXPECT_EQ(keyValuePairs["udp"], rlp(5544));
+}
+
+TEST(enr, predefinedKeys)
+{
+    auto keyPair = KeyPair::create();
+    ENR enr = IdentitySchemeV4::createENR(
+        keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+
+    EXPECT_EQ(enr.id(), "v4");
+    EXPECT_EQ(enr.ip(), bi::address::from_string("127.0.0.1"));
+    EXPECT_EQ(enr.tcpPort(), 3322);
+    EXPECT_EQ(enr.udpPort(), 5544);
+}
+
+TEST(enr, publicKeyV4)
+{
+    auto keyPair = KeyPair::create();
+    ENR enr = IdentitySchemeV4::createENR(
+        keyPair.secret(), bi::address::from_string("127.0.0.1"), 3322, 5544);
+
+    EXPECT_EQ(IdentitySchemeV4::publicKey(enr), toPublicCompressed(keyPair.secret()));
 }

--- a/test/unittests/libp2p/eip-8.cpp
+++ b/test/unittests/libp2p/eip-8.cpp
@@ -378,8 +378,8 @@ shared_ptr<TestHandshake> TestHandshake::runWithInput(
     });
 
     // Spawn a client to execute the handshake.
-    auto host = make_shared<Host>(
-        "peer name", make_pair(_hostAlias, createV4ENR(_hostAlias, endpoint.address(), 0, 0)));
+    auto host = make_shared<Host>("peer name",
+        make_pair(_hostAlias, IdentitySchemeV4::createENR(_hostAlias, endpoint.address(), 0, 0)));
     auto client = make_shared<RLPXSocket>(io);
     shared_ptr<TestHandshake> handshake;
     if (_remoteID == NodeID())

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -48,8 +48,8 @@ struct TestNodeTable: public NodeTable
     TestNodeTable(
         ba::io_service& _io, KeyPair _alias, bi::address const& _addr, uint16_t _port = 30311)
       : NodeTable(_io, _alias, NodeIPEndpoint(_addr, _port, _port),
-            createV4ENR(_alias.secret(), _addr, _port, _port), true /* discovery enabled */,
-            true /* allow local discovery */)
+            IdentitySchemeV4::createENR(_alias.secret(), _addr, _port, _port),
+            true /* discovery enabled */, true /* allow local discovery */)
     {}
 
     static vector<pair<Public, uint16_t>> createTestNodes(unsigned _count)
@@ -1476,7 +1476,7 @@ BOOST_AUTO_TEST_CASE(nodeTableReturnsUnspecifiedNode)
     auto const keyPair = KeyPair::create();
     auto const addr = bi::address::from_string(c_localhostIp);
     NodeTable t(io, keyPair, NodeIPEndpoint(addr, port, port),
-        createV4ENR(keyPair.secret(), addr, port, port));
+        IdentitySchemeV4::createENR(keyPair.secret(), addr, port, port));
     if (Node n = t.node(NodeID()))
         BOOST_REQUIRE(false);
 }

--- a/test/unittests/libp2p/net.cpp
+++ b/test/unittests/libp2p/net.cpp
@@ -1267,6 +1267,7 @@ BOOST_AUTO_TEST_CASE(changingHostEndpoint)
     auto& nodeTable = nodeTableHost.nodeTable;
 
     auto const originalHostEndpoint = nodeTable->m_hostNodeEndpoint;
+    auto const originalHostENR = nodeTable->hostENR();
     uint16_t const newPort = originalHostEndpoint.udpPort() + 1;
     auto const newHostEndpoint = NodeIPEndpoint{
         bi::address::from_string(c_localhostIp), newPort, nodeTable->m_hostNodeEndpoint.tcpPort()};
@@ -1274,6 +1275,7 @@ BOOST_AUTO_TEST_CASE(changingHostEndpoint)
     for (int i = 0; i < 10; ++i)
     {
         BOOST_CHECK_EQUAL(nodeTable->m_hostNodeEndpoint, originalHostEndpoint);
+        BOOST_CHECK(nodeTable->hostENR().signature() == originalHostENR.signature());
 
         // socket receiving PING
         TestUDPSocketHost nodeSocketHost;
@@ -1302,7 +1304,12 @@ BOOST_AUTO_TEST_CASE(changingHostEndpoint)
         nodeTable->packetsReceived.pop();
     }
 
-    BOOST_REQUIRE_EQUAL(nodeTable->m_hostNodeEndpoint, newHostEndpoint);
+    BOOST_CHECK_EQUAL(nodeTable->m_hostNodeEndpoint, newHostEndpoint);
+
+    ENR const newENR = nodeTable->hostENR();
+    BOOST_CHECK_EQUAL(newENR.ip(), newHostEndpoint.address());
+    BOOST_CHECK_EQUAL(newENR.udpPort(), newHostEndpoint.udpPort());
+    BOOST_CHECK_EQUAL(newENR.tcpPort(), newHostEndpoint.tcpPort());
 }
 
 

--- a/test/unittests/libp2p/peer.cpp
+++ b/test/unittests/libp2p/peer.cpp
@@ -238,6 +238,23 @@ BOOST_AUTO_TEST_CASE(saveENR)
     BOOST_REQUIRE(enr1.signature() == enr2.signature());
 }
 
+BOOST_AUTO_TEST_CASE(updateENRfromConfig)
+{
+    NetworkConfig config("", "", 30303, false);
+    Host host1("Test", config);
+    ENR enr1 = host1.enr();
+
+    bytes store(host1.saveNetwork());
+
+    NetworkConfig config2("13.74.189.148", "", 30303, false);
+    Host host2("Test", config2, bytesConstRef(&store));
+    host2.start();
+    host2.stop();
+    ENR enr2 = host2.enr();
+
+    BOOST_REQUIRE_EQUAL(enr2.sequenceNumber(), enr1.sequenceNumber() + 1);
+    BOOST_REQUIRE_EQUAL(enr2.ip(), bi::address::from_string("13.74.189.148"));
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Implements part 3 of https://github.com/ethereum/aleth/issues/5551

New host ENR is generated:
- when network config given to `Host` contains new public address / listen port
- when `EndpointTracker` in `NodeTable` detects new public UDP endpoint