### PR TITLE
Reset code to empty in rollback

### DIFF
--- a/libethereum/Account.cpp
+++ b/libethereum/Account.cpp
@@ -41,6 +41,13 @@ void Account::setCode(bytes&& _code)
     m_codeHash = sha3(m_codeCache);
 }
 
+void Account::resetCode()
+{
+    m_codeCache.clear();
+    m_hasNewCode = false;
+    m_codeHash = EmptySHA3;
+}
+
 u256 Account::originalStorageValue(u256 const& _key, OverlayDB const& _db) const
 {
     auto it = m_storageOriginal.find(_key);

--- a/libethereum/Account.h
+++ b/libethereum/Account.h
@@ -173,6 +173,9 @@ public:
     /// Sets the code of the account. Used by "create" messages.
     void setCode(bytes&& _code);
 
+    /// Reset the code set by previous setCode
+    void resetCode();
+
     /// Specify to the object what the actual code is for the account. @a _code must have a SHA3
     /// equal to codeHash().
     void noteCode(bytesConstRef _code) { assert(sha3(_code) == m_codeHash); m_codeCache = _code.toBytes(); }

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -518,7 +518,7 @@ bytes const& State::code(Address const& _addr) const
 
 void State::setCode(Address const& _address, bytes&& _code)
 {
-    m_changeLog.emplace_back(_address, code(_address));
+    m_changeLog.emplace_back(Change::Code, _address);
     m_cache[_address].setCode(std::move(_code));
 }
 
@@ -583,7 +583,7 @@ void State::rollback(size_t _savepoint)
             m_cache.erase(change.address);
             break;
         case Change::Code:
-            account.setCode(std::move(change.oldCode));
+            account.resetCode();
             break;
         case Change::Touch:
             account.untouch();

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -518,6 +518,9 @@ bytes const& State::code(Address const& _addr) const
 
 void State::setCode(Address const& _address, bytes&& _code)
 {
+    // rollback assumes that overwriting of the code never happens
+    // (not allowed in contract creation logic in Executive)
+    assert(!addressHasCode(_address));
     m_changeLog.emplace_back(Change::Code, _address);
     m_cache[_address].setCode(std::move(_code));
 }

--- a/libethereum/State.h
+++ b/libethereum/State.h
@@ -116,13 +116,11 @@ struct Change
     Address address;  ///< Changed account address.
     u256 value;       ///< Change value, e.g. balance, storage and nonce.
     u256 key;         ///< Storage key. Last because used only in one case.
-    bytes oldCode;    ///< Code overwritten by CREATE, empty except in case of address collision.
 
     /// Helper constructor to make change log update more readable.
     Change(Kind _kind, Address const& _addr, u256 const& _value = 0):
             kind(_kind), address(_addr), value(_value)
     {
-        assert(_kind != Code); // For this the special constructor needs to be used.
     }
 
     /// Helper constructor especially for storage change log.
@@ -133,11 +131,6 @@ struct Change
     /// Helper constructor for nonce change log.
     Change(Address const& _addr, u256 const& _value):
             kind(Nonce), address(_addr), value(_value)
-    {}
-
-    /// Helper constructor especially for new code change log.
-    Change(Address const& _addr, bytes const& _oldCode):
-            kind(Code), address(_addr), oldCode(_oldCode)
     {}
 };
 

--- a/test/unittests/libethereum/StateUnitTests.cpp
+++ b/test/unittests/libethereum/StateUnitTests.cpp
@@ -53,6 +53,20 @@ BOOST_AUTO_TEST_CASE(LoadAccountCode)
     ));
 }
 
+BOOST_AUTO_TEST_CASE(RollbackSetCode)
+{
+    Address addr{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"};
+    State s{0};
+    auto savepoint = s.savepoint();
+    s.createContract(addr);
+    uint8_t codeData[] = {'c', 'o', 'd', 'e'};
+    s.setCode(addr, {std::begin(codeData), std::end(codeData)});
+    s.rollback(savepoint);
+
+    BOOST_CHECK(!s.addressHasCode(addr));
+    BOOST_CHECK(!s.accountNonemptyAndExisting(addr));
+}
+
 class AddressRangeTestFixture : public TestOutputHelperFixture
 {
 public:


### PR DESCRIPTION
I think we don't need to save the old code for rollback anymore, because overwriting the code is not allowed according to address collision rules (https://github.com/ethereum/EIPs/issues/684 and https://eips.ethereum.org/EIPS/eip-689) and we never get to rolling back the overwritten code.

A bit of history of this code:
It was written as a fix of incorrect rollback of code overwrite in case of address collision (back then it was possible to overwrite the code)
https://github.com/ethereum/aleth/issues/4130
https://github.com/ethereum/aleth/pull/4151

Then in preparation for Byzantium new collision rules were introduced, which applied retroactively to all previous forks, too.
https://github.com/ethereum/aleth/pull/4384

To quote EIP-689:

> Regarding testing, this EIP relieves clients from supporting reversion of code overwriting.

This will simplify a little bit the implementation of EIP-1702 Generalized Account Versioning Scheme, because if we don't need to save the old code in journal, then we don't need to save the version either.