### PR TITLE
Don't save empty code into database

### DIFF
--- a/libethereum/Account.cpp
+++ b/libethereum/Account.cpp
@@ -36,9 +36,13 @@ namespace fs = boost::filesystem;
 
 void Account::setCode(bytes&& _code)
 {
-    m_codeCache = std::move(_code);
-    m_hasNewCode = true;
-    m_codeHash = sha3(m_codeCache);
+    auto const newHash = sha3(_code);
+    if (newHash != m_codeHash)
+    {
+        m_codeCache = std::move(_code);
+        m_hasNewCode = true;
+        m_codeHash = newHash;
+    }
 }
 
 void Account::resetCode()

--- a/test/unittests/libethereum/StateUnitTests.cpp
+++ b/test/unittests/libethereum/StateUnitTests.cpp
@@ -67,6 +67,20 @@ BOOST_AUTO_TEST_CASE(RollbackSetCode)
     BOOST_CHECK(!s.accountNonemptyAndExisting(addr));
 }
 
+BOOST_AUTO_TEST_CASE(SetEmptyCode)
+{
+    Address addr{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"};
+    State s{0};
+    s.createContract(addr);
+    s.setNonce(addr, 1);
+    s.setCode(addr, {});
+    s.commit(State::CommitBehaviour::RemoveEmptyAccounts);
+
+    BOOST_CHECK(!s.addressHasCode(addr));
+
+    // empty code is not saved to DB
+    BOOST_CHECK(!s.db().exists(EmptySHA3));
+}
 class AddressRangeTestFixture : public TestOutputHelperFixture
 {
 public:


### PR DESCRIPTION
Extracted from #5640.

When init code returns empty code, account is still created, and setting `m_hasNewCode` to `true` in `setCode` was leading to `commit` function pushing into the database the pair `EmptySHA3 => ""`, which is not necessary.

This doesn't affect consensus.