### PR TITLE
Use metrics of the requested revision in aleth-interpreter

### DIFF
--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -244,7 +244,7 @@ void VM::logGasMem()
 void VM::fetchInstruction()
 {
     m_OP = Instruction(m_code[m_PC]);
-    auto const metric = c_metrics[static_cast<size_t>(m_OP)];
+    auto const metric = metrics(m_rev)[static_cast<size_t>(m_OP)];
     adjustStack(metric.num_stack_arguments, metric.num_stack_returned_items);
 
     // FEES...

--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -247,7 +247,7 @@ void VM::logGasMem()
 void VM::fetchInstruction()
 {
     m_OP = Instruction(m_code[m_PC]);
-    auto const metric = metrics(m_rev)[static_cast<size_t>(m_OP)];
+    auto const metric = (*m_metrics)[static_cast<size_t>(m_OP)];
     adjustStack(metric.num_stack_arguments, metric.num_stack_returned_items);
 
     // FEES...
@@ -273,6 +273,7 @@ owning_bytes_ref VM::exec(evmc_context* _context, evmc_revision _rev, const evmc
 {
     m_context = _context;
     m_rev = _rev;
+    m_metrics = &s_metrics[m_rev];
     m_message = _msg;
     m_io_gas = uint64_t(_msg->gas);
     m_PC = 0;

--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -127,6 +127,9 @@ extern "C" evmc_instance* evmc_create_interpreter() noexcept
         nullptr,  // set_tracer
         nullptr,  // set_option
     };
+    static bool metricsInited = dev::eth::VM::initMetrics();
+    (void)metricsInited;
+
     return &s_instance;
 }
 

--- a/libaleth-interpreter/VM.h
+++ b/libaleth-interpreter/VM.h
@@ -63,6 +63,8 @@ struct VMSchedule
 class VM
 {
 public:
+    static bool initMetrics();
+
     VM() = default;
 
     owning_bytes_ref exec(evmc_context* _context, evmc_revision _rev, const evmc_message* _msg,
@@ -75,13 +77,11 @@ private:
     evmc_message const* m_message = nullptr;
     boost::optional<evmc_tx_context> m_tx_context;
 
-    static void initMetrics(evmc_revision _revision);
     static std::array<evmc_instruction_metrics, 256> const& metrics(evmc_revision _revision)
     {
         return s_metrics[_revision];
     }
     static std::array<std::array<evmc_instruction_metrics, 256>, EVMC_MAX_REVISION + 1> s_metrics;
-    static std::array<std::once_flag, EVMC_MAX_REVISION + 1> s_metricsInitialized;
     static u256 exp256(u256 _base, u256 _exponent);
     void copyCode(int);
     typedef void (VM::*MemFnPtr)();

--- a/libaleth-interpreter/VM.h
+++ b/libaleth-interpreter/VM.h
@@ -75,8 +75,13 @@ private:
     evmc_message const* m_message = nullptr;
     boost::optional<evmc_tx_context> m_tx_context;
 
-    static std::array<evmc_instruction_metrics, 256> c_metrics;
-    static void initMetrics();
+    static void initMetrics(evmc_revision _revision);
+    static std::array<evmc_instruction_metrics, 256> const& metrics(evmc_revision _revision)
+    {
+        return s_metrics[_revision];
+    }
+    static std::array<std::array<evmc_instruction_metrics, 256>, EVMC_MAX_REVISION + 1> s_metrics;
+    static std::array<std::once_flag, EVMC_MAX_REVISION + 1> s_metricsInitialized;
     static u256 exp256(u256 _base, u256 _exponent);
     void copyCode(int);
     typedef void (VM::*MemFnPtr)();

--- a/libaleth-interpreter/VM.h
+++ b/libaleth-interpreter/VM.h
@@ -74,13 +74,9 @@ public:
 private:
     evmc_context* m_context = nullptr;
     evmc_revision m_rev = EVMC_FRONTIER;
+    std::array<evmc_instruction_metrics, 256>* m_metrics = nullptr;
     evmc_message const* m_message = nullptr;
     boost::optional<evmc_tx_context> m_tx_context;
-
-    static std::array<evmc_instruction_metrics, 256> const& metrics(evmc_revision _revision)
-    {
-        return s_metrics[_revision];
-    }
     static std::array<std::array<evmc_instruction_metrics, 256>, EVMC_MAX_REVISION + 1> s_metrics;
     static u256 exp256(u256 _base, u256 _exponent);
     void copyCode(int);


### PR DESCRIPTION
Fixes the problem described in https://github.com/ethereum/aleth/issues/5653#issuecomment-510605376, makes this change in test not needed https://github.com/ethereum/evmone/pull/91

~~I came up here with (maybe a bit tricky) way to lazy-initialize metrics array for needed revision using `std::once_flag`. But I think it looks not so complicated.~~ Settled upon a simpler non-lazy approach.