### PR TITLE
Remove devcore from aleth-interpreter dependencies

### DIFF
--- a/libaleth-interpreter/CMakeLists.txt
+++ b/libaleth-interpreter/CMakeLists.txt
@@ -11,13 +11,23 @@ set(
     VMConfig.h
     VMOpt.cpp
 )
+
+set(
+    dependencies
+    aleth-buildinfo
+    ethash::ethash
+    evmc::evmc
+    evmc::instructions
+    Boost::boost
+)
+
 add_library(aleth-interpreter STATIC ${sources})
-target_link_libraries(aleth-interpreter PRIVATE devcore aleth-buildinfo evmc::evmc evmc::instructions)
+target_link_libraries(aleth-interpreter PRIVATE ${dependencies})
 
 if(ALETH_INTERPRETER_SHARED)
     # Build aleth-interpreter additionally as a shared library to include it in the package
     add_library(aleth-interpreter-shared SHARED ${sources})
-    target_link_libraries(aleth-interpreter-shared PRIVATE devcore aleth-buildinfo evmc::evmc evmc::instructions)
+    target_link_libraries(aleth-interpreter-shared PRIVATE ${dependencies})
     set_target_properties(aleth-interpreter-shared PROPERTIES OUTPUT_NAME aleth-interpreter)
     install(TARGETS aleth-interpreter-shared EXPORT alethTargets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -445,7 +445,9 @@ void VM::interpretCases()
 
             uint64_t inOff = (uint64_t)m_SP[0];
             uint64_t inSize = (uint64_t)m_SP[1];
-            m_SPP[0] = (u256)sha3(bytesConstRef(m_mem.data() + inOff, inSize));
+
+            const auto h = ethash::keccak256(m_mem.data() + inOff, inSize);
+            m_SPP[0] = static_cast<u256>(h256{h.bytes, h256::ConstructFromPointer});
         }
         NEXT
 


### PR DESCRIPTION
This should make building aleth-interpreter only much easier. We will not need to build devcore library but also probably we will not need to link boost_system.