### PR TITLE
Initiate p2p disconnect when all capabilities are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Changed: [#5632](https://github.com/ethereum/aleth/pull/5632) RocksDB support is disabled by default. Enable with `-DROCKSB=ON` CMake option.
 - Changed: [#5648](https://github.com/ethereum/aleth/pull/5648) `BlockChainTests` suite is split into `BlockChainTests/ValidBlocks` and `BlockChainTests/InvalidBlocks`.
 - Changed: [#5678](https://github.com/ethereum/aleth/pull/5678) Enable optimizer in aleth-interpreter by default.
+- Changed: [#5675](https://github.com/ethereum/aleth/pull/5675) Disconnect from peer when syncing is disabled for peer.
 - Removed: [#5631](https://github.com/ethereum/aleth/pull/5631) Removed PARANOID build option.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -298,7 +298,7 @@ void Session::drop(DisconnectReason _reason)
 
 void Session::disconnect(DisconnectReason _reason)
 {
-    cnetdetails << "Disconnecting (our reason: " << reasonOf(_reason) << ") from " << m_logSuffix;
+    clog(VerbosityTrace, "p2pcap") << "Disconnecting (our reason: " << reasonOf(_reason) << ") from " << m_logSuffix;
 
     if (m_socket->ref().is_open())
     {
@@ -442,6 +442,11 @@ void Session::disableCapability(std::string const& _capabilityName, std::string 
 {
     cnetlog << "Disabling capability '" << _capabilityName << "'. Reason: " << _problem << " " << m_logSuffix;
     m_disabledCapabilities.insert(_capabilityName);
+    if (m_disabledCapabilities.size() == m_capabilities.size())
+    {
+        cnetlog << "All capabilities disabled. Disconnecting session.";
+        disconnect(DisconnectReason::UselessPeer);
+    }
 }
 
 boost::optional<unsigned> Session::capabilityOffset(std::string const& _capabilityName) const


### PR DESCRIPTION
Fix #5674 

Send out a p2p capability disconnect packet when all capabilities are disabled. Also log the outgoing Disconnect p2p capability packet to the `p2pcap `logger rather than the `net ` logger.