### PR TITLE
Log block queue status in BlockChainSync

### DIFF
--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -75,7 +75,8 @@ private:
     void continueSync();
 
     /// Enter waiting state
-    void pauseSync();
+    void pauseSync() { m_state = SyncState::Waiting; }
+    bool isSyncPaused() { return m_state == SyncState::Waiting; }
 
     EthereumCapability& host() { return m_host; }
     EthereumCapability const& host() const { return m_host; }

--- a/libethereum/BlockQueue.cpp
+++ b/libethereum/BlockQueue.cpp
@@ -32,10 +32,10 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-size_t const c_maxKnownCount = 100000;
-size_t const c_maxKnownSize = 128 * 1024 * 1024;
-size_t const c_maxUnknownCount = 100000;
-size_t const c_maxUnknownSize = 512 * 1024 * 1024; // Block size can be ~50kb
+constexpr size_t c_maxKnownCount = 100000;
+constexpr size_t c_maxKnownSize = 128 * 1024 * 1024;
+constexpr size_t c_maxUnknownCount = 100000;
+constexpr size_t c_maxUnknownSize = 512 * 1024 * 1024;  // Block size can be ~50kb
 
 BlockQueue::BlockQueue()
 {
@@ -514,7 +514,8 @@ void BlockQueue::retryAllUnknown()
     m_moreToVerify.notify_all();
 }
 
-std::ostream& dev::eth::operator<<(std::ostream& _out, BlockQueueStatus const& _bqs)
+boost::log::formatting_ostream& dev::eth::operator<<(
+    boost::log::formatting_ostream& _out, BlockQueueStatus const& _bqs)
 {
     _out << "importing: " << _bqs.importing << endl;
     _out << "verified: " << _bqs.verified << endl;

--- a/libethereum/BlockQueue.h
+++ b/libethereum/BlockQueue.h
@@ -328,7 +328,7 @@ private:
     Logger m_loggerDetail{createLogger(VerbosityTrace, "bq")};
 };
 
-std::ostream& operator<<(std::ostream& _out, BlockQueueStatus const& _s);
-
+boost::log::formatting_ostream& operator<<(
+    boost::log::formatting_ostream& _out, BlockQueueStatus const& _s);
 }
 }


### PR DESCRIPTION
Log the block queue status when BlockChainSync cannot sync with a peer due to syncing being paused and when it cannot request blocks due to the block queue being full.

Also convert some BlockQueue constants to constexpr and wrap checking for a paused sync in a helper function (BlockChainSync::isSyncPaused) in the interest of consistency since pausing a sync is done via a helper function (BlockChainSync::pauseSync).