### PR TITLE
Dynamic predicting of external IP and UDP port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.
 - Changed: [#5576](https://github.com/ethereum/aleth/pull/5576) Moved sstore_combinations and static_Call50000_sha256 tests to stTimeConsuming test suite. (testeth runs them only with `--all` flag)
 - Changed: [#5589](https://github.com/ethereum/aleth/pull/5589) Make aleth output always line-buffered even when redirected to file or pipe.
+- Changed: [#5602](https://github.com/ethereum/aleth/pull/5602) Better predicting external IP address and UDP port.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
 

--- a/libp2p/EndpointTracker.cpp
+++ b/libp2p/EndpointTracker.cpp
@@ -1,0 +1,76 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#include "EndpointTracker.h"
+
+namespace dev
+{
+namespace p2p
+{
+namespace
+{
+// Interval during which each endpoint statement is kept
+constexpr std::chrono::minutes c_statementTimeToLiveMin{5};
+}  // namespace
+
+// Register the statement about endpoint from one othe peers.
+// Returns number of currently kept statements in favor of _externalEndpoint
+size_t EndpointTracker::addEndpointStatement(
+    bi::udp::endpoint const& _sourceEndpoint, bi::udp::endpoint const& _externalEndpoint)
+{
+    // remove previous statement by this peer
+    auto it = m_statementsMap.find(_sourceEndpoint);
+    if (it != m_statementsMap.end())
+        removeStatement(it);
+
+    return addStatement(_sourceEndpoint, _externalEndpoint);
+}
+
+// Find endpoint with max number of statemens
+bi::udp::endpoint EndpointTracker::bestEndpoint() const
+{
+    size_t maxCount = 0;
+    bi::udp::endpoint bestEndpoint;
+    for (auto const& endpointAndCount : m_endpointStatementCountMap)
+        if (endpointAndCount.second > maxCount)
+            std::tie(bestEndpoint, maxCount) = endpointAndCount;
+
+    return bestEndpoint;
+}
+
+// Remove old statements
+void EndpointTracker::garbageCollectStatements()
+{
+    auto const expiration = std::chrono::steady_clock::now() - c_statementTimeToLiveMin;
+    for (auto it = m_statementsMap.begin(); it != m_statementsMap.end();)
+    {
+        if (it->second.second > expiration)
+            it = removeStatement(it);
+        else
+            ++it;
+    }
+}
+
+size_t EndpointTracker::addStatement(
+    bi::udp::endpoint const& _sourceEndpoint, bi::udp::endpoint const& _externalEndpoint)
+{
+    EndpointAndTimePoint endpointAndTime{_externalEndpoint, std::chrono::steady_clock::now()};
+    m_statementsMap.insert({_sourceEndpoint, endpointAndTime});
+    return ++m_endpointStatementCountMap[_externalEndpoint];
+}
+
+EndpointTracker::SourceToStatementMap::iterator EndpointTracker::removeStatement(
+    SourceToStatementMap::iterator _it)
+{
+    // first decrement statement counter
+    auto itCount = m_endpointStatementCountMap.find(_it->second.first);
+    assert(itCount != m_endpointStatementCountMap.end() && itCount->second > 0);
+    if (--itCount->second == 0)
+        m_endpointStatementCountMap.erase(itCount);
+
+    return m_statementsMap.erase(_it);
+}
+
+}  // namespace p2p
+}  // namespace dev

--- a/libp2p/EndpointTracker.cpp
+++ b/libp2p/EndpointTracker.cpp
@@ -8,11 +8,6 @@ namespace dev
 {
 namespace p2p
 {
-namespace
-{
-// Interval during which each endpoint statement is kept
-constexpr std::chrono::minutes c_statementTimeToLiveMin{5};
-}  // namespace
 
 // Register the statement about endpoint from one othe peers.
 // Returns number of currently kept statements in favor of _externalEndpoint
@@ -40,12 +35,12 @@ bi::udp::endpoint EndpointTracker::bestEndpoint() const
 }
 
 // Remove old statements
-void EndpointTracker::garbageCollectStatements()
+void EndpointTracker::garbageCollectStatements(std::chrono::seconds const& _timeToLive)
 {
-    auto const expiration = std::chrono::steady_clock::now() - c_statementTimeToLiveMin;
+    auto const expiration = std::chrono::steady_clock::now() - _timeToLive;
     for (auto it = m_statementsMap.begin(); it != m_statementsMap.end();)
     {
-        if (it->second.second > expiration)
+        if (it->second.second < expiration)
             it = removeStatement(it);
         else
             ++it;

--- a/libp2p/EndpointTracker.cpp
+++ b/libp2p/EndpointTracker.cpp
@@ -24,13 +24,18 @@ size_t EndpointTracker::addEndpointStatement(
 /// Find endpoint with max number of statemens
 bi::udp::endpoint EndpointTracker::bestEndpoint() const
 {
-    size_t maxCount = 0;
-    bi::udp::endpoint bestEndpoint;
-    for (auto const& endpointAndCount : m_endpointStatementCountMap)
-        if (endpointAndCount.second > maxCount)
-            std::tie(bestEndpoint, maxCount) = endpointAndCount;
+    if (m_endpointStatementCountMap.empty())
+        return {};
 
-    return bestEndpoint;
+    // find endpoint with max count
+    auto itMax =
+        std::max_element(m_endpointStatementCountMap.begin(), m_endpointStatementCountMap.end(),
+            [](std::pair<bi::udp::endpoint const, size_t> const& _endpointAndCount1,
+                std::pair<bi::udp::endpoint const, size_t> const& _endpointAndCount2) {
+                return _endpointAndCount1.second < _endpointAndCount2.second;
+            });
+
+    return itMax->first;
 }
 
 /// Remove old statements

--- a/libp2p/EndpointTracker.cpp
+++ b/libp2p/EndpointTracker.cpp
@@ -8,9 +8,8 @@ namespace dev
 {
 namespace p2p
 {
-
-// Register the statement about endpoint from one othe peers.
-// Returns number of currently kept statements in favor of _externalEndpoint
+/// Register the statement about endpoint from one othe peers.
+/// @returns number of currently kept statements in favor of @a _externalEndpoint
 size_t EndpointTracker::addEndpointStatement(
     bi::udp::endpoint const& _sourceEndpoint, bi::udp::endpoint const& _externalEndpoint)
 {
@@ -22,7 +21,7 @@ size_t EndpointTracker::addEndpointStatement(
     return addStatement(_sourceEndpoint, _externalEndpoint);
 }
 
-// Find endpoint with max number of statemens
+/// Find endpoint with max number of statemens
 bi::udp::endpoint EndpointTracker::bestEndpoint() const
 {
     size_t maxCount = 0;
@@ -34,7 +33,7 @@ bi::udp::endpoint EndpointTracker::bestEndpoint() const
     return bestEndpoint;
 }
 
-// Remove old statements
+/// Remove old statements
 void EndpointTracker::garbageCollectStatements(std::chrono::seconds const& _timeToLive)
 {
     auto const expiration = std::chrono::steady_clock::now() - _timeToLive;

--- a/libp2p/EndpointTracker.h
+++ b/libp2p/EndpointTracker.h
@@ -21,7 +21,7 @@ public:
     size_t addEndpointStatement(
         bi::udp::endpoint const& _sourceEndpoint, bi::udp::endpoint const& _externalEndpoint);
 
-    // Find endpoint with max number of statemens
+    // Find endpoint with max number of statements
     bi::udp::endpoint bestEndpoint() const;
 
     // Remove old statements

--- a/libp2p/EndpointTracker.h
+++ b/libp2p/EndpointTracker.h
@@ -10,21 +10,21 @@ namespace dev
 {
 namespace p2p
 {
-// Class for keeping track of our external endpoint as seen by our peers.
-// Keeps track of what external endpoint is seen by every peer
-// and finds which endpoint is reported most often
+/// Class for keeping track of our external endpoint as seen by our peers.
+/// Keeps track of what external endpoint is seen by every peer
+/// and finds which endpoint is reported most often
 class EndpointTracker
 {
 public:
-    // Register the statement about endpoint from one of the peers.
-    // Returns number of currently kept statements in favor of _externalEndpoint
+    /// Register the statement about endpoint from one of the peers.
+    /// @returns number of currently kept statements in favor of @a _externalEndpoint
     size_t addEndpointStatement(
         bi::udp::endpoint const& _sourceEndpoint, bi::udp::endpoint const& _externalEndpoint);
 
-    // Find endpoint with max number of statements
+    /// Find endpoint with max number of statements
     bi::udp::endpoint bestEndpoint() const;
 
-    // Remove statements older than _timeToLive
+    /// Remove statements older than _timeToLive
     void garbageCollectStatements(std::chrono::seconds const& _timeToLive);
 
 private:
@@ -37,9 +37,9 @@ private:
 
     SourceToStatementMap::iterator removeStatement(SourceToStatementMap::iterator _it);
 
-    // Statements about our external endpoint, maps statement source peer => endpoint, timestamp
+    /// Statements about our external endpoint, maps statement source peer => endpoint, timestamp
     SourceToStatementMap m_statementsMap;
-    // map external endpoint => how many sources reported it
+    /// map external endpoint => how many sources reported it
     std::map<bi::udp::endpoint, size_t> m_endpointStatementCountMap;
 };
 

--- a/libp2p/EndpointTracker.h
+++ b/libp2p/EndpointTracker.h
@@ -24,8 +24,8 @@ public:
     // Find endpoint with max number of statements
     bi::udp::endpoint bestEndpoint() const;
 
-    // Remove old statements
-    void garbageCollectStatements();
+    // Remove statements older than _timeToLive
+    void garbageCollectStatements(std::chrono::seconds const& _timeToLive);
 
 private:
     using EndpointAndTimePoint =

--- a/libp2p/EndpointTracker.h
+++ b/libp2p/EndpointTracker.h
@@ -1,0 +1,47 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#pragma once
+
+#include "Common.h"
+
+namespace dev
+{
+namespace p2p
+{
+// Class for keeping track of our external endpoint as seen by our peers.
+// Keeps track of what external endpoint is seen by every peer
+// and finds which endpoint is reported most often
+class EndpointTracker
+{
+public:
+    // Register the statement about endpoint from one of the peers.
+    // Returns number of currently kept statements in favor of _externalEndpoint
+    size_t addEndpointStatement(
+        bi::udp::endpoint const& _sourceEndpoint, bi::udp::endpoint const& _externalEndpoint);
+
+    // Find endpoint with max number of statemens
+    bi::udp::endpoint bestEndpoint() const;
+
+    // Remove old statements
+    void garbageCollectStatements();
+
+private:
+    using EndpointAndTimePoint =
+        std::pair<bi::udp::endpoint, std::chrono::steady_clock::time_point>;
+    using SourceToStatementMap = std::map<bi::udp::endpoint, EndpointAndTimePoint>;
+
+    size_t addStatement(
+        bi::udp::endpoint const& _sourceEndpoint, bi::udp::endpoint const& _externalEndpoint);
+
+    SourceToStatementMap::iterator removeStatement(SourceToStatementMap::iterator _it);
+
+    // Statements about our external endpoint, maps statement source peer => endpoint, timestamp
+    SourceToStatementMap m_statementsMap;
+    // map external endpoint => how many sources reported it
+    std::map<bi::udp::endpoint, size_t> m_endpointStatementCountMap;
+};
+
+}  // namespace p2p
+}  // namespace dev

--- a/libp2p/NodeTable.cpp
+++ b/libp2p/NodeTable.cpp
@@ -22,6 +22,8 @@ constexpr chrono::milliseconds c_handleTimeoutsIntervalMs{5000};
 constexpr chrono::milliseconds c_removeOldEndpointStatementsIntervalMs{5000};
 // Change external endpoint after this number of peers report new one
 constexpr size_t c_minEndpointTrackStatements{10};
+// Interval during which each endpoint statement is kept
+constexpr std::chrono::minutes c_endpointStatementTimeToLiveMin{5};
 
 }  // namespace
 
@@ -800,7 +802,7 @@ void NodeTable::doHandleTimeouts()
 void NodeTable::doEndpointTracking()
 {
     runBackgroundTask(c_removeOldEndpointStatementsIntervalMs, m_endpointTrackingTimer,
-        [this]() { m_endpointTracker.garbageCollectStatements(); });
+        [this]() { m_endpointTracker.garbageCollectStatements(c_endpointStatementTimeToLiveMin); });
 }
 
 void NodeTable::runBackgroundTask(std::chrono::milliseconds const& _period,

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -133,17 +133,6 @@ public:
         }
     }
 
-    void cancelTimer(std::shared_ptr<ba::steady_timer> _timer)
-    {
-        // We "cancel" the timers by setting c_steadyClockMin rather than calling cancel()
-        // because cancel won't set the boost error code if the timers have already expired and
-        // the handlers are in the ready queue.
-        //
-        // Note that we "cancel" via io_service::post to ensure thread safety when accessing the
-        // timers
-        m_io.post([_timer] { _timer->expires_at(c_steadyClockMin); });
-    }
-
     /// Set event handler for NodeEntryAdded and NodeEntryDropped events.
     void setEventHandler(NodeTableEventHandler* _handler) { m_nodeEventHandler.reset(_handler); }
 
@@ -187,7 +176,13 @@ public:
     /// Returns the Node to the corresponding node id or the empty Node if that id is not found.
     Node node(NodeID const& _id);
 
-// protected only for derived classes in tests
+
+    void runBackgroundTask(std::chrono::milliseconds const& _period,
+        std::shared_ptr<ba::steady_timer> _timer, std::function<void()> _f);
+
+    void cancelTimer(std::shared_ptr<ba::steady_timer> _timer);
+
+    // protected only for derived classes in tests
 protected:
     /**
      * NodeValidation is used to record information about the nodes that we have sent Ping to.

--- a/libp2p/NodeTable.h
+++ b/libp2p/NodeTable.h
@@ -1,16 +1,15 @@
 // Aleth: Ethereum C++ client, tools and libraries.
-// Copyright 2018 Aleth Authors.
+// Copyright 2019 Aleth Authors.
 // Licensed under the GNU General Public License, Version 3.
 
 #pragma once
 
-#include <algorithm>
-
-#include <boost/integer/static_log2.hpp>
-
 #include "Common.h"
 #include "ENR.h"
+#include "EndpointTracker.h"
 #include <libp2p/UDP.h>
+#include <boost/integer/static_log2.hpp>
+#include <algorithm>
 
 namespace dev
 {
@@ -127,18 +126,22 @@ public:
     {
         if (m_socket->isOpen())
         {
-            // We "cancel" the timers by setting c_steadyClockMin rather than calling cancel()
-            // because cancel won't set the boost error code if the timers have already expired and
-            // the handlers are in the ready queue.
-            //
-            // Note that we "cancel" via io_service::post to ensure thread safety when accessing the
-            // timers
-            auto discoveryTimer{m_discoveryTimer};
-            m_io.post([discoveryTimer] { discoveryTimer->expires_at(c_steadyClockMin); });
-            auto timeoutsTimer{m_timeoutsTimer};
-            m_io.post([timeoutsTimer] { timeoutsTimer->expires_at(c_steadyClockMin); });
+            cancelTimer(m_discoveryTimer);
+            cancelTimer(m_timeoutsTimer);
+            cancelTimer(m_endpointTrackingTimer);
             m_socket->disconnect();
         }
+    }
+
+    void cancelTimer(std::shared_ptr<ba::steady_timer> _timer)
+    {
+        // We "cancel" the timers by setting c_steadyClockMin rather than calling cancel()
+        // because cancel won't set the boost error code if the timers have already expired and
+        // the handlers are in the ready queue.
+        //
+        // Note that we "cancel" via io_service::post to ensure thread safety when accessing the
+        // timers
+        m_io.post([_timer] { _timer->expires_at(c_steadyClockMin); });
     }
 
     /// Set event handler for NodeEntryAdded and NodeEntryDropped events.
@@ -312,6 +315,9 @@ protected:
     /// bring in their replacements
     void doHandleTimeouts();
 
+    // Remove old records in m_endpointTracker.
+    void doEndpointTracking();
+
     // Useful only for tests.
     void setRequestTimeToLive(std::chrono::seconds const& _time) { m_requestTimeToLive = _time; }
     uint32_t nextRequestExpirationTime() const
@@ -329,6 +335,9 @@ protected:
 
     NodeID const m_hostNodeID;
     h256 const m_hostNodeIDHash;
+    // Host IP address given to constructor
+    bi::address const m_hostStaticIP;
+    // Dynamically updated host endpoint
     NodeIPEndpoint m_hostNodeEndpoint;
     ENR const m_hostENR;
     Secret m_secret;												///< This nodes secret key.
@@ -358,8 +367,11 @@ protected:
 
     bool m_allowLocalDiscovery;                                     ///< Allow nodes with local addresses to be included in the discovery process
 
+    EndpointTracker m_endpointTracker;
+
     std::shared_ptr<ba::steady_timer> m_discoveryTimer;
     std::shared_ptr<ba::steady_timer> m_timeoutsTimer;
+    std::shared_ptr<ba::steady_timer> m_endpointTrackingTimer;
 
     ba::io_service& m_io;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(unittest_sources
 
     unittests/libp2p/capability.cpp
     unittests/libp2p/eip-8.cpp
+    unittests/libp2p/EndpointTrackerTest.cpp
     unittests/libp2p/ENRTest.cpp
     unittests/libp2p/rlpx.cpp
 

--- a/test/unittests/libp2p/EndpointTrackerTest.cpp
+++ b/test/unittests/libp2p/EndpointTrackerTest.cpp
@@ -1,0 +1,89 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#include <libp2p/EndpointTracker.h>
+#include <gtest/gtest.h>
+#include <thread>
+
+using namespace dev;
+using namespace dev::p2p;
+
+namespace
+{
+    bi::udp::endpoint createEndpoint(std::string const& _address, uint16_t _port)
+    {
+        return bi::udp::endpoint{bi::address::from_string(_address), _port};
+    }
+}
+
+
+TEST(endpointTracker, findBestEndpoint)
+{
+    EndpointTracker tracker;
+
+    auto const endpoint1 = createEndpoint("204.25.170.185", 30303);
+    auto const endpoint2 = createEndpoint("53.124.81.255", 30305);
+
+    auto const sourceEndpoint1 = createEndpoint("13.74.189.147", 30303);
+    auto const sourceEndpoint2 = createEndpoint("13.74.189.148", 30303);
+    auto const sourceEndpoint3 = createEndpoint("13.74.189.149", 30303);
+
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint1, endpoint1), 1);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint2, endpoint1), 2);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint3, endpoint2), 1);
+
+    EXPECT_EQ(tracker.bestEndpoint(), endpoint1);
+}
+
+TEST(endpointTracker, sourceSendsDifferentEndpoints)
+{
+    EndpointTracker tracker;
+
+    auto const endpoint1 = createEndpoint("204.25.170.185", 30303);
+    auto const endpoint2 = createEndpoint("53.124.81.255", 30305);
+    auto const endpoint3 = createEndpoint("111.175.56.85", 30306);
+    auto const endpoint4 = createEndpoint("215.185.124.47", 30303);
+
+    auto const sourceEndpoint1 = createEndpoint("13.74.189.147", 30303);
+    auto const sourceEndpoint2 = createEndpoint("13.74.189.148", 30303);
+    auto const sourceEndpoint3 = createEndpoint("13.74.189.149", 30303);
+    auto const sourceEndpoint4 = createEndpoint("13.74.189.150", 30303);
+
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint1, endpoint1), 1);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint1, endpoint2), 1);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint1, endpoint3), 1);
+
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint2, endpoint1), 1);
+
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint3, endpoint4), 1);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint4, endpoint4), 2);
+
+    EXPECT_EQ(tracker.bestEndpoint(), endpoint4);
+}
+
+TEST(endpointTracker, garbageCollection)
+{
+    EndpointTracker tracker;
+
+    auto const endpoint1 = createEndpoint("204.25.170.185", 30303);
+    auto const endpoint2 = createEndpoint("53.124.81.255", 30305);
+
+    auto const sourceEndpoint1 = createEndpoint("13.74.189.147", 30303);
+    auto const sourceEndpoint2 = createEndpoint("13.74.189.148", 30303);
+    auto const sourceEndpoint3 = createEndpoint("13.74.189.149", 30303);
+    auto const sourceEndpoint4 = createEndpoint("13.74.189.150", 30303);
+    auto const sourceEndpoint5 = createEndpoint("13.74.189.151", 30303);
+
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint1, endpoint1), 1);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint2, endpoint1), 2);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint3, endpoint1), 3);
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    tracker.garbageCollectStatements(std::chrono::seconds(1));
+
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint4, endpoint2), 1);
+    EXPECT_EQ(tracker.addEndpointStatement(sourceEndpoint5, endpoint2), 2);
+
+    EXPECT_EQ(tracker.bestEndpoint(), endpoint2);
+}


### PR DESCRIPTION
This improves how we track what our peers see as our external IP address / UDP port.

Previously we updated external port every time we receive new port number in Pong packet, now we count which port is reported by most of the peers and update it when new value is reported from more than 10 peers.

Also external IP address is similarly updated from Pong packet, but only unless it was given as a command line argument (or detected by UPNP).

Here's go-ethereum code doing quite the same:
https://github.com/ethereum/go-ethereum/blob/HEAD@%7B2019-05-15T10:20:04Z%7D/p2p/netutil/iptrack.go
https://github.com/ethereum/go-ethereum/blob/97d3615612a49488d02807944696d001b88f9e0d/p2p/enode/localnode.go#L180-L202