### PR TITLE
Replace optimizer-special opcodes with 0xaf instead of INVALID.

### DIFF
--- a/libaleth-interpreter/VMOpt.cpp
+++ b/libaleth-interpreter/VMOpt.cpp
@@ -72,7 +72,7 @@ void VM::optimize()
         )
         {
             TRACE_OP(1, pc, op);
-            m_code[pc] = (byte)Instruction::INVALID;
+            m_code[pc] = (byte)Instruction::UNDEFINED;
         }
 
         if (op == Instruction::JUMPDEST)

--- a/libevm/Instruction.h
+++ b/libevm/Instruction.h
@@ -172,6 +172,7 @@ enum class Instruction : uint8_t
     PUSHC = 0xac,  ///< push value from constant pool
     JUMPC,         ///< alter the program counter - pre-verified
     JUMPCI,        ///< conditionally alter the program counter - pre-verified
+    UNDEFINED,     ///< Replaces PUSHC/JUMPC/JUMPCI in the original code
 
     JUMPTO = 0xb0,  ///< alter the program counter to a jumpdest
     JUMPIF,         ///< conditionally alter the program counter


### PR DESCRIPTION
Follow-up to https://github.com/ethereum/aleth/pull/5666 fix.
Fixes the problem described in https://github.com/ethereum/aleth/issues/5653#issuecomment-511495461 - allows `EVMC_UNDEFINED_INSTRUCTION` to be returned when `PUSHC`/`JUMPC`/`JUMPCI` are encountered in input code.