### PR TITLE
Distinguish between INVALID opcode and unknown opcodes in aleth-interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - Fixed: [#5644](https://github.com/ethereum/aleth/pull/5644) Avoid attempting to sync with disconnected peers.
 - Fixed: [#5647](https://github.com/ethereum/aleth/pull/5647) test_importRawBlock RPC method correctly fails in case of import failure.
 - Fixed: [#5664](https://github.com/ethereum/aleth/pull/5664) Behavior in corner case tests about touching empty Precompiles now agrees with geth's results.
+- Fixed: [#5662](https://github.com/ethereum/aleth/pull/5662) Correct depth value when aleth-interpreter invokes `evmc_host_interface::call` callback.
+- Fixed: [#5666](https://github.com/ethereum/aleth/pull/5666) aleth-interpreter returns `EVMC_INVALID_INSTRUCTION` when `INVALID` opcode is encountered and `EVMC_UNKNOWN_INSTRUCTION` for undefined opcodes.
 
 ## [1.6.0] - 2019-04-16
 

--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -59,6 +59,10 @@ evmc_result execute(evmc_instance* _instance, evmc_context* _context, evmc_revis
         result.gas_left = vm->m_io_gas;
         output = ex.output();  // This moves the output from the exception!
     }
+    catch (dev::eth::InvalidInstruction const&)
+    {
+        result.status_code = EVMC_INVALID_INSTRUCTION;
+    }
     catch (dev::eth::BadInstruction const&)
     {
         result.status_code = EVMC_UNDEFINED_INSTRUCTION;
@@ -1416,7 +1420,10 @@ void VM::interpretCases()
         CASE(INVALID)
         DEFAULT
         {
-            throwBadInstruction();
+            if (m_OP == Instruction::INVALID)
+                throwInvalidInstruction();
+            else
+                throwBadInstruction();
         }
     }
     WHILE_CASES

--- a/libaleth-interpreter/VM.h
+++ b/libaleth-interpreter/VM.h
@@ -134,6 +134,7 @@ private:
     const evmc_tx_context& getTxContext();
 
     void throwOutOfGas();
+    void throwInvalidInstruction();
     void throwBadInstruction();
     void throwBadJumpDestination();
     void throwBadStack(int _removed, int _added);

--- a/libaleth-interpreter/VMCalls.cpp
+++ b/libaleth-interpreter/VMCalls.cpp
@@ -44,6 +44,11 @@ void VM::throwOutOfGas()
     BOOST_THROW_EXCEPTION(OutOfGas());
 }
 
+void VM::throwInvalidInstruction()
+{
+    BOOST_THROW_EXCEPTION(InvalidInstruction());
+}
+
 void VM::throwBadInstruction()
 {
     BOOST_THROW_EXCEPTION(BadInstruction());

--- a/libevm/VMFace.h
+++ b/libevm/VMFace.h
@@ -27,6 +27,7 @@ namespace eth
 
 struct VMException: Exception {};
 #define ETH_SIMPLE_EXCEPTION_VM(X) struct X: VMException { const char* what() const noexcept override { return #X; } }
+ETH_SIMPLE_EXCEPTION_VM(InvalidInstruction);
 ETH_SIMPLE_EXCEPTION_VM(BadInstruction);
 ETH_SIMPLE_EXCEPTION_VM(BadJumpDestination);
 ETH_SIMPLE_EXCEPTION_VM(OutOfGas);


### PR DESCRIPTION
This fixes the failure of `evm.invalid` test, which expects `EVMC_INVALID_INSTRUCTION` to be returned for `INVALID` (`0xfe`) opcode and `EVMC_UNKNOWN_INSTRUCTION` for all not defined opcodes.
```
[ RUN      ] evm.invalid
/home/andrei/dev/evmone/test/unittests/evm_test.cpp:668: Failure
Expected equality of these values:
  result.status_code
    Which is: 5
  EVMC_INVALID_INSTRUCTION
    Which is: 4
[  FAILED  ] evm.invalid (0 ms)
```