### PR TITLE
[WIP] Fix sync race condition which causes syncing to get stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
 - Fixed: [#5599](https://github.com/ethereum/aleth/pull/5600) Prevent aleth from attempting concurrent connection to node which results in disconnect of original connection.
+- Fixed: [#5608](https://github.com/ethereum/aleth/pull/5608) Fix sync race condition which causes syncing to get stuck.
 
 ## [1.6.0] - 2019-04-16
 

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -144,11 +144,12 @@ BlockChainSync::BlockChainSync(EthereumCapability& _host)
     m_lastImportedBlock(m_startingBlock),
     m_lastImportedBlockHash(_host.chain().currentHash())
 {
-    m_bqRoomAvailable = host().bq().onRoomAvailable([this]()
-    {
-        RecursiveGuard l(x_sync);
-        m_state = SyncState::Blocks;
-        continueSync();
+    m_bqRoomAvailable = host().bq().onRoomAvailable([this]() {
+        host().capabilityHost().postWork([this]() {
+            RecursiveGuard l(x_sync);
+            m_state = SyncState::Blocks;
+            continueSync();
+        });
     });
 }
 

--- a/libethereum/BlockChainSync.h
+++ b/libethereum/BlockChainSync.h
@@ -88,8 +88,8 @@ private:
     void clearPeerDownload();
     void collectBlocks();
     bool requestDaoForkBlockHeader(NodeID const& _peerID);
-    bool verifyDaoChallengeResponse(RLP const& _r);
-    void logImported(unsigned _success, unsigned _future, unsigned _got, unsigned _unknown);
+    bool verifyDaoChallengeResponse(RLP const& _r) const;
+    void logImported(unsigned _success, unsigned _future, unsigned _got, unsigned _unknown) const;
 
 private:
     struct Header
@@ -147,7 +147,7 @@ private:
     h256 m_lastImportedBlockHash;				///< Last imported block hash
     u256 m_syncingTotalDifficulty;				///< Highest peer difficulty
 
-    Logger m_logger{createLogger(VerbosityDebug, "sync")};
+    mutable Logger m_logger{createLogger(VerbosityDebug, "sync")};
     Logger m_loggerInfo{createLogger(VerbosityInfo, "sync")};
     Logger m_loggerDetail{createLogger(VerbosityTrace, "sync")};
 


### PR DESCRIPTION
Fix #5312 

Fix race condition which can occur due to the block queue "room available" handler (`BlockChainSync::m_bqRoomAvailable`) executing on the client thread concurrently with `BlockChainSync::requestBlocks` executing on the network thread which results in syncing getting paused forever. 

The race condition occurs when the block queue gets full and `BlockChainSync::requestBlocks` executes, checks the block queue status, and since it's full pauses the sync:  https://github.com/ethereum/aleth/blob/b094d0ccd58965571be0daad8074857216e1bbf7/libethereum/BlockChainSync.cpp#L290-L297

However, if right after `requestBlocks ` checks the block queue status but before it pauses syncing, the `m_bqRoomAvailable `handler starts executing and changes the sync state to `SyncState::Blocks` and calls `continueSync`, we can get into a state where the sync state will be paused but `BlockChainSync `will attempt to continue syncing (i.e. request data from peers), but reject the incoming data (due to the paused sync state).

The fix for this is to acquire the `BlockChainSync::x_sync` mutex in `requestBlocks` so that the handler and requestBlocks can't access the sync state concurrently.

I've also reviewed the `BlockChainSync ` code and found several other places where I think it makes sense to acquire the mutex. Additionally, I've updated the `m_bqRoomAvailable `handler to post the lambda to the network thread to simplify the threading story of `BlockChainSync `a little bit.