### PR TITLE
NoReward seal engine

### DIFF
--- a/aleth-vm/main.cpp
+++ b/aleth-vm/main.cpp
@@ -91,6 +91,7 @@ int main(int argc, char** argv)
 
     Ethash::init();
     NoProof::init();
+    NoReward::init();
 
     po::options_description transactionOptions("Transaction options", c_lineWidth);
     string const gasLimitDescription =

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -115,6 +115,7 @@ int main(int argc, char** argv)
     // Init defaults
     Ethash::init();
     NoProof::init();
+    NoReward::init();
 
     /// Operating mode.
     OperationMode mode = OperationMode::Node;

--- a/libethcore/SealEngine.cpp
+++ b/libethcore/SealEngine.cpp
@@ -31,6 +31,11 @@ void NoProof::init()
     ETH_REGISTER_SEAL_ENGINE(NoProof);
 }
 
+void NoReward::init()
+{
+    ETH_REGISTER_SEAL_ENGINE(NoReward);
+}
+
 void NoProof::populateFromParent(BlockHeader& _bi, BlockHeader const& _parent) const
 {
     SealEngineFace::populateFromParent(_bi, _parent);

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -161,11 +161,7 @@ class NoReward : public NoProof
 public:
     static std::string name() { return "NoReward"; }
     static void init();
-    u256 blockReward(u256 const& _blockNumber) const override
-    {
-        (void)_blockNumber;
-        return 0;
-    }
+    u256 blockReward(u256 const&) const override { return 0; }
 };
 }
 }

--- a/libethcore/SealEngine.h
+++ b/libethcore/SealEngine.h
@@ -154,5 +154,18 @@ u256 calculateEthashDifficulty(
 
 u256 calculateGasLimit(ChainOperationParams const& _chainParams, BlockHeader const& _bi,
     u256 const& _gasFloorTarget = Invalid256);
+
+
+class NoReward : public NoProof
+{
+public:
+    static std::string name() { return "NoReward"; }
+    static void init();
+    u256 blockReward(u256 const& _blockNumber) const override
+    {
+        (void)_blockNumber;
+        return 0;
+    }
+};
 }
 }

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -61,7 +61,8 @@ void ClientTest::setChainParams(string const& _genesis)
     try
     {
         params = params.loadConfig(_genesis);
-        if (params.sealEngineName != NoProof::name() && params.sealEngineName != Ethash::name())
+        if (params.sealEngineName != NoProof::name() && params.sealEngineName != Ethash::name() &&
+            params.sealEngineName != NoReward::name())
             BOOST_THROW_EXCEPTION(
                 ChainParamsInvalid() << errinfo_comment("Seal engine is not supported!"));
 


### PR DESCRIPTION
working on generating the state tests via RPC
state tests does not have mining reward
there for introducing sealEngine: NoReward  
same as NoProof but wont calculate any mining rewards whatsoever