### PR TITLE
Minor fix in RLP

### DIFF
--- a/libdevcore/RLP.h
+++ b/libdevcore/RLP.h
@@ -240,7 +240,7 @@ public:
     template <class T, size_t N>
     std::array<T, N> toArray(int _flags = LaissezFaire) const
     {
-        if (itemCountStrict() != N)
+        if (itemCount() != N)
         {
             if (_flags & ThrowOnFail)
                 BOOST_THROW_EXCEPTION(BadCast());

--- a/test/unittests/libdevcore/RLP.cpp
+++ b/test/unittests/libdevcore/RLP.cpp
@@ -64,3 +64,26 @@ TEST(RLP, bignumSerialization)
 
     EXPECT_EQ(bignum, bignumPost) << "The post-processed bignum does not match the original.";
 }
+
+TEST(RLP, toArray)
+{
+    auto const data = rlpList(1, 2, 3);
+    RLP rlp{data};
+
+    array<uint8_t, 3> const expected = {{1, 2, 3}};
+    EXPECT_EQ((rlp.toArray<uint8_t, 3>()), expected);
+}
+
+TEST(RLP, toArrayFail)
+{
+    // non-list RLP data
+    auto const data = rlp(0);
+    RLP rlp{data};
+
+    // toArray doesn't throw by default
+    array<uint8_t, 3> const expected = {};
+    EXPECT_EQ((rlp.toArray<uint8_t, 3>()), expected);
+
+    // toArray throws in strict mode
+    EXPECT_THROW((rlp.toArray<uint8_t, 3>(RLP::VeryStrict)), BadCast);
+}


### PR DESCRIPTION
`RLP::toArray()` should throw exception only when `ThrowOnFail` flag is passed, but currently it throws always from `itemCountStrict()` when called for non-list RLP.