### PR TITLE
split BlockchainTests into Valid and Invalid

### DIFF
--- a/test/tools/jsontests/BlockChainTests.h
+++ b/test/tools/jsontests/BlockChainTests.h
@@ -31,8 +31,7 @@ namespace dev
 {
 namespace test
 {
-
-class BlockchainTestSuite: public TestSuite
+class BlockchainInvalidTestSuite : public TestSuite
 {
 public:
     json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override;
@@ -40,7 +39,15 @@ public:
     boost::filesystem::path suiteFillerFolder() const override;
 };
 
-class BCGeneralStateTestsSuite: public BlockchainTestSuite
+class BlockchainValidTestSuite : public TestSuite
+{
+public:
+    json_spirit::mValue doTests(json_spirit::mValue const& _input, bool _fillin) const override;
+    boost::filesystem::path suiteFolder() const override;
+    boost::filesystem::path suiteFillerFolder() const override;
+};
+
+class BCGeneralStateTestsSuite : public BlockchainValidTestSuite
 {
     boost::filesystem::path suiteFolder() const override;
     boost::filesystem::path suiteFillerFolder() const override;
@@ -79,7 +86,8 @@ void checkJsonSectionForInvalidBlock(mObject& _blObj);
 void checkExpectedException(mObject& _blObj, Exception const& _e);
 void checkBlocks(TestBlock const& _blockFromFields, TestBlock const& _blockFromRlp, string const& _testname);
 bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, SealEngineFace const& _sealEngine);
-json_spirit::mObject fillBCTest(json_spirit::mObject const& _input);
+json_spirit::mObject fillBCTest(
+    json_spirit::mObject const& _input, bool _allowInvalidBlocks = false);
 void testBCTest(json_spirit::mObject const& _o);
 
 } } // Namespace Close

--- a/test/tools/libtesteth/TestOutputHelper.h
+++ b/test/tools/libtesteth/TestOutputHelper.h
@@ -60,7 +60,6 @@ private:
 	TestOutputHelper() {}
     void checkUnfinishedTestFolders();  // Checkup that all test folders are active during the test
                                         // run
-    std::string detectFilterForMinusTArgument();
     Timer m_timer;
 	size_t m_currTest;
 	size_t m_maxTests;

--- a/test/tools/libtesteth/TestOutputHelper.h
+++ b/test/tools/libtesteth/TestOutputHelper.h
@@ -60,6 +60,7 @@ private:
 	TestOutputHelper() {}
     void checkUnfinishedTestFolders();  // Checkup that all test folders are active during the test
                                         // run
+    std::string detectFilterForMinusTArgument();
     Timer m_timer;
 	size_t m_currTest;
 	size_t m_maxTests;

--- a/test/tools/libtesteth/boostTest.cpp
+++ b/test/tools/libtesteth/boostTest.cpp
@@ -56,7 +56,7 @@ void customTestSuite()
         }
         else if (opt.rCurrentTestSuite.find("BlockchainTests") != std::string::npos)
         {
-            dev::test::BlockchainTestSuite suite;
+            dev::test::BlockchainValidTestSuite suite;
             suite.runTestWithoutFiller(file);
         }
         else if (opt.rCurrentTestSuite.find("TransitionTests") != std::string::npos)

--- a/test/unittests/libethereum/GasPricer.cpp
+++ b/test/unittests/libethereum/GasPricer.cpp
@@ -35,6 +35,9 @@ using namespace dev::eth;
 using namespace dev::test;
 namespace fs = boost::filesystem;
 
