### PR TITLE
Set new handshake failure reason when disconnect is received instead of hello during RLPX handshake

### DIFF
--- a/libp2p/Common.h
+++ b/libp2p/Common.h
@@ -110,15 +110,16 @@ enum DisconnectReason
 /// @returns the string form of the given disconnection reason.
 std::string reasonOf(DisconnectReason _r);
 
-enum HandshakeFailureReason
+enum class HandshakeFailureReason
 {
     NoFailure = 0,
     UnknownFailure,
     Timeout,
-    TcpError,
+    TCPError,
     FrameDecryptionFailure,
     InternalError,
-    ProtocolError
+    ProtocolError,
+    DisconnectRequested
 };
 
 using CapDesc = std::pair<std::string, unsigned>;

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -280,7 +280,7 @@ void Host::startPeerSession(Public const& _id, RLP const& _hello,
         if (itPeer != m_peers.end())
         {
             peer = itPeer->second;
-            peer->m_lastHandshakeFailure = NoFailure;
+            peer->m_lastHandshakeFailure = HandshakeFailureReason::NoFailure;
         }
         else
         {

--- a/libp2p/Peer.cpp
+++ b/libp2p/Peer.cpp
@@ -69,8 +69,8 @@ bool Peer::isUseless() const
 
     switch (m_lastHandshakeFailure)
     {
-    case FrameDecryptionFailure:
-    case ProtocolError:
+    case HandshakeFailureReason::FrameDecryptionFailure:
+    case HandshakeFailureReason::ProtocolError:
         return true;
     default:
         break;

--- a/libp2p/Peer.h
+++ b/libp2p/Peer.h
@@ -97,7 +97,8 @@ private:
     std::chrono::system_clock::time_point m_lastAttempted;
     std::atomic<unsigned> m_failedAttempts{0};
     DisconnectReason m_lastDisconnect = NoDisconnect;	///< Reason for disconnect that happened last.
-    HandshakeFailureReason m_lastHandshakeFailure = NoFailure; ///< Reason for most recent handshake failure
+    HandshakeFailureReason m_lastHandshakeFailure =
+        HandshakeFailureReason::NoFailure;  ///< Reason for most recent handshake failure
 
     /// Used by isOffline() and (todo) for peer to emit session information.
     std::weak_ptr<Session> m_session;


### PR DESCRIPTION
We set this new failure reason (`DisconnectRequested`) to avoid garbage collecting these nodes in `Host::run` since this isn't a critical condition - they aren't in violation of the protocol (the p2p capability section of the RLPX handshake spec states that a disconnect can be sent at any time) and we often encounter nodes in practice from whom we receive a disconnect while handshaking but with which we can later successfully complete the handshake and peer with.

Also log the disconnect reason (if present in the received disconnect packet) which fixes #5569 

