### PR TITLE
Avoid attempting to sync with disconnected peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.
 - Fixed: [#5599](https://github.com/ethereum/aleth/pull/5600) Prevent aleth from attempting concurrent connection to node which results in disconnect of original connection.
 - Fixed: [#5609](https://github.com/ethereum/aleth/pull/5609) Log valid local enode-address when external IP is not known.
-- Fixed: [#5627](https://github.com/ethereum/aleth/pull/5627) Correct testeth --help log output indentation
+- Fixed: [#5627](https://github.com/ethereum/aleth/pull/5627) Correct testeth --help log output indentation.
+- Fixed: [#5644](https://github.com/ethereum/aleth/pull/5644) Avoid attempting to sync with disconnected peers.
+
 
 ## [1.6.0] - 2019-04-16
 

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -400,13 +400,14 @@ void Host::startPeerSession(Public const& _id, RLP const& _hello,
 shared_ptr<SessionFace> Host::peerSession(NodeID const& _id) const
 {
     RecursiveGuard l(x_sessions);
-    if (m_sessions.count(_id))
+    auto const it = m_sessions.find(_id);
+    if (it != m_sessions.end())
     {
-        auto const s = m_sessions[_id].lock();
+        auto const s = it->second.lock();
         if (s && s->isConnected())
             return s;
     }
-    return{};
+    return {};
 }
 
 void Host::onHandshakeFailed(NodeID const& _n, HandshakeFailureReason _r)
@@ -1175,7 +1176,7 @@ void Host::forEachPeer(
     vector<shared_ptr<SessionFace>> sessions;
     for (auto const& i : m_sessions)
     {
-        shared_ptr<SessionFace> s = i.second.lock();
+        auto const s = i.second.lock();
         if (s && s->isConnected())
         {
             vector<CapDesc> capabilities = s->capabilities();

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -208,11 +208,7 @@ public:
         std::unique_ptr<RLPXFrameCoder>&& _io, std::shared_ptr<RLPXSocket> const& _s);
 
     /// Get session by id
-    std::shared_ptr<SessionFace> peerSession(NodeID const& _id) const
-    {
-        RecursiveGuard l(x_sessions);
-        return m_sessions.count(_id) ? m_sessions[_id].lock() : std::shared_ptr<SessionFace>();
-    }
+    std::shared_ptr<SessionFace> peerSession(NodeID const& _id) const;
 
     /// Set a handshake failure reason for a peer
     void onHandshakeFailed(NodeID const& _n, HandshakeFailureReason _r);


### PR DESCRIPTION
Fix #5643 

Fix a bug where Aleth can try to sync with a node after it has failed status validation (e.g. its on a different chain), which results in wasted resources and confusing logs e.g: "starting full sync" being displayed but no blocks being imported.

The root cause is that Aleth can initiate syncing with peers via `Host::forEachPeer` (see `BlockChainSync::continueSync`), and `Host::forEachPeer` iterates through its map of Session weak_ptrs without checking if the session is still connected i.e. the socket isn't closed. This means that the following case can occur:

1. Status packet validation fails (see `BlockChainSync::onPeerStatus`) so Aleth sends a disconnect packet to the remote node (`Host::capabilityHost()::disconnect()`). This results in` Session::disconnect() `being called which results in a write to the socket being queued and the write handler being placed in the boost asio handler queue (see `Session::write`). The socket is then closed. Note that the Session instance is still active until the write is completed and the handler is executed (`Session::shared_from_this()` is captured in the handler).
	
2. Something happens which triggers a call to `BlockChainSync::continueSync` (e.g. a peer session with another node is closed - see `BlockChainSync::onPeerAborting`) - `BlockChainSync::continueSync` makes sync calls for each peer via `host().capabilityHost().forEachPeer()`. Meanwhile the write handler is still sitting in the boost ASIO handler queue so the session is still active. 

3. Eventually the write is performed and the write handler is removed from the queue and executed and the Session instance is destructed. This means that the attempted syncing with the disconnected node is wasted cycles and also makes the logs confusing.
