### PR TITLE
Garbage collect incompatible peers in Host::run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added: [#5591](https://github.com/ethereum/aleth/pull/5591) Network logging bugfixes and improvements and add p2pcap log channel.
 - Added: [#5588](https://github.com/ethereum/aleth/pull/5588) Testeth prints similar test suite name suggestions, when the name passed in `-t` argument is not found.
 - Added: [#5593](https://github.com/ethereum/aleth/pull/5593) Dynamically updating host ENR.
+- Added: [#5624](https://github.com/ethereum/aleth/pull/5624) Remove useless peers from peer list.
 - Changed: [#5532](https://github.com/ethereum/aleth/pull/5532) The leveldb is upgraded to 1.22. This is breaking change on Windows and the old databases are not compatible.
 - Changed: [#5559](https://github.com/ethereum/aleth/pull/5559) Update peer validation error messages.
 - Changed: [#5568](https://github.com/ethereum/aleth/pull/5568) Improve rlpx handshake log messages and create new rlpx log channel.

--- a/libethereum/BlockChainSync.cpp
+++ b/libethereum/BlockChainSync.cpp
@@ -197,7 +197,7 @@ void BlockChainSync::onPeerStatus(EthereumPeer const& _peer)
     if (!disconnectReason.empty())
     {
         LOG(m_logger) << "Peer " << _peer.id() << " not suitable for sync: " << disconnectReason;
-        m_host.capabilityHost().disconnect(_peer.id(), p2p::UserReason);
+        m_host.capabilityHost().disconnect(_peer.id(), p2p::UselessPeer);
         return;
     }
 

--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -110,6 +110,17 @@ enum DisconnectReason
 /// @returns the string form of the given disconnection reason.
 std::string reasonOf(DisconnectReason _r);
 
+enum HandshakeFailureReason
+{
+    NoFailure = 0,
+    UnknownFailure,
+    Timeout,
+    TcpError,
+    FrameDecryptionFailure,
+    InternalError,
+    ProtocolError
+};
+
 using CapDesc = std::pair<std::string, unsigned>;
 using CapDescSet = std::set<CapDesc>;
 using CapDescs = std::vector<CapDesc>;

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -211,7 +211,11 @@ std::shared_ptr<Peer> Host::peer(NodeID const& _n) const
 void Host::handshakeFailed(NodeID const& _n, HandshakeFailureReason _r)
 {
     std::shared_ptr<Peer> p = peer(_n);
-    assert(p);
+    if (!p)
+    {
+        cerror << "Peer " << _n << " not found";
+        return;
+    }
     p->m_lastHandshakeFailure = _r;
 }
 
@@ -812,7 +816,7 @@ void Host::run(boost::system::error_code const& _ec)
                     reqConn++;
                 else if (!haveSession)
                 {
-                    if (p->second->fallbackSeconds() == numeric_limits<unsigned>::max())
+                    if (p->second->uselessPeer())
                         p = m_peers.erase(p);
                     else if (p->second->shouldReconnect() && (!m_netConfig.pin || required))
                         toConnect.push_back(p->second);

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -343,6 +343,11 @@ private:
     /// Stop registered capabilities, typically done when the network is being shut down.
     void stopCapabilities();
 
+    std::shared_ptr<Peer> peer(NodeID const& _n) const;
+
+    /// Set a handshake failure reason for a peer
+    void handshakeFailed(NodeID const& _n, HandshakeFailureReason _r);
+
     bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
 
     std::atomic<bool> m_run{false};													///< Whether network is running.
@@ -408,7 +413,7 @@ private:
     /// logging to once every c_logActivePeersInterval seconds
     std::chrono::steady_clock::time_point m_lastPeerLogMessage;
 
-    Logger m_logger{createLogger(VerbosityDebug, "net")};
+    mutable Logger m_logger{createLogger(VerbosityDebug, "net")};
     Logger m_detailsLogger{createLogger(VerbosityTrace, "net")};
     Logger m_infoLogger{createLogger(VerbosityInfo, "net")};
 };

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -214,6 +214,9 @@ public:
         return m_sessions.count(_id) ? m_sessions[_id].lock() : std::shared_ptr<SessionFace>();
     }
 
+    /// Set a handshake failure reason for a peer
+    void onHandshakeFailed(NodeID const& _n, HandshakeFailureReason _r);
+
     /// Get our current node ID.
     NodeID id() const { return m_alias.pub(); }
 
@@ -344,9 +347,6 @@ private:
     void stopCapabilities();
 
     std::shared_ptr<Peer> peer(NodeID const& _n) const;
-
-    /// Set a handshake failure reason for a peer
-    void handshakeFailed(NodeID const& _n, HandshakeFailureReason _r);
 
     bytes m_restoreNetwork;										///< Set by constructor and used to set Host key and restore network peers & nodes.
 

--- a/libp2p/Peer.cpp
+++ b/libp2p/Peer.cpp
@@ -52,6 +52,9 @@ bool Peer::shouldReconnect() const
 
 bool Peer::uselessPeer() const
 {
+    if (peerType == PeerType::Required)
+        return false;
+
     switch (m_lastHandshakeFailure)
     {
     case FrameDecryptionFailure:

--- a/libp2p/Peer.h
+++ b/libp2p/Peer.h
@@ -80,7 +80,8 @@ public:
     void noteSessionGood() { m_failedAttempts = 0; }
 
 private:
-    /// Returns number of seconds to wait until attempting connection, based on attempted connection history.
+    /// Returns number of seconds to wait until attempting connection, based on attempted connection history, or
+    /// numeric_limits<unsigned>::max() if a connection should never be attempted.
     unsigned fallbackSeconds() const;
 
     std::atomic<int> m_score{0};									///< All time cumulative.
@@ -92,6 +93,7 @@ private:
     std::chrono::system_clock::time_point m_lastAttempted;
     std::atomic<unsigned> m_failedAttempts{0};
     DisconnectReason m_lastDisconnect = NoDisconnect;	///< Reason for disconnect that happened last.
+    HandshakeFailureReason m_lastHandshakeFailure = NoFailure; ///< Reason for most recent handshake failure
 
     /// Used by isOffline() and (todo) for peer to emit session information.
     std::weak_ptr<Session> m_session;

--- a/libp2p/Peer.h
+++ b/libp2p/Peer.h
@@ -70,6 +70,10 @@ public:
     /// Return true if connection attempt should be made to this peer or false if
     bool shouldReconnect() const;
 
+    /// A peer which should never be reconnected to - e.g. it's running on a different network, we
+    /// don't have any common capabilities
+    bool uselessPeer() const;
+
     /// Number of times connection has been attempted to peer.
     int failedAttempts() const { return m_failedAttempts; }
 

--- a/libp2p/Peer.h
+++ b/libp2p/Peer.h
@@ -72,7 +72,7 @@ public:
 
     /// A peer which should never be reconnected to - e.g. it's running on a different network, we
     /// don't have any common capabilities
-    bool uselessPeer() const;
+    bool isUseless() const;
 
     /// Number of times connection has been attempted to peer.
     int failedAttempts() const { return m_failedAttempts; }
@@ -84,8 +84,8 @@ public:
     void noteSessionGood() { m_failedAttempts = 0; }
 
 private:
-    /// Returns number of seconds to wait until attempting connection, based on attempted connection history, or
-    /// numeric_limits<unsigned>::max() if a connection should never be attempted.
+    /// Returns number of seconds to wait until attempting connection, based on attempted connection
+    /// history
     unsigned fallbackSeconds() const;
 
     std::atomic<int> m_score{0};									///< All time cumulative.

--- a/libp2p/RLPxHandshake.h
+++ b/libp2p/RLPxHandshake.h
@@ -137,6 +137,8 @@ protected:
     /// Timer which enforces c_timeout. Reset for each stage of the handshake.
     ba::steady_timer m_idleTimer;
 
+    HandshakeFailureReason m_failureReason;
+
     Logger m_logger{createLogger(VerbosityTrace, "rlpx")};
     Logger m_errorLogger{createLogger(VerbosityError, "rlpx")};
 };


### PR DESCRIPTION
Garbage collect peers in `Host::run()` which are deemed incompatible - an incompatible peer is one with which we will never be able to successfully peer with (e.g. on a different chain or network, not running any capabilities).