### PR TITLE
Various network-related logging changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Changed: [#5576](https://github.com/ethereum/aleth/pull/5576) Moved sstore_combinations and static_Call50000_sha256 tests to stTimeConsuming test suite. (testeth runs them only with `--all` flag)
 - Changed: [#5589](https://github.com/ethereum/aleth/pull/5589) Make aleth output always line-buffered even when redirected to file or pipe.
 - Changed: [#5602](https://github.com/ethereum/aleth/pull/5602) Better predicting external IP address and UDP port.
+- Changed: [#5605](https://github.com/ethereum/aleth/pull/5605) Network logging bugfixes and improvements and add warpcap log channel.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
 - Fixed: [#5599](https://github.com/ethereum/aleth/pull/5600) Prevent aleth from attempting concurrent connection to node which results in disconnect of original connection.

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -323,7 +323,7 @@ int main(int argc, char** argv)
 
     std::string const logChannels =
         "block blockhdr bq chain client debug discov error ethcap exec host impolite info net "
-        "overlaydb p2pcap peer rlpx rpc snap statedb sync timer tq trace vmtrace warn watch";
+        "overlaydb p2pcap peer rlpx rpc snap statedb sync timer tq trace vmtrace warn warpcap watch";
     LoggingOptions loggingOptions;
     po::options_description loggingProgramOptions(
         createLoggingProgramOptions(c_lineWidth, loggingOptions, logChannels));

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -48,7 +48,8 @@ using log_sink = boost::log::sinks::synchronous_sink<T>;
 namespace dev
 {
 BOOST_LOG_ATTRIBUTE_KEYWORD(channel, "Channel", std::string)
-BOOST_LOG_ATTRIBUTE_KEYWORD(context, "Context", std::string)
+BOOST_LOG_ATTRIBUTE_KEYWORD(prefix, "Prefix", std::string)
+BOOST_LOG_ATTRIBUTE_KEYWORD(suffix, "Suffix", std::string)
 BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", int)
 BOOST_LOG_ATTRIBUTE_KEYWORD(threadName, "ThreadName", std::string)
 BOOST_LOG_ATTRIBUTE_KEYWORD(timestamp, "TimeStamp", boost::posix_time::ptime)
@@ -96,10 +97,13 @@ void formatter(boost::log::record_view const& _rec, boost::log::formatting_ostre
 
     _strm << EthNavy << std::setw(4) << std::left << _rec[threadName] << EthReset " ";
     _strm << std::setw(6) << std::left << _rec[channel] << " ";
-    if (boost::log::expressions::has_attr(context)(_rec))
-        _strm << EthNavy << _rec[context] << EthReset " ";
+    if (boost::log::expressions::has_attr(prefix)(_rec))
+        _strm << EthNavy << _rec[prefix] << EthReset " ";
 
     _strm << _rec[boost::log::expressions::smessage];
+
+    if (boost::log::expressions::has_attr(suffix)(_rec))
+        _strm << " " EthNavy << _rec[suffix] << EthReset;
 }
 
 }  // namespace

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -1,23 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-/** @file Log.cpp
- * @author Gav Wood <i@gavwood.com>
- * @date 2014
- */
+/// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #include "Log.h"
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -128,11 +128,6 @@ inline Logger createLogger(int _severity, std::string const& _channel)
         boost::log::keywords::severity = _severity, boost::log::keywords::channel = _channel);
 }
 
-// Adds the context string to all log messages in the scope
-#define LOG_SCOPED_CONTEXT(context) \
-    BOOST_LOG_SCOPED_THREAD_ATTR("Prefix", boost::log::attributes::constant<std::string>(context));
-
-
 // Below overloads for both const and non-const references are needed, because without overload for
 // non-const reference generic operator<<(formatting_ostream& _strm, T& _value) will be preferred by
 // overload resolution.

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -1,19 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
+/// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 
 #pragma once
 

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -130,7 +130,7 @@ inline Logger createLogger(int _severity, std::string const& _channel)
 
 // Adds the context string to all log messages in the scope
 #define LOG_SCOPED_CONTEXT(context) \
-    BOOST_LOG_SCOPED_THREAD_ATTR("Context", boost::log::attributes::constant<std::string>(context));
+    BOOST_LOG_SCOPED_THREAD_ATTR("Prefix", boost::log::attributes::constant<std::string>(context));
 
 
 // Below overloads for both const and non-const references are needed, because without overload for

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -380,10 +380,7 @@ void BlockChainSync::requestBlocks(NodeID const& _peerID)
             }
         }
         else
-        {
-            LOG(m_loggerDetail) << "Requesting block headers from " << _peerID;
             m_host.peer(_peerID).requestBlockHeaders(start, 1 /* count */, 0 /* skip */, false);
-        }
     }
 }
 

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -196,7 +196,7 @@ void BlockChainSync::onPeerStatus(EthereumPeer const& _peer)
 
     if (!disconnectReason.empty())
     {
-        LOG(m_logger) << "Peer (" << _peer.id() << ") not suitable for sync: " << disconnectReason;
+        LOG(m_logger) << "Peer " << _peer.id() << " not suitable for sync: " << disconnectReason;
         m_host.capabilityHost().disconnect(_peer.id(), p2p::UserReason);
         return;
     }