+const string c_pathToValidBlocks = "/BlockchainTests/ValidBlocks/";
+const string c_pathToInValidBlocks = "/BlockchainTests/InvalidBlocks/";
+
 namespace dev {  namespace test {
 
 void executeGasPricerTest(string const& name, double _etherPrice, double _blockFee, fs::path const& _bcTestPath, TransactionPriority _txPrio, u256 _expectedAsk, u256 _expectedBid, eth::Network _sealEngineNetwork = eth::Network::TransitionnetTest)
@@ -95,95 +98,95 @@ BOOST_AUTO_TEST_CASE(basicGasPricer_RPC_API_Test_Frontier)
 {
 	u256 _expectedAsk = 16056883295;
 	u256 _expectedBid = 1;
-    dev::test::executeGasPricerTest("RPC_API_Test_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("RPC_API_Test_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_RPC_API_Test_Homestead)
 {
 	u256 _expectedAsk = 16056864311;
 	u256 _expectedBid = 1;
-    dev::test::executeGasPricerTest("RPC_API_Test_Homestead", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("RPC_API_Test_Homestead", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcValidBlockTest)
 {
-    dev::test::executeGasPricerTest("SimpleTx_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcValidBlockTest/SimpleTx.json", TransactionPriority::Medium, 155632494086, 10);
+    dev::test::executeGasPricerTest("SimpleTx_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcValidBlockTest/SimpleTx.json", TransactionPriority::Medium, 155632494086, 10);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleTest_Frontier)
 {
 	u256 _expectedAsk = 155632494086;
 	u256 _expectedBid = 1;
-    dev::test::executeGasPricerTest("twoUncle_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("twoUncle_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleTest_Homestead)
 {
     u256 _expectedAsk = 155632494086;
     u256 _expectedBid = 1;
-    dev::test::executeGasPricerTest("twoUncle_Homestead", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("twoUncle_Homestead", 30.679, 15.0, c_pathToValidBlocks + "bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleHeaderValidity_Frontier)
 {
 	u256 _expectedAsk = 155632494086;
 	u256 _expectedBid = 1;
-    dev::test::executeGasPricerTest("correct_Frontier", 30.679, 15.0, "/BlockchainTests/InvalidBlocks/bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("correct_Frontier", 30.679, 15.0, c_pathToInValidBlocks + "bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleHeaderValidity_Homestead)
 {
 	u256 _expectedAsk = 155633980282;
 	u256 _expectedBid = 1;
-    dev::test::executeGasPricerTest("correct_Homestead", 30.679, 15.0, "/BlockchainTests/InvalidBlocks/bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("correct_Homestead", 30.679, 15.0, c_pathToInValidBlocks + "bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_notxs_frontier)
 {
 	u256 _expectedAsk = 155632494086;
 	u256 _expectedBid = 155632494086;
-    dev::test::executeGasPricerTest("notxs_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("notxs_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_notxs_homestead)
 {
     u256 _expectedAsk = 155632494086;
     u256 _expectedBid = 155632494086;
-    dev::test::executeGasPricerTest("notxs_Homestead", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("notxs_Homestead", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_LowestPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 10000000000000;
-    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Lowest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/highGasUsage.json", TransactionPriority::Lowest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_LowPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 15734152261884;
-    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Low, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/highGasUsage.json", TransactionPriority::Low, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_MediumPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 20000000000000;
-    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/highGasUsage.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_HighPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 24265847738115;
-    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::High, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/highGasUsage.json", TransactionPriority::High, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_HighestPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 30000000000000;
-    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Highest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, c_pathToValidBlocks + "bcGasPricerTest/highGasUsage.json", TransactionPriority::Highest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethereum/GasPricer.cpp
+++ b/test/unittests/libethereum/GasPricer.cpp
@@ -95,95 +95,95 @@ BOOST_AUTO_TEST_CASE(basicGasPricer_RPC_API_Test_Frontier)
 {
 	u256 _expectedAsk = 16056883295;
 	u256 _expectedBid = 1;
-	dev::test::executeGasPricerTest("RPC_API_Test_Frontier", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("RPC_API_Test_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_RPC_API_Test_Homestead)
 {
 	u256 _expectedAsk = 16056864311;
 	u256 _expectedBid = 1;
-	dev::test::executeGasPricerTest("RPC_API_Test_Homestead", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("RPC_API_Test_Homestead", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/RPC_API_Test.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcValidBlockTest)
 {
-	dev::test::executeGasPricerTest("SimpleTx_Frontier", 30.679, 15.0, "/BlockchainTests/bcValidBlockTest/SimpleTx.json", TransactionPriority::Medium, 155632494086, 10);
+    dev::test::executeGasPricerTest("SimpleTx_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcValidBlockTest/SimpleTx.json", TransactionPriority::Medium, 155632494086, 10);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleTest_Frontier)
 {
 	u256 _expectedAsk = 155632494086;
 	u256 _expectedBid = 1;
-	dev::test::executeGasPricerTest("twoUncle_Frontier", 30.679, 15.0, "/BlockchainTests/bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("twoUncle_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleTest_Homestead)
 {
     u256 _expectedAsk = 155632494086;
     u256 _expectedBid = 1;
-	dev::test::executeGasPricerTest("twoUncle_Homestead", 30.679, 15.0, "/BlockchainTests/bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("twoUncle_Homestead", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcUncleTest/twoUncle.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleHeaderValidity_Frontier)
 {
 	u256 _expectedAsk = 155632494086;
 	u256 _expectedBid = 1;
-	dev::test::executeGasPricerTest("correct_Frontier", 30.679, 15.0, "/BlockchainTests/bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("correct_Frontier", 30.679, 15.0, "/BlockchainTests/InvalidBlocks/bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_bcUncleHeaderValidity_Homestead)
 {
 	u256 _expectedAsk = 155633980282;
 	u256 _expectedBid = 1;
-	dev::test::executeGasPricerTest("correct_Homestead", 30.679, 15.0, "/BlockchainTests/bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("correct_Homestead", 30.679, 15.0, "/BlockchainTests/InvalidBlocks/bcUncleHeaderValidity/correct.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_notxs_frontier)
 {
 	u256 _expectedAsk = 155632494086;
 	u256 _expectedBid = 155632494086;
-	dev::test::executeGasPricerTest("notxs_Frontier", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("notxs_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_notxs_homestead)
 {
     u256 _expectedAsk = 155632494086;
     u256 _expectedBid = 155632494086;
-    dev::test::executeGasPricerTest("notxs_Homestead", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
+    dev::test::executeGasPricerTest("notxs_Homestead", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/notxs.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::HomesteadTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_LowestPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 10000000000000;
-	dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/highGasUsage.json", TransactionPriority::Lowest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Lowest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_LowPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 15734152261884;
-	dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/highGasUsage.json", TransactionPriority::Low, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Low, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_MediumPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 20000000000000;
-	dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/highGasUsage.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Medium, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_HighPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 24265847738115;
-	dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/highGasUsage.json", TransactionPriority::High, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::High, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 
 BOOST_AUTO_TEST_CASE(basicGasPricer_highGasUsage_HighestPrio)
 {
     u256 _expectedAsk = 15731408053;
     u256 _expectedBid = 30000000000000;
-	dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/bcGasPricerTest/highGasUsage.json", TransactionPriority::Highest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
+    dev::test::executeGasPricerTest("highGasUsage_Frontier", 30.679, 15.0, "/BlockchainTests/ValidBlocks/bcGasPricerTest/highGasUsage.json", TransactionPriority::Highest, _expectedAsk, _expectedBid, eth::Network::FrontierTest);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libtesteth/blockchainTest.cpp
+++ b/test/unittests/libtesteth/blockchainTest.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(fillingExpectationOnMultipleNetworks)
     )";
     json_spirit::mValue input;
     json_spirit::read_string(s, input);
-    BlockchainTestSuite suite;
+    BlockchainValidTestSuite suite;
     json_spirit::mValue output = suite.doTests(input, true);
     BOOST_CHECK_MESSAGE(output.get_obj().size() == 2, "A wrong number of tests were generated.");
 }
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(fillingExpectationOnSingleNetwork)
     )";
     json_spirit::mValue input;
     json_spirit::read_string(s, input);
-    BlockchainTestSuite suite;
+    BlockchainValidTestSuite suite;
     json_spirit::mValue output = suite.doTests(input, true);
     const string testname = "fillingExpectationOnSingleNetwork_EIP150";
     BOOST_CHECK_MESSAGE(output.get_obj().size() == 1, "A wrong number of tests were generated.");
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(fillingWithWrongExpectation)
     json_spirit::mValue input;
     json_spirit::read_string(s, input);
 
-    BlockchainTestSuite suite;
+    BlockchainValidTestSuite suite;
     json_spirit::mValue output = suite.doTests(input, true);
     BOOST_CHECK_MESSAGE(output.get_obj().size() == 1, "A wrong number of tests were generated.");
 }


### PR DESCRIPTION
split BlockchainTests into BlockchainTests/ValidBlocks and BlockchainTests/InvalidBlocks
move TransitionTests under BlockchainTests

ValidBlocks contain only tests with valid rlps 
InvalidBlocks contain tests where some block rlp's are invalid and expect and exception upon import

Update test subfolder to this PR https://github.com/ethereum/tests/pull/605