### PR TITLE
Istanbul test config

### DIFF
--- a/libethashseal/GenesisInfo.cpp
+++ b/libethashseal/GenesisInfo.cpp
@@ -27,15 +27,16 @@ using namespace dev;
 #include "genesis/test/byzantiumNoProofTest.cpp"
 #include "genesis/test/byzantiumTest.cpp"
 #include "genesis/test/byzantiumTransitionTest.cpp"
+#include "genesis/test/constantinopleFixTest.cpp"
 #include "genesis/test/constantinopleNoProofTest.cpp"
 #include "genesis/test/constantinopleTest.cpp"
-#include "genesis/test/constantinopleFixTest.cpp"
 #include "genesis/test/eip150Test.cpp"
 #include "genesis/test/eip158Test.cpp"
 #include "genesis/test/experimentalTransitionTest.cpp"
 #include "genesis/test/frontierNoProofTest.cpp"
 #include "genesis/test/frontierTest.cpp"
 #include "genesis/test/homesteadTest.cpp"
+#include "genesis/test/istanbulTransitionTest.cpp"
 #include "genesis/test/mainNetworkNoProofTest.cpp"
 #include "genesis/test/mainNetworkTest.cpp"
 
@@ -77,6 +78,8 @@ std::string const& dev::eth::genesisInfo(Network _n)
         return c_genesisInfoExperimentalTransitionTest;
     case Network::ConstantinopleFixTest:
         return c_genesisInfoConstantinopleFixTest;
+    case Network::IstanbulTransitionTest:
+        return c_genesisInfoIstanbulTransitionTest;
 
 
     //Transition test genesis
@@ -108,6 +111,7 @@ h256 const& dev::eth::genesisStateRoot(Network _n)
     case Network::ByzantiumTest:
     case Network::ConstantinopleTest:
     case Network::ConstantinopleFixTest:
+    case Network::IstanbulTransitionTest:
     case Network::ExperimentalTransitionTest:
         return c_genesisDefaultStateRoot;
     default:

--- a/libethashseal/GenesisInfo.h
+++ b/libethashseal/GenesisInfo.h
@@ -67,6 +67,8 @@ enum class Network
     ConstantinopleNoProofTest = 82,
     /// Byzantium + Constantinople + ConstantinopleFix active from block 0
     ConstantinopleFixTest = 83,
+    /// ConstantinopleFixTest + Istanbul active from block 2
+    IstanbulTransitionTest = 84,
 
     // TransitionTest networks
     FrontierToHomesteadAt5 = 100,

--- a/libethashseal/genesis/test/istanbulTransitionTest.cpp
+++ b/libethashseal/genesis/test/istanbulTransitionTest.cpp
@@ -1,0 +1,54 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#include "../../GenesisInfo.h"
+
+static std::string const c_genesisInfoIstanbulTransitionTest = std::string() +
+R"E(
+{
+    "sealEngine": "NoProof",
+    "params": {
+        "accountStartNonce": "0x00",
+        "maximumExtraDataSize": "0x20",
+        "homesteadForkBlock": "0x00",
+        "EIP150ForkBlock": "0x00",
+        "EIP158ForkBlock": "0x00",
+        "byzantiumForkBlock": "0x00",
+        "constantinopleForkBlock": "0x00",
+        "constantinopleFixForkBlock": "0x00",
+        "istanbulForkBlock": "0x02",
+        "minGasLimit": "0x1388",
+        "maxGasLimit": "7fffffffffffffff",
+        "tieBreakingGas": false,
+        "gasLimitBoundDivisor": "0x0400",
+        "minimumDifficulty": "0x020000",
+        "difficultyBoundDivisor": "0x0800",
+        "durationLimit": "0x0d",
+        "blockReward": "0x4563918244F40000",
+        "networkID" : "0x1",
+        "chainID": "0x01",
+        "allowFutureBlocks" : true
+    },
+    "genesis": {
+        "nonce": "0x0000000000000042",
+        "difficulty": "0x020000",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "author": "0x0000000000000000000000000000000000000000",
+        "timestamp": "0x00",
+        "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+        "gasLimit": "0x1388"
+    },
+    "accounts": {
+        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
+        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
+        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
+        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
+        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
+        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
+        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
+        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product"} }
+    }
+}
+)E";

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -96,6 +96,7 @@ public:
     u256 constantinopleFixForkBlock = c_infiniteBlockNumber;
     u256 daoHardforkBlock = c_infiniteBlockNumber;
     u256 experimentalForkBlock = c_infiniteBlockNumber;
+    u256 istanbulForkBlock = c_infiniteBlockNumber;
     int chainID = 0;    // Distinguishes different chains (mainnet, Ropsten, etc).
     int networkID = 0;  // Distinguishes different sub protocols.
 

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -107,6 +107,7 @@ ChainParams ChainParams::loadConfig(
     setOptionalU256Parameter(cp.eWASMForkBlock, c_eWASMForkBlock);
     setOptionalU256Parameter(cp.constantinopleForkBlock, c_constantinopleForkBlock);
     setOptionalU256Parameter(cp.constantinopleFixForkBlock, c_constantinopleFixForkBlock);
+    setOptionalU256Parameter(cp.istanbulForkBlock, c_istanbulForkBlock);
     setOptionalU256Parameter(cp.daoHardforkBlock, c_daoHardforkBlock);
     setOptionalU256Parameter(cp.experimentalForkBlock, c_experimentalForkBlock);
     setOptionalU256Parameter(cp.minimumDifficulty, c_minimumDifficulty);

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -61,6 +61,7 @@ string const c_byzantiumForkBlock = "byzantiumForkBlock";
 string const c_eWASMForkBlock = "eWASMForkBlock";
 string const c_constantinopleForkBlock = "constantinopleForkBlock";
 string const c_constantinopleFixForkBlock = "constantinopleFixForkBlock";
+string const c_istanbulForkBlock = "istanbulForkBlock";
 string const c_experimentalForkBlock = "experimentalForkBlock";
 string const c_accountStartNonce = "accountStartNonce";
 string const c_maximumExtraDataSize = "maximumExtraDataSize";

--- a/libethereum/ValidationSchemes.h
+++ b/libethereum/ValidationSchemes.h
@@ -60,6 +60,7 @@ extern std::string const c_byzantiumForkBlock;
 extern std::string const c_eWASMForkBlock;
 extern std::string const c_constantinopleForkBlock;
 extern std::string const c_constantinopleFixForkBlock;
+extern std::string const c_istanbulForkBlock;
 extern std::string const c_experimentalForkBlock;
 extern std::string const c_accountStartNonce;
 extern std::string const c_maximumExtraDataSize;


### PR DESCRIPTION
Extracted from #5640.

1. Support for `istanbulForkBlock` in config.
2. `IstanbulTransitionTest` config to be used in tests.