@@ -256,7 +256,7 @@ void BlockChainSync::syncPeer(NodeID const& _peerID, bool _force)
     {
         if (peerTotalDifficulty > syncingDifficulty)
             LOG(m_logger) << "Discovered new highest difficulty (" << peerTotalDifficulty
-                          << ") from peer (" << peer.id() << ")";
+                          << ") from peer " << peer.id();
 
         // start sync
         m_syncingTotalDifficulty = peerTotalDifficulty;
@@ -610,7 +610,7 @@ void BlockChainSync::onPeerBlockBodies(NodeID const& _peerID, RLP const& _r)
     }
     if (itemCount == 0)
     {
-        LOG(m_loggerDetail) << "Peer (" << _peerID << ") does not have the blocks requested";
+        LOG(m_loggerDetail) << "Peer " << _peerID << " does not have the blocks requested";
         m_host.capabilityHost().updateRating(_peerID, -1);
     }
     for (unsigned i = 0; i < itemCount; i++)
@@ -826,8 +826,8 @@ void BlockChainSync::onPeerNewBlock(NodeID const& _peerID, RLP const& _r)
         if (totalDifficulty > peer.totalDifficulty())
         {
             LOG(m_loggerDetail) << "Received block (" << blockNumber
-                                << ") with no known parent. Peer (" << _peerID
-                                << ") needs syncing...";
+                                << ") with no known parent. Peer " << _peerID
+                                << " needs syncing...";
             syncPeer(_peerID, true);
         }
         break;

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -150,6 +150,7 @@ private:
     Logger m_logger{createLogger(VerbosityDebug, "sync")};
     Logger m_loggerInfo{createLogger(VerbosityInfo, "sync")};
     Logger m_loggerDetail{createLogger(VerbosityTrace, "sync")};
