### PR TITLE
Don't add official Ethereum bootnodes as required peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Changed: [#5589](https://github.com/ethereum/aleth/pull/5589) Make aleth output always line-buffered even when redirected to file or pipe.
 - Changed: [#5602](https://github.com/ethereum/aleth/pull/5602) Better predicting external IP address and UDP port.
 - Changed: [#5605](https://github.com/ethereum/aleth/pull/5605) Network logging bugfixes and improvements and add warpcap log channel.
+- Changed: [#5628](https://github.com/ethereum/aleth/pull/5628) Don't try to endlessly reconnect to official Ethereum bootnodes.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
 - Fixed: [#5599](https://github.com/ethereum/aleth/pull/5600) Prevent aleth from attempting concurrent connection to node which results in disconnect of original connection.

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -1011,7 +1011,7 @@ int main(int argc, char** argv)
 
         if (bootstrap)
             for (auto const& i : defaultBootNodes())
-                web3.requirePeer(i.first, i.second);
+                web3.addNode(i.first, i.second);
         if (!remoteHost.empty())
             web3.addNode(p2p::NodeID(), remoteHost + ":" + toString(remotePort));
     }


### PR DESCRIPTION
Add them to the node table rather than as required peers - this results in us interacting with them via discovery (which is where their real value lies) and if we can validate the endpoint proof, adding them as optional peers and trying to connect to them via devp2p. However, we stop trying to connect to them if we get disconnected for a critical reason (e.g. they're on a different network or we don't have any common capabilities). If we get disconnected for a non-critical reason (e.g. a TCP error), we'll try to reconnect at increasing intervals. 

This makes more sense than adding them as required peers which results in us endlessly trying to connect to them via devp2p, regardless of the disconnect reason - note that many of them are on different Ethereum networks and also don't appear to be running devp2p so they don't support syncing, so we never end up being able to connect to them anyway. In practice, I believe we're only ever able to peer with 1 node out of our full list.