### PR TITLE
Coming to agreement with geth on RIPEMD touch revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed: [#5627](https://github.com/ethereum/aleth/pull/5627) Correct testeth --help log output indentation.
 - Fixed: [#5644](https://github.com/ethereum/aleth/pull/5644) Avoid attempting to sync with disconnected peers.
 - Fixed: [#5647](https://github.com/ethereum/aleth/pull/5647) test_importRawBlock RPC method correctly fails in case of import failure.
+- Fixed: [#5652](https://github.com/ethereum/aleth/pull/5652) Behavior in corner case tests about touching empty Precompiles now agrees with geth's results.
 
 
 ## [1.6.0] - 2019-04-16


### PR DESCRIPTION
> figured cpp does a very complicated thing. It's so complicated that I don't want to describe it.
> 
> -- Yoichi Hirai

This is the old issue, originated that time when both Geth and Parity had incorrect revert behavior, and then it was decided to introduce a hack into consensus rules instead of doing huge chain reorg.

The buggy behavior that is now a rule is basically: when precompiled contract with address `0x03` (RIPEMD160) is touched, then exception happens and state changes are reverted, this address should be still considered touched in the end, so that "remove empty touched accounts" rule (EIP-158) deletes it from the state at the end of transaction.

There are several related tests created after this incident:
- [`GeneralStateTests/stSpecialTest/tx_xcf416c53`](https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/stSpecialTest/failed_tx_xcf416c53Filler.json) - emulates the transaction where this special behavior took place on the main net. Here the gas given to `CALL` to RIPEMD is not enough, so the `CALL` itself fails, but then transaction proceeds further till success. RIPEMD stays touched and then is deleted. All clients pass this test (otherwise they wouldn't be able to do full sync)
- [`GeneralStateTests/stRevertTest/RevertPrecompiledTouch`](https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/stRevertTest/RevertPrecompiledTouchFiller.json) and  [`GeneralStateTests/stRevertTest/RevertPrecompiledTouch_storage`](https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/stRevertTest/RevertPrecompiledTouch_storageFiller.json) - here `CALL` to RIPEMD succeeds, but later execution runs out of gas. Changes to the state are reverted, but RIPEMD stays touched and then is deleted. In these tests we have different results than geth.

Dimitriy now has regenerated these latter tests via geth, and now aleth doesn't pass them. 

In geth all of these cases look to be handled by just one hack https://github.com/ethereum/go-ethereum/blob/7527215a68eaac8a880be83f3f1ded0ed82f6650/core/state/state_object.go#L145-L149

Our current hack covers only the first `tx_xcf416c53` case, because for us failing `CALL` to precompile is a special case, that doesn't invoke any rollback https://github.com/ethereum/aleth/blob/007d89a712209ca16198be41a5d9c70498138eb6/libethereum/Executive.cpp#L313-L318

Now for us to cover the case of OOG in caller's frame, it looks like we unfortunately have to add another similar hack in revert logic.

From the point of view of our code it feels like an unnecessary hack, not related to original problem, but I guess from geth's perspective to replicate our behavior they would need to do some "unnecessary" hacks in their code. Oh well.

More references:
- Original geth's fix https://github.com/ethereum/go-ethereum/pull/3341/files#diff-2433aa143ee4772026454b8abd76b9dd
- More detailed description https://github.com/ethereum/EIPs/issues/716
- Recent mention in AllCoreDevs chat https://gitter.im/ethereum/AllCoreDevs?at=5ce3bd9863dea422b4bc9b91
- Yellow Paper mentions this anomaly in Appendix K https://ethereum.github.io/yellowpaper/paper.pdf

cc @holiman @winsvega 