### PR TITLE
testeth: compress large state data into hash

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -275,6 +275,21 @@ void ChainBranch::resetBlockchain()
     dev::test::TestBlockChain::s_sealEngineNetwork = s_tempBlockchainNetwork;
 }
 
+bool isSmallState(State const& _state)
+{
+    if (_state.addresses().size() > 20)
+        return false;
+    size_t totalSize = 0;
+    for (auto const& accAddr : _state.addresses())
+    {
+        totalSize += _state.codeSize(accAddr.first) * 2;         // each byte represented by 2 chars
+        totalSize += _state.storage(accAddr.first).size() * 64;  // potentially expensive operation
+        if (totalSize > 1024000)                                 // 1MB
+            return false;
+    }
+    return true;
+}
+
 json_spirit::mObject fillBCTest(json_spirit::mObject const& _input, bool _allowInvalidBlocks)
 {
     json_spirit::mObject output;
@@ -471,7 +486,11 @@ json_spirit::mObject fillBCTest(json_spirit::mObject const& _input, bool _allowI
     }
 
     output["blocks"] = blArray;
-    output["postState"] = fillJsonWithState(testChain.topBlock().state());
+
+    if (Options::get().fullstate || isSmallState(testChain.topBlock().state()))
+        output["postState"] = fillJsonWithState(testChain.topBlock().state());
+    else
+        output["postState"] = toHexPrefixed(testChain.topBlock().blockHeader().stateRoot());
     output["lastblockhash"] = toHexPrefixed(testChain.topBlock().blockHeader().hash(WithSeal));
 
     //make all values hex in pre section
@@ -628,9 +647,24 @@ void testBCTest(json_spirit::mObject const& _o)
 
     State postState(State::Null); //Compare post states
     BOOST_REQUIRE((_o.count("postState") > 0));
-    ImportTest::importState(_o.at("postState").get_obj(), postState);
-    ImportTest::compareStates(postState, testChain.topBlock().state());
-    ImportTest::compareStates(postState, blockchain.topBlock().state());
+    if (_o.at("postState").type() == json_spirit::Value_type::obj_type)
+    {
+        ImportTest::importState(_o.at("postState").get_obj(), postState);
+        ImportTest::compareStates(postState, testChain.topBlock().state());
+        ImportTest::compareStates(postState, blockchain.topBlock().state());
+    }
+    else
+    {
+        // Attempt to read hash instead of the full state
+        BOOST_REQUIRE(_o.at("postState").type() == json_spirit::Value_type::str_type);
+        auto postHash = h256{_o.at("postState").get_str()};
+        string message = testName +
+                         "Final StateRoot is different! (Look at expect section in the test /src "
+                         "Filler file, or run the test generation with --fullstate flag to get the "
+                         "full post state.";
+        BOOST_CHECK_MESSAGE(postHash == testChain.topBlock().state().rootHash(), message);
+        BOOST_CHECK_MESSAGE(postHash == blockchain.topBlock().state().rootHash(), message);
+    }
 }
 
 bigint calculateMiningReward(u256 const& _blNumber, u256 const& _unNumber1, u256 const& _unNumber2, SealEngineFace const& _sealEngine)

--- a/test/tools/libtesteth/Options.cpp
+++ b/test/tools/libtesteth/Options.cpp
@@ -71,7 +71,7 @@ void printHelp()
     cout << setw(35) << "--createRandomTest <PathToOptions.json> " << setw(25) << "Use following options file for random code generation\n";
     cout << setw(35) << "--seed <uint>" << setw(25) << "Define a seed for random test\n";
     cout << setw(35) << "--options <PathTo.json>" << setw(25) << "Use following options file for random code generation\n";
-    //cout << setw(30) << "--fulloutput" << setw(25) << "Disable address compression in the output field\n";
+    cout << setw(30) << "--fullstate" << setw(25) << "Do not compress large states to hash\n";
     cout << setw(35) << "--db <name> (=memorydb)" << setw(25) << "Use the supplied database for the block and state databases. Valid options: leveldb, rocksdb, memorydb\n";
     cout << setw(35) << "--help" << setw(25) << "Display list of command arguments\n";
     cout << setw(35) << "--version" << setw(25) << "Display build information\n";
@@ -237,8 +237,8 @@ Options::Options(int argc, const char** argv)
             singleTestNet = std::string{argv[++i]};
             ImportTest::checkAllowedNetwork(singleTestNet);
         }
-        else if (arg == "--fulloutput")
-            fulloutput = true;
+        else if (arg == "--fullstate")
+            fullstate = true;
         else if (arg == "--verbosity")
         {
             throwIfNoArgumentFollows();

--- a/test/tools/libtesteth/Options.h
+++ b/test/tools/libtesteth/Options.h
@@ -44,7 +44,7 @@ public:
     bool exectimelog = false; ///< Print execution time for each test suite
     std::string rCurrentTestSuite; ///< Remember test suite before boost overwrite (for random tests)
     bool statediff = false;///< Fill full post state in General tests
-    bool fulloutput = false;///< Replace large output to just it's length
+    bool fullstate = false;        ///< Replace large state output to it's hash
     bool createRandomTest = false; ///< Generate random test
     boost::optional<uint64_t> randomTestSeed; ///< Define a seed for random test
     bool jsontrace = false; ///< Vmtrace to stdout in json format


### PR DESCRIPTION
do not print a megabyte long states to the tests. use hashing instead. 