+    Logger m_loggerWarning{createLogger(VerbosityWarning, "sync")};
 
 private:
     static char const* const s_stateNames[static_cast<int>(SyncState::Size)];

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -704,8 +704,8 @@ bool EthereumCapability::interpretCapabilityPacket(
         case BlockHeadersPacket:
         {
             if (peer.asking() != Asking::BlockHeaders)
-                LOG(m_loggerImpolite) << "Peer (" << _peerID
-                                      << ") giving us block headers when we didn't ask for them.";
+                LOG(m_loggerImpolite) << "Peer " << _peerID
+                                      << " giving us block headers when we didn't ask for them.";
             else
             {
                 setIdle(_peerID);
@@ -737,8 +737,8 @@ bool EthereumCapability::interpretCapabilityPacket(
         case BlockBodiesPacket:
         {
             if (peer.asking() != Asking::BlockBodies)
-                LOG(m_loggerImpolite) << "Peer (" << _peerID
-                                      << ") giving us block bodies when we didn't ask for them.";
+                LOG(m_loggerImpolite)
+                    << "Peer " << _peerID << " giving us block bodies when we didn't ask for them.";
             else
             {
                 setIdle(_peerID);
@@ -816,7 +816,7 @@ bool EthereumCapability::interpretCapabilityPacket(
         {
             if (peer.asking() != Asking::NodeData)
                 LOG(m_loggerImpolite)
-                    << "Peer (" << _peerID << ") giving us node data when we didn't ask for them.";
+                    << "Peer " << _peerID << " giving us node data when we didn't ask for them.";
             else
             {
                 setIdle(_peerID);
@@ -828,7 +828,7 @@ bool EthereumCapability::interpretCapabilityPacket(
         {
             if (peer.asking() != Asking::Receipts)
                 LOG(m_loggerImpolite)
-                    << "Peer (" << _peerID << ") giving us receipts when we didn't ask for them.";
+                    << "Peer " << _peerID << " giving us receipts when we didn't ask for them.";
             else
             {
                 setIdle(_peerID);
@@ -842,12 +842,12 @@ bool EthereumCapability::interpretCapabilityPacket(
     }
     catch (Exception const&)
     {
-        LOG(m_loggerError) << "Peer (" << _peerID << ") causing an exception: "
+        LOG(m_loggerError) << "Peer " << _peerID << " causing an exception: "
                            << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        LOG(m_loggerError) << "Peer (" << _peerID << ") causing an exception: " << _e.what() << " "
+        LOG(m_loggerError) << "Peer " << _peerID << " causing an exception: " << _e.what() << " "
                            << _r;
     }
 

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -842,13 +842,13 @@ bool EthereumCapability::interpretCapabilityPacket(
     }
     catch (Exception const&)
     {
-        LOG(m_loggerError) << "Peer " << _peerID << " causing an exception: "
-                           << boost::current_exception_diagnostic_information() << " " << _r;
+        LOG(m_loggerWarn) << "Peer " << _peerID << " causing an exception: "
+                          << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        LOG(m_loggerError) << "Peer " << _peerID << " causing an exception: " << _e.what() << " "
-                           << _r;
+        LOG(m_loggerWarn) << "Peer " << _peerID << " causing an exception: " << _e.what() << " "
+                          << _r;
     }
 
     return true;

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -189,6 +189,8 @@ private:
     mutable std::mt19937_64 m_urng;  // Mersenne Twister psuedo-random number generator
 
     Logger m_logger{createLogger(VerbosityDebug, "ethcap")};
+    Logger m_loggerDetail{createLogger(VerbosityTrace, "ethcap")};
+    Logger m_loggerError{createLogger(VerbosityError, "ethcap")};
     /// Logger for messages about impolite behaivour of peers.
     Logger m_loggerImpolite{createLogger(VerbosityDebug, "impolite")};
 };

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -190,7 +190,6 @@ private:
 
     Logger m_logger{createLogger(VerbosityDebug, "ethcap")};
     Logger m_loggerDetail{createLogger(VerbosityTrace, "ethcap")};
-    Logger m_loggerError{createLogger(VerbosityError, "ethcap")};
     Logger m_loggerWarn{createLogger(VerbosityWarning, "ethcap")};
     /// Logger for messages about impolite behaivour of peers.
     Logger m_loggerImpolite{createLogger(VerbosityDebug, "impolite")};

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -191,6 +191,7 @@ private:
     Logger m_logger{createLogger(VerbosityDebug, "ethcap")};
     Logger m_loggerDetail{createLogger(VerbosityTrace, "ethcap")};
     Logger m_loggerError{createLogger(VerbosityError, "ethcap")};
+    Logger m_loggerWarn{createLogger(VerbosityWarning, "ethcap")};
     /// Logger for messages about impolite behaivour of peers.
     Logger m_loggerImpolite{createLogger(VerbosityDebug, "impolite")};
 };

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -35,7 +35,12 @@ public:
     EthereumPeer(std::shared_ptr<p2p::CapabilityHostFace> _host, NodeID const& _peerID,
         u256 const& /*_capabilityVersion*/)
       : m_host(std::move(_host)), m_id(_peerID)
-    {}
+    {
+        std::stringstream remoteInfoStream;
+        remoteInfoStream << m_id;
+        m_logger.add_attribute(
+            "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
+    }
 
     bool statusReceived() const { return m_protocolVersion != 0; }
 

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -1,20 +1,6 @@
-/*
-    This file is part of cpp-ethereum.
-
-    cpp-ethereum is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    cpp-ethereum is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2018 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
 #pragma once
 
 #include "CommonNet.h"

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -22,10 +22,7 @@ public:
         u256 const& /*_capabilityVersion*/)
       : m_host(std::move(_host)), m_id(_peerID)
     {
-        std::stringstream remoteInfoStream;
-        remoteInfoStream << m_id;
-        m_logger.add_attribute(
-            "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
+        m_logger.add_attribute("Suffix", boost::log::attributes::constant<std::string>{m_id.hex()});
     }
 
     bool statusReceived() const { return m_protocolVersion != 0; }

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -22,7 +22,8 @@ public:
         u256 const& /*_capabilityVersion*/)
       : m_host(std::move(_host)), m_id(_peerID)
     {
-        m_logger.add_attribute("Suffix", boost::log::attributes::constant<std::string>{m_id.hex()});
+        m_logger.add_attribute(
+            "Suffix", boost::log::attributes::constant<std::string>{m_id.abridged()});
     }
 
     bool statusReceived() const { return m_protocolVersion != 0; }

--- a/libethereum/WarpCapability.cpp
+++ b/libethereum/WarpCapability.cpp
@@ -123,9 +123,10 @@ public:
                 data.toBytesConstRef());
 
             LOG(m_logger) << "Saved chunk " << hash << " Chunks left: " << m_neededChunks.size()
-                          << " Requested chunks: " << m_requestedChunks.size();
+                          << " Requested chunks: " << m_requestedChunks.size()
+                          << " (peer: " << _peerID << ")";
             if (m_neededChunks.empty() && m_requestedChunks.empty())
-                LOG(m_logger) << "Snapshot download complete!";
+                LOG(m_logger) << "Snapshot download complete! (peer: " << _peerID << ")";
         }
         else
             m_neededChunks.push_back(askedHash);
@@ -288,7 +289,7 @@ private:
                 peerID = m_freePeers.value_pop();
             } while (!m_host.requestData(peerID, chunkHash));
 
-            LOG(m_logger) << "Requested chunk " << chunkHash;
+            LOG(m_logger) << "Requested chunk " << chunkHash << " from " << peerID;
 
             m_requestedChunks[peerID] = chunkHash;
             m_neededChunks.pop_front();
@@ -389,7 +390,7 @@ bool WarpCapability::interpretCapabilityPacket(NodeID const& _peerID, unsigned _
             peerStatus.m_snapshotHash = _r[5].toHash<h256>();
             peerStatus.m_snapshotNumber = _r[6].toInt<u256>();
 
-            cnetlog << "Status: "
+            cnetlog << "Status from " << _peerID << ": "
                     << " protocol version " << peerStatus.m_protocolVersion << " networkId "
                     << peerStatus.m_networkId << " genesis hash " << peerStatus.m_genesisHash
                     << " total difficulty " << peerStatus.m_totalDifficulty << " latest hash "
@@ -455,12 +456,13 @@ bool WarpCapability::interpretCapabilityPacket(NodeID const& _peerID, unsigned _
     }
     catch (Exception const&)
     {
-        cnetlog << "Warp Peer causing an Exception: "
-                << boost::current_exception_diagnostic_information() << " " << _r;
+        cnetlog << "Warp Peer " << _peerID
+                << " causing an Exception: " << boost::current_exception_diagnostic_information()
+                << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        cnetlog << "Warp Peer causing an exception: " << _e.what() << " " << _r;
+        cnetlog << "Warp Peer " << _peerID << " causing an exception: " << _e.what() << " " << _r;
     }
 
     return true;

--- a/libethereum/WarpCapability.cpp
+++ b/libethereum/WarpCapability.cpp
@@ -126,7 +126,7 @@ public:
                           << " Requested chunks: " << m_requestedChunks.size()
                           << " (peer: " << _peerID << ")";
             if (m_neededChunks.empty() && m_requestedChunks.empty())
-                LOG(m_logger) << "Snapshot download complete! (peer: " << _peerID << ")";
+                LOG(m_logger) << "Snapshot download complete from " << _peerID;
         }
         else
             m_neededChunks.push_back(askedHash);
@@ -390,12 +390,13 @@ bool WarpCapability::interpretCapabilityPacket(NodeID const& _peerID, unsigned _
             peerStatus.m_snapshotHash = _r[5].toHash<h256>();
             peerStatus.m_snapshotNumber = _r[6].toInt<u256>();
 
-            cnetlog << "Status from " << _peerID << ": "
-                    << " protocol version " << peerStatus.m_protocolVersion << " networkId "
-                    << peerStatus.m_networkId << " genesis hash " << peerStatus.m_genesisHash
-                    << " total difficulty " << peerStatus.m_totalDifficulty << " latest hash "
-                    << peerStatus.m_latestHash << " snapshot hash " << peerStatus.m_snapshotHash
-                    << " snapshot number " << peerStatus.m_snapshotNumber;
+            LOG(m_logger) << "Status (from " << _peerID << "): "
+                          << " protocol version " << peerStatus.m_protocolVersion << " networkId "
+                          << peerStatus.m_networkId << " genesis hash " << peerStatus.m_genesisHash
+                          << " total difficulty " << peerStatus.m_totalDifficulty << " latest hash "
+                          << peerStatus.m_latestHash << " snapshot hash "
+                          << peerStatus.m_snapshotHash << " snapshot number "
+                          << peerStatus.m_snapshotNumber;
             setIdle(_peerID);
             m_peerObserver->onPeerStatus(_peerID);
             break;
@@ -456,13 +457,13 @@ bool WarpCapability::interpretCapabilityPacket(NodeID const& _peerID, unsigned _
     }
     catch (Exception const&)
     {
-        cnetlog << "Warp Peer " << _peerID
-                << " causing an Exception: " << boost::current_exception_diagnostic_information()
-                << " " << _r;
+        LOG(m_loggerError) << "Warp Peer (" << _peerID << ") causing an exception: "
+                           << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        cnetlog << "Warp Peer " << _peerID << " causing an exception: " << _e.what() << " " << _r;
+        LOG(m_loggerError) << "Warp Peer (" << _peerID << ") causing an exception: " << _e.what()
+                           << " " << _r;
     }
 
     return true;

--- a/libethereum/WarpCapability.cpp
+++ b/libethereum/WarpCapability.cpp
@@ -457,12 +457,12 @@ bool WarpCapability::interpretCapabilityPacket(NodeID const& _peerID, unsigned _
     }
     catch (Exception const&)
     {
-        LOG(m_loggerError) << "Warp Peer (" << _peerID << ") causing an exception: "
+        LOG(m_loggerError) << "Warp Peer " << _peerID << " causing an exception: "
                            << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        LOG(m_loggerError) << "Warp Peer (" << _peerID << ") causing an exception: " << _e.what()
+        LOG(m_loggerError) << "Warp Peer " << _peerID << " causing an exception: " << _e.what()
                            << " " << _r;
     }
 

--- a/libethereum/WarpCapability.cpp
+++ b/libethereum/WarpCapability.cpp
@@ -123,10 +123,9 @@ public:
                 data.toBytesConstRef());
 
             LOG(m_logger) << "Saved chunk " << hash << " Chunks left: " << m_neededChunks.size()
-                          << " Requested chunks: " << m_requestedChunks.size()
                           << " (peer: " << _peerID << ")";
             if (m_neededChunks.empty() && m_requestedChunks.empty())
-                LOG(m_logger) << "Snapshot download complete from " << _peerID;
+                LOG(m_logger) << "Snapshot download complete";
         }
         else
             m_neededChunks.push_back(askedHash);
@@ -457,13 +456,13 @@ bool WarpCapability::interpretCapabilityPacket(NodeID const& _peerID, unsigned _
     }
     catch (Exception const&)
     {
-        LOG(m_loggerError) << "Warp Peer " << _peerID << " causing an exception: "
-                           << boost::current_exception_diagnostic_information() << " " << _r;
+        LOG(m_loggerWarn) << "Warp Peer " << _peerID << " causing an exception: "
+                          << boost::current_exception_diagnostic_information() << " " << _r;
     }
     catch (std::exception const& _e)
     {
-        LOG(m_loggerError) << "Warp Peer " << _peerID << " causing an exception: " << _e.what()
-                           << " " << _r;
+        LOG(m_loggerWarn) << "Warp Peer " << _peerID << " causing an exception: " << _e.what()
+                          << " " << _r;
     }
 
     return true;

--- a/libethereum/WarpCapability.h
+++ b/libethereum/WarpCapability.h
@@ -129,6 +129,9 @@ private:
     std::shared_ptr<WarpPeerObserverFace> m_peerObserver;
 
     std::unordered_map<NodeID, WarpPeerStatus> m_peers;
+
+    Logger m_logger{createLogger(VerbosityDebug, "warpcap")};
+    Logger m_loggerError{createLogger(VerbosityError, "warpcap")};
 };
 
 }  // namespace eth

--- a/libethereum/WarpCapability.h
+++ b/libethereum/WarpCapability.h
@@ -131,7 +131,7 @@ private:
     std::unordered_map<NodeID, WarpPeerStatus> m_peers;
 
     Logger m_logger{createLogger(VerbosityDebug, "warpcap")};
-    Logger m_loggerError{createLogger(VerbosityError, "warpcap")};
+    Logger m_loggerWarn{createLogger(VerbosityWarning, "warpcap")};
 };
 
 }  // namespace eth

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -891,7 +891,7 @@ void Host::logActivePeers()
     if (m_netConfig.discovery)
         LOG(m_infoLogger) << "Looking for peers...";
 
-    LOG(m_detailsLogger) << "Peers: " << peerSessionInfos();
+    LOG(m_logger) << "Peers: " << peerSessionInfos();
     m_lastPeerLogMessage = chrono::steady_clock::now();
 }
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -311,8 +311,9 @@ void Host::startPeerSession(Public const& _id, RLP const& _hello,
     for (auto cap: caps)
         capslog << "(" << cap.first << "," << dec << cap.second << ")";
 
-    cnetlog << "Starting peer session with " << clientVersion << " V[" << protocolVersion << "]"
-            << " " << _id << " " << showbase << capslog.str() << " " << dec << listenPort;
+    cnetlog << "Starting peer session with " << clientVersion << " (protocol: V" << protocolVersion
+            << ") " << _id << " " << showbase << "capabilities: " << capslog.str() << " " << dec
+            << "port: " << listenPort;
 
     // create session so disconnects are managed
     shared_ptr<SessionFace> session = make_shared<Session>(this, move(_io), _s, peer,
@@ -659,8 +660,8 @@ void Host::connect(shared_ptr<Peer> const& _p)
 
     if (isHandshaking(_p->id))
     {
-        cwarn << "Aborted connection. RLPX handshake to peer already in progress: " << _p->id << "@"
-              << _p->endpoint;
+        cwarn << "Aborted connection. RLPX handshake with peer already in progress: " << _p->id
+              << "@" << _p->endpoint;
         return;
     }
 

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -252,7 +252,7 @@ void RLPXHandshake::error(boost::system::error_code _ech)
     if (_ech)
         errorStream << " (I/O error: " << _ech.message() << ")";
     if (remoteSocketConnected())
-        errorStream << ". Disconnecting...";
+        errorStream << ". Disconnecting from";
     else
         errorStream << " (Connection reset by peer)";
 
@@ -278,7 +278,7 @@ void RLPXHandshake::transition(boost::system::error_code _ech)
     {
         if (!_ec)
         {
-            LOG(m_logger) << "Disconnecting (Handshake Timeout)";
+            LOG(m_logger) << "Disconnecting (Handshake Timeout) from";
             cancel();
         }
     });

--- a/libp2p/RLPxHandshake.cpp
+++ b/libp2p/RLPxHandshake.cpp
@@ -32,20 +32,19 @@ RLPXHandshake::RLPXHandshake(
     m_socket(_socket),
     m_idleTimer(m_socket->ref().get_io_service())
 {
-    m_logger.add_attribute(
-        "Prefix", boost::log::attributes::constant<std::string>(connectionDirectionString()));
-    m_errorLogger.add_attribute(
-        "Prefix", boost::log::attributes::constant<std::string>(connectionDirectionString()));
+    auto const prefixAttr =
+        boost::log::attributes::constant<std::string>{connectionDirectionString()};
+    m_logger.add_attribute("Prefix", prefixAttr);
+    m_errorLogger.add_attribute("Prefix", prefixAttr);
 
     stringstream remoteInfoStream;
     remoteInfoStream << "(" << _remote;
     if (remoteSocketConnected())
         remoteInfoStream << "@" << m_socket->remoteEndpoint();
     remoteInfoStream << ")";
-    m_logger.add_attribute(
-        "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
-    m_errorLogger.add_attribute(
-        "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
+    auto const suffixAttr = boost::log::attributes::constant<std::string>{remoteInfoStream.str()};
+    m_logger.add_attribute("Suffix", suffixAttr);
+    m_errorLogger.add_attribute("Suffix", suffixAttr);
 
     crypto::Nonce::get().ref().copyTo(m_nonce.ref());
 }

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -90,10 +90,10 @@ protected:
     void readAckEIP8();
     
     /// Closes connection and ends transitions.
-    void error(boost::system::error_code _ech = boost::system::error_code());
+    void error(boost::system::error_code _ech = {});
 
     /// Performs transition for m_nextState.
-    virtual void transition(boost::system::error_code _ech = boost::system::error_code());
+    virtual void transition(boost::system::error_code _ech = {});
 
     /// Get a string indicating if the connection is incoming or outgoing
     inline char const* connectionDirectionString() const

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -90,8 +90,8 @@ protected:
     void readAckEIP8();
     
     /// Closes connection and ends transitions.
-    void error();
-    
+    void error(boost::system::error_code _ech = boost::system::error_code());
+
     /// Performs transition for m_nextState.
     virtual void transition(boost::system::error_code _ech = boost::system::error_code());
 

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -104,7 +104,7 @@ bool Session::readPacket(uint16_t _capId, unsigned _packetType, RLP const& _r)
         // v4 frame headers are useless, offset packet type used
         // v5 protocol type is in header, packet type not offset
         if (_capId == 0 && _packetType < UserPacket)
-            return interpretP2pCapabilityPacket(static_cast<P2pPacketType>(_packetType), _r);
+            return interpretCapabilityPacket(static_cast<P2pPacketType>(_packetType), _r);
 
         for (auto const& cap : m_capabilities)
         {
@@ -135,7 +135,7 @@ bool Session::readPacket(uint16_t _capId, unsigned _packetType, RLP const& _r)
     return true;
 }
 
-bool Session::interpretP2pCapabilityPacket(P2pPacketType _t, RLP const& _r)
+bool Session::interpretCapabilityPacket(P2pPacketType _t, RLP const& _r)
 {
     LOG(m_capLoggerDetail) << p2pPacketTypeToString(_t) << " from";
     switch (_t)
@@ -208,7 +208,7 @@ bool Session::checkPacket(bytesConstRef _msg)
 void Session::send(bytes&& _msg)
 {
     bytesConstRef msg(&_msg);
-    LOG(m_netLoggerDetail) << "Sending " << capabilityPacketTypeToString(_msg[0]) << " to";
+    LOG(m_netLoggerDetail) << capabilityPacketTypeToString(_msg[0]) << " to";
     if (!checkPacket(msg))
         LOG(m_netLoggerError) << "Invalid packet constructed. Size: " << msg.size()
                               << " bytes, message: " << toHex(msg);
@@ -282,8 +282,7 @@ void Session::drop(DisconnectReason _reason)
         try
         {
             boost::system::error_code ec;
-            LOG(m_netLoggerDetail)
-                << "Closing " << socket.remote_endpoint(ec) << " (" << reasonOf(_reason) << ")";
+            LOG(m_netLoggerDetail) << "Closing (" << reasonOf(_reason) << ") connection with";
             socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
             socket.close();
         }

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -27,17 +27,13 @@ Session::Session(Host* _h, unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLP
     stringstream remoteInfoStream;
     remoteInfoStream << "(" << m_info.id << "@" << m_socket->remoteEndpoint() << ")";
 
-    m_netLogger.add_attribute(
-        "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
-    m_netLoggerDetail.add_attribute(
-        "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
-    m_netLoggerError.add_attribute(
-        "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
+    auto const attr = boost::log::attributes::constant<std::string>{remoteInfoStream.str()};
+    m_netLogger.add_attribute("Suffix", attr);
+    m_netLoggerDetail.add_attribute("Suffix", attr);
+    m_netLoggerError.add_attribute("Suffix", attr);
 
-    m_capLogger.add_attribute(
-        "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
-    m_capLoggerDetail.add_attribute(
-        "Suffix", boost::log::attributes::constant<std::string>(remoteInfoStream.str()));
+    m_capLogger.add_attribute("Suffix", attr);
+    m_capLoggerDetail.add_attribute("Suffix", attr);
 
     m_peer->m_lastDisconnect = NoDisconnect;
     m_lastReceived = m_connect = chrono::steady_clock::now();
@@ -126,9 +122,9 @@ bool Session::readPacket(uint16_t _capId, unsigned _packetType, RLP const& _r)
     }
     catch (std::exception const& _e)
     {
-        LOG(m_netLoggerError) << "Exception caught in p2p::Session::readPacket(): " << _e.what()
-                              << ". PacketType: " << capabilityPacketTypeToString(_packetType)
-                              << " (" << _packetType << "). RLP: " << _r;
+        LOG(m_netLogger) << "Exception caught in p2p::Session::readPacket(): " << _e.what()
+                         << ". PacketType: " << capabilityPacketTypeToString(_packetType) << " ("
+                         << _packetType << "). RLP: " << _r;
         disconnect(BadProtocol);
         return true;
     }
@@ -330,7 +326,7 @@ void Session::doRead()
                 return;
             else if (!m_io->authAndDecryptHeader(bytesRef(m_data.data(), length)))
             {
-                LOG(m_netLoggerError) << "Header decrypt failed";
+                LOG(m_netLogger) << "Header decrypt failed";
                 drop(BadProtocol);  // todo: better error
                 return;
             }

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -135,7 +135,7 @@ private:
     bool readPacket(uint16_t _capId, unsigned _t, RLP const& _r);
 
     /// Interpret an incoming Session packet.
-    bool interpret(P2pPacketType _t, RLP const& _r);
+    bool interpretP2pCapabilityPacket(P2pPacketType _t, RLP const& _r);
 
     /// @returns true iff the _msg forms a valid message for sending or receiving on the network.
     static bool checkPacket(bytesConstRef _msg);
@@ -177,7 +177,12 @@ private:
 
     std::set<std::string> m_disabledCapabilities;
 
-    std::string const m_logContext;
+    Logger m_netLogger{createLogger(VerbosityDebug, "net")};
+    Logger m_netLoggerDetail{createLogger(VerbosityTrace, "net")};
+    Logger m_netLoggerError{createLogger(VerbosityError, "net")};
+
+    Logger m_capLogger{createLogger(VerbosityDebug, "p2pcap")};
+    Logger m_capLoggerDetail{createLogger(VerbosityTrace, "p2pcap")};
 };
 
 }

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -135,7 +135,7 @@ private:
     bool readPacket(uint16_t _capId, unsigned _t, RLP const& _r);
 
     /// Interpret an incoming Session packet.
-    bool interpretP2pCapabilityPacket(P2pPacketType _t, RLP const& _r);
+    bool interpretCapabilityPacket(P2pPacketType _t, RLP const& _r);
 
     /// @returns true iff the _msg forms a valid message for sending or receiving on the network.
     static bool checkPacket(bytesConstRef _msg);

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -135,7 +135,7 @@ private:
     bool readPacket(uint16_t _capId, unsigned _t, RLP const& _r);
 
     /// Interpret an incoming Session packet.
-    bool interpretCapabilityPacket(P2pPacketType _t, RLP const& _r);
+    bool interpretP2pPacket(P2pPacketType _t, RLP const& _r);
 
     /// @returns true iff the _msg forms a valid message for sending or receiving on the network.
     static bool checkPacket(bytesConstRef _msg);
@@ -176,6 +176,8 @@ private:
     std::unordered_map<std::string, unsigned> m_capabilityOffsets;
 
     std::set<std::string> m_disabledCapabilities;
+
+    std::string m_logSuffix;
 
     Logger m_netLogger{createLogger(VerbosityDebug, "net")};
     Logger m_netLoggerDetail{createLogger(VerbosityTrace, "net")};


### PR DESCRIPTION
* Move log messages from global thread-safe loggers to class-instance-loggers (where thread safety isn't needed because logging is done in functions called on a single thread)
* Add a log suffix to the `RLPXHandshake`, `Session`, and `EthereumPeer `log messages which is comprised of either the remote node ID and endpoint or just the remote node id (to remove the need of having to manually include this information in each log message). This suffix also removes the need for the `LOG_SCOPED_CONTEXT ` macro so I've removed it as well
* Manually log the peer ID where appropriate in the `BlockChainSync`, `EthereumCapability`, and `WarpCapability `classes (since these classes no longer automatically get peer client information in their log messages due to the removal of `LOG_SCOPED_CONTEXT ` in `Session`)
* Move `RLPXHandshake `log messages related to receiving specific messages from a remote node from before the read (which reads the message bytes from the socket) to after the read so identifying issues related to non-responsive nodes is more intuitive
* Remove redundant error messages from `RLPXHandshake`

Here's a snippet of the new logs:

```
DEBUG 05-23 21:07:41 p2p  net    Starting peer session with Geth/v1.7.1-stable-05101641/linux-amd64/go1.9 (protocol: V5) ##0546e7dd… capabilities: (eth,63) port: 0
DEBUG 05-23 21:07:41 p2p  net    New session for capability eth; idOffset: 16 with ##0546e7dd…@34.237.25.200:30303
TRACE 05-23 21:07:41 p2p  net    Status to (##0546e7dd…@34.237.25.200:30303)
TRACE 05-23 21:07:41 p2p  p2pcap Ping to (##0546e7dd…@34.237.25.200:30303)
TRACE 05-23 21:07:41 p2p  net    Ping to (##0546e7dd…@34.237.25.200:30303)
DEBUG 05-23 21:07:41 p2p  net    Peer connection successfully established with ##0546e7dd…@34.237.25.200:30303
TRACE 05-23 21:07:41 p2p  net    Starting RLPX handshake with ##374fd3c0…@35.198.202.233:30303
TRACE 05-23 21:07:41 p2p  rlpx   egress auth to (##374fd3c0…@35.198.202.233:30303)
TRACE 05-23 21:07:41 p2p  net    Starting RLPX handshake with ##348197fd…@47.91.239.54:30303
TRACE 05-23 21:07:41 p2p  rlpx   egress auth to (##348197fd…@47.91.239.54:30303)
DEBUG 05-23 21:07:41 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##c8f41b59…
DEBUG 05-23 21:07:41 p2p  net    p2p.host.peers.events.peerAdded ##c8f41b59… 188.166.216.1:30303
TRACE 05-23 21:07:41 p2p  net    Attempting connection to ##c8f41b59…@188.166.216.1:30303 from ##5c1c3e78…
DEBUG 05-23 21:07:41 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##fd6f0c38…
DEBUG 05-23 21:07:41 p2p  net    p2p.host.peers.events.peerAdded ##fd6f0c38… 31.3.23.102:30303
TRACE 05-23 21:07:41 p2p  net    Attempting connection to ##fd6f0c38…@31.3.23.102:30303 from ##5c1c3e78…
DEBUG 05-23 21:07:41 p2p  net    p2p.host.nodeTable.events.nodeEntryAdded ##c8e5b4b6…
DEBUG 05-23 21:07:41 p2p  net    p2p.host.peers.events.peerAdded ##c8e5b4b6… 101.207.224.48:40115
TRACE 05-23 21:07:41 p2p  net    Attempting connection to ##c8e5b4b6…@101.207.224.48:40115 from ##5c1c3e78…
TRACE 05-23 21:07:41 p2p  net    Starting RLPX handshake with ##9d676310…@18.197.177.150:30303
TRACE 05-23 21:07:41 p2p  rlpx   egress auth to (##9d676310…@18.197.177.150:30303)
TRACE 05-23 21:07:41 p2p  net    Received Status (16) from (##0546e7dd…@34.237.25.200:30303)
DEBUG 05-23 21:07:41 p2p  ethcap Status (from ##0546e7dd…): 63 / 4514 / #5e31ddf9…, TD: 3478195 = #f2df48a6…
DEBUG 05-23 21:07:41 p2p  sync   Peer ##0546e7dd… not suitable for sync: Network identifier mismatch. Host network id: 1, peer network id: 4514
TRACE 05-23 21:07:41 p2p  net    Disconnecting (our reason: Subprotocol reason.) from (##0546e7dd…@34.237.25.200:30303)
TRACE 05-23 21:07:41 p2p  net    Disconnect to (##0546e7dd…@34.237.25.200:30303)
```