### PR TITLE
Cap max incoming new block hashes at c_maxIncomingNewHashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Changed: [#5648](https://github.com/ethereum/aleth/pull/5648) `BlockChainTests` suite is split into `BlockChainTests/ValidBlocks` and `BlockChainTests/InvalidBlocks`.
 - Changed: [#5678](https://github.com/ethereum/aleth/pull/5678) Enable optimizer in aleth-interpreter by default.
 - Changed: [#5675](https://github.com/ethereum/aleth/pull/5675) Disconnect from peer when syncing is disabled for peer.
+- Changed: [#5676](https://github.com/ethereum/aleth/pull/5676) When receiving large batches of new block hashes, process up to 1024 hashes instead of disabling the peer.
 - Removed: [#5631](https://github.com/ethereum/aleth/pull/5631) Removed PARANOID build option.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -760,8 +760,9 @@ bool EthereumCapability::interpretCapabilityPacket(
 
             if (itemCount > c_maxIncomingNewHashes)
             {
-                disablePeer(_peerID, "Too many new hashes");
-                break;
+                LOG(m_logger) << "Received too many hashes (" << itemCount << ") from " << _peerID
+                              << ", only processing first " << c_maxIncomingNewHashes << " hashes";
+                itemCount = c_maxIncomingNewHashes;
             }
 
             vector<pair<h256, u256>> hashes(itemCount);


### PR DESCRIPTION
Fix #5677 

When we receive a NewBlockHashes ethereum capability packet which contains more hashes than `c_maxIncomingNewHashes`, process the first `c_maxIncomingNewHashes` hashes rather than disabling the peer. 

This bring's Aleth's behavior in line with Parity's (and I suspect Geth's as well). 

Parity's processing of the NewBlockHashes packet is here: https://github.com/paritytech/parity-ethereum/blob/7f707fa524baaaccac499d69f9e452b380c31ffa/ethcore/sync/src/chain/handler.rs#L219-L288