### PR TITLE
Check for existing RLPX handshake when connecting to a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Changed: [#5589](https://github.com/ethereum/aleth/pull/5589) Make aleth output always line-buffered even when redirected to file or pipe.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
+- Fixed: [#5599](https://github.com/ethereum/aleth/pull/5600) Prevent aleth from attempting concurrent connection to node which results in disconnect of original connection.
 
 ## [1.6.0] - 2019-04-16
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -421,7 +421,7 @@ void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
     }
 }
 
-bool Host::isConnecting(NodeID const& _id)
+bool Host::isHandshaking(NodeID const& _id) const
 {
     Guard l(x_connecting);
     for (auto const& cIter : m_connecting)
@@ -657,9 +657,9 @@ void Host::connect(shared_ptr<Peer> const& _p)
         return;
     }
 
-    if (isConnecting(_p->id))
+    if (isHandshaking(_p->id))
     {
-        cwarn << "Aborted connection. Connection to peer already in progress: " << _p->id << "@"
+        cwarn << "Aborted connection. RLPX handshake to peer already in progress: " << _p->id << "@"
               << _p->endpoint;
         return;
     }

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -421,6 +421,18 @@ void Host::onNodeTableEvent(NodeID const& _n, NodeTableEventType const& _e)
     }
 }
 
+bool Host::isConnecting(NodeID const& _id)
+{
+    Guard l(x_connecting);
+    for (auto const& cIter : m_connecting)
+    {
+        std::shared_ptr<RLPXHandshake> const connecting = cIter.lock();
+        if (connecting && connecting->remote() == _id)
+            return true;
+    }
+    return false;
+}
+
 void Host::determinePublic()
 {
     // set m_tcpPublic := listenIP (if public) > public > upnp > unspecified address.
@@ -638,15 +650,24 @@ void Host::connect(shared_ptr<Peer> const& _p)
         cwarn << "Network not running so cannot connect to peer " << _p->id << "@" << _p->address();
         return;
     }
+
     if (!haveCapabilities())
     {
         cwarn << "No capabilities registered so cannot connect to peer " << _p->id << "@" << _p->address();
         return;
     }
-    
+
+    if (isConnecting(_p->id))
+    {
+        cwarn << "Aborted connection. Connection to peer already in progress: " << _p->id << "@"
+              << _p->endpoint;
+        return;
+    }
+
     if (havePeerSession(_p->id))
     {
-        cnetdetails << "Aborted connect. Node already connected.";
+        cnetdetails << "Aborted connection. Peer already connected: " << _p->id << "@"
+                    << _p->endpoint;
         return;
     }
 

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -260,7 +260,7 @@ private:
     
     bool havePeerSession(NodeID const& _id) { return !!peerSession(_id); }
 
-    bool isConnecting(NodeID const& _id);
+    bool isHandshaking(NodeID const& _id) const;
 
     /// Determines and sets m_tcpPublic to publicly advertised address.
     void determinePublic();
@@ -363,7 +363,7 @@ private:
     /// Pending connections. Completed handshakes are garbage-collected in run() (a handshake is
     /// complete when there are no more shared_ptrs in handlers)
     std::list<std::weak_ptr<RLPXHandshake>> m_connecting;
-    Mutex x_connecting;													///< Mutex for m_connecting.
+    mutable Mutex x_connecting;													///< Mutex for m_connecting.
 
     unsigned m_idealPeerCount = 11;										///< Ideal number of peers to be connected to.
     unsigned m_stretchPeers = 7;										///< Accepted connection multiplier (max peers = ideal*stretch).

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -260,6 +260,8 @@ private:
     
     bool havePeerSession(NodeID const& _id) { return !!peerSession(_id); }
 
+    bool isConnecting(NodeID const& _id);
+
     /// Determines and sets m_tcpPublic to publicly advertised address.
     void determinePublic();
 
@@ -358,7 +360,9 @@ private:
     mutable std::unordered_map<NodeID, std::weak_ptr<SessionFace>> m_sessions;
     mutable RecursiveMutex x_sessions;
 
-    std::list<std::weak_ptr<RLPXHandshake>> m_connecting;               ///< Pending connections.
+    /// Pending connections. Completed handshakes are garbage-collected in run() (a handshake is
+    /// complete when there are no more shared_ptrs in handlers)
+    std::list<std::weak_ptr<RLPXHandshake>> m_connecting;
     Mutex x_connecting;													///< Mutex for m_connecting.
 
     unsigned m_idealPeerCount = 11;										///< Ideal number of peers to be connected to.

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -46,6 +46,8 @@ public:
     /// Aborts the handshake.
     void cancel();
 
+    NodeID remote() const { return m_remote; }
+
 protected:
     /// Timeout for a stage in the handshake to complete (the remote to respond to transition
     /// events). Enforced by m_idleTimer and refreshed by transition().


### PR DESCRIPTION
Fix #5600 

Check for existing RLPX handshake in `Host::connect` before attempting a new connection to a node - this is required because `Host::connect` only checks `m_pendingPeerConns` before starting a new connection, and entries are removed from `m_pendingPeerConns` after a new RLPX handshake has started rather than after the handshake has completed.

I've chosen to check for an existing RLPX handshake rather than garbage-collecting `m_pendingPeerConns` in `Host::run` since the former only adds cost during a new connection while the latter would add cost on every `Host::run` invocation.