### PR TITLE
interpreter: Fix call depth handling in CALLs

### DIFF
--- a/libaleth-interpreter/VMCalls.cpp
+++ b/libaleth-interpreter/VMCalls.cpp
@@ -258,6 +258,7 @@ bool VM::caseCallSetup(evmc_message& o_msg, bytesRef& o_output)
     m_runGas = o_msg.gas;
     updateIOGas();
 
+    o_msg.depth = m_message->depth + 1;
     o_msg.destination = destination;
     o_msg.sender = m_message->destination;
     o_msg.input_data = m_mem.data() + size_t(inputOffset);

--- a/libevm/ExtVMFace.cpp
+++ b/libevm/ExtVMFace.cpp
@@ -202,6 +202,7 @@ evmc::result EvmCHost::create(evmc_message const& _msg) noexcept
 evmc::result EvmCHost::call(evmc_message const& _msg) noexcept
 {
     assert(_msg.gas >= 0 && "Invalid gas value");
+    assert(_msg.depth == static_cast<int>(m_extVM.depth) + 1);
 
     // Handle CREATE separately.
     if (_msg.kind == EVMC_CREATE || _msg.kind == EVMC_CREATE2)


### PR DESCRIPTION
Fixes an issue in aleth-interpreter where for call the depth is not increased.
The additional assert now checks if the depth is the same as in ExtVM (will cause a lot of state test failures if the fix is not applied).