### PR TITLE
Implement EIP-2046 Reduced gas cost for static calls made to precompiles in LegacyVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.8.0] - Unreleased
 
+- Added: [#5699](https://github.com/ethereum/aleth/pull/5699) EIP 2046: Reduced gas cost for static calls made to precompiles.
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14. 
 
 ## [1.7.0] - Unreleased

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -144,7 +144,6 @@ static const EVMSchedule IstanbulSchedule = [] {
     schedule.sloadGas = 800;
     schedule.balanceGas = 700;
     schedule.extcodehashGas = 700;
-    schedule.precompileStaticCallGas = 40;
     schedule.haveChainID = true;
     schedule.haveSelfbalance = true;
     schedule.eip2200Mode = true;
@@ -154,6 +153,7 @@ static const EVMSchedule IstanbulSchedule = [] {
 
 static const EVMSchedule BerlinSchedule = [] {
     EVMSchedule schedule = IstanbulSchedule;
+    schedule.precompileStaticCallGas = 40;
     return schedule;
 }();
 

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -47,6 +47,7 @@ struct EVMSchedule
     unsigned logTopicGas = 375;
     unsigned createGas = 32000;
     unsigned callGas = 40;
+    unsigned precompileStaticCallGas = 700;
     unsigned callStipend = 2300;
     unsigned callValueTransferGas = 9000;
     unsigned callNewAccountGas = 25000;
@@ -143,6 +144,7 @@ static const EVMSchedule IstanbulSchedule = [] {
     schedule.sloadGas = 800;
     schedule.balanceGas = 700;
     schedule.extcodehashGas = 700;
+    schedule.precompileStaticCallGas = 40;
     schedule.haveChainID = true;
     schedule.haveSelfbalance = true;
     schedule.eip2200Mode = true;

--- a/libevm/LegacyVMCalls.cpp
+++ b/libevm/LegacyVMCalls.cpp
@@ -190,13 +190,16 @@ bool LegacyVM::caseCallSetup(CallParameters *callParams, bytesRef& o_output)
     assert(callParams->valueTransfer == 0);
     assert(callParams->apparentValue == 0);
 
-    m_runGas = toInt63(m_schedule->callGas);
-
     callParams->staticCall = (m_OP == Instruction::STATICCALL || m_ext->staticCall);
+    Address const destinationAddr = asAddress(m_SP[1]);
+
+    if (callParams->staticCall && isPrecompiledContract(destinationAddr))
+        m_runGas = toInt63(m_schedule->precompileStaticCallGas);
+    else
+        m_runGas = toInt63(m_schedule->callGas);
 
     bool const haveValueArg = m_OP == Instruction::CALL || m_OP == Instruction::CALLCODE;
 
-    Address destinationAddr = asAddress(m_SP[1]);
     if (m_OP == Instruction::CALL &&
         (m_SP[2] > 0 || m_schedule->zeroValueTransferChargesNewAccountGas()) &&
         !m_ext->exists(destinationAddr))

--- a/libevm/VMFace.h
+++ b/libevm/VMFace.h
@@ -74,5 +74,11 @@ inline u256 fromAddress(Address _a)
 	return (u160)_a;
 }
 
+// Checks whether address is in the address range for precompiles according to EIP-1352
+inline bool isPrecompiledContract(Address const& _addr) noexcept
+{
+    static Address const c_maxPrecompiledAddress{0xffff};
+    return _addr <= c_maxPrecompiledAddress;
+}
 }
 }

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -782,13 +782,13 @@ public:
         BOOST_REQUIRE_EQUAL(gasBefore - gasAfter, 700 + 15);
     }
 
-    void testStaticCallCostEqualToCallBeforeIstanbul()
+    void testStaticCallCostEqualToCallBeforeBerlin()
     {
         // let r := staticcall(10000, 0x4, 0, 0, 0, 0)
         bytes code = fromHex("60006000600060006004612710fa50");
 
-        se.reset(ChainParams(genesisInfo(Network::ConstantinopleFixTest)).createSealEngine());
-        version = ConstantinopleFixSchedule.accountVersion;
+        se.reset(ChainParams(genesisInfo(Network::IstanbulTest)).createSealEngine());
+        version = IstanbulSchedule.accountVersion;
 
         ExtVM extVm(state, envInfo, *se, address, address, address, value, gasPrice, {}, ref(code),
             sha3(code), version, depth, isCreate, staticCall);
@@ -810,7 +810,7 @@ public:
         BOOST_REQUIRE_EQUAL(gasBefore - gasAfter, 700 + 15);
     }
 
-    void testStaticCallHasCorrectCostInIstanbul()
+    void testStaticCallHasCorrectCostInBerlin()
     {
         // let r := staticcall(10000, 0x4, 0, 0, 0, 0)
         bytes code = fromHex("60006000600060006004612710fa50");
@@ -841,12 +841,12 @@ public:
     Address address{KeyPair::create().address()};
     State state{0};
     std::unique_ptr<SealEngineFace> se{
-        ChainParams(genesisInfo(Network::IstanbulTest)).createSealEngine()};
+        ChainParams(genesisInfo(Network::BerlinTest)).createSealEngine()};
     EnvInfo envInfo{blockHeader, lastBlockHashes, 0, se->chainParams().chainID};
 
     u256 value = 0;
     u256 gasPrice = 1;
-    u256 version = IstanbulSchedule.accountVersion;
+    u256 version = BerlinSchedule.accountVersion;
     int depth = 0;
     bool isCreate = false;
     bool staticCall = false;
@@ -1022,14 +1022,14 @@ BOOST_AUTO_TEST_CASE(LegacyVMCallHasCorrectCost)
     testCallHasCorrectCost();
 }
 
-BOOST_AUTO_TEST_CASE(LegacyVMStaticCallCostEqualToCallBeforeIstanbul)
+BOOST_AUTO_TEST_CASE(LegacyVMStaticCallCostEqualToCallBeforeBerlin)
 {
-    testStaticCallCostEqualToCallBeforeIstanbul();
+    testStaticCallCostEqualToCallBeforeBerlin();
 }
 
-BOOST_AUTO_TEST_CASE(LegacyVMStaticCallHasCorrectCostInIstanbul)
+BOOST_AUTO_TEST_CASE(LegacyVMStaticCallHasCorrectCostInBerlin)
 {
-    testStaticCallHasCorrectCostInIstanbul();
+    testStaticCallHasCorrectCostInBerlin();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -751,6 +751,115 @@ class AlethInterpreterBalanceFixture : public BalanceFixture
 public:
     AlethInterpreterBalanceFixture() : BalanceFixture{new EVMC{evmc_create_interpreter()}} {}
 };
+
+class PrecompileCallFixture : public TestOutputHelperFixture
+{
+public:
+    explicit PrecompileCallFixture(VMFace* _vm) : vm{_vm} { state.addBalance(address, 1 * ether); }
+
+    void testCallHasCorrectCost()
+    {
+        // let r := call(10000, 0x4, 0, 0, 0, 0, 0)
+        bytes code = fromHex("600060006000600060006004612710f150");
+
+        ExtVM extVm(state, envInfo, *se, address, address, address, value, gasPrice, {}, ref(code),
+            sha3(code), version, depth, isCreate, staticCall);
+
+        bigint gasBefore;
+        bigint gasAfter;
+        auto onOp = [&gasBefore, &gasAfter](uint64_t /*steps*/, uint64_t /* PC */,
+                        Instruction _instr, bigint /*newMemSize*/, bigint /*gasCost*/, bigint _gas,
+                        VMFace const*, ExtVMFace const*) {
+            if (_instr == Instruction::CALL)
+                gasBefore = _gas;
+            else if (gasBefore != 0 && gasAfter == 0)
+                gasAfter = _gas;
+        };
+
+        vm->exec(gas, extVm, onOp);
+
+        // 700 for CALL and 15 for identity precompile with empty input
+        BOOST_REQUIRE_EQUAL(gasBefore - gasAfter, 700 + 15);
+    }
+
+    void testStaticCallCostEqualToCallBeforeIstanbul()
+    {
+        // let r := staticcall(10000, 0x4, 0, 0, 0, 0)
+        bytes code = fromHex("60006000600060006004612710fa50");
+
+        se.reset(ChainParams(genesisInfo(Network::ConstantinopleFixTest)).createSealEngine());
+        version = ConstantinopleFixSchedule.accountVersion;
+
+        ExtVM extVm(state, envInfo, *se, address, address, address, value, gasPrice, {}, ref(code),
+            sha3(code), version, depth, isCreate, staticCall);
+
+        bigint gasBefore;
+        bigint gasAfter;
+        auto onOp = [&gasBefore, &gasAfter](uint64_t /*steps*/, uint64_t /* PC */,
+                        Instruction _instr, bigint /*newMemSize*/, bigint /*gasCost*/, bigint _gas,
+                        VMFace const*, ExtVMFace const*) {
+            if (_instr == Instruction::STATICCALL)
+                gasBefore = _gas;
+            else if (gasBefore != 0 && gasAfter == 0)
+                gasAfter = _gas;
+        };
+
+        vm->exec(gas, extVm, onOp);
+
+        // 700 for STATICCALL and 15 for identity precompile with empty input
+        BOOST_REQUIRE_EQUAL(gasBefore - gasAfter, 700 + 15);
+    }
+
+    void testStaticCallHasCorrectCostInIstanbul()
+    {
+        // let r := staticcall(10000, 0x4, 0, 0, 0, 0)
+        bytes code = fromHex("60006000600060006004612710fa50");
+
+        ExtVM extVm(state, envInfo, *se, address, address, address, value, gasPrice, {}, ref(code),
+            sha3(code), version, depth, isCreate, staticCall);
+
+        bigint gasBefore;
+        bigint gasAfter;
+        auto onOp = [&gasBefore, &gasAfter](uint64_t /*steps*/, uint64_t /* PC */,
+                        Instruction _instr, bigint /*newMemSize*/, bigint /*gasCost*/, bigint _gas,
+                        VMFace const*, ExtVMFace const*) {
+            if (_instr == Instruction::STATICCALL)
+                gasBefore = _gas;
+            else if (gasBefore != 0 && gasAfter == 0)
+                gasAfter = _gas;
+        };
+
+        vm->exec(gas, extVm, onOp);
+
+        // 40 for STATICCALL and 15 for identity precompile with empty input
+        BOOST_REQUIRE_EQUAL(gasBefore - gasAfter, 40 + 15);
+    }
+
+
+    BlockHeader blockHeader{initBlockHeader()};
+    LastBlockHashes lastBlockHashes;
+    Address address{KeyPair::create().address()};
+    State state{0};
+    std::unique_ptr<SealEngineFace> se{
+        ChainParams(genesisInfo(Network::IstanbulTest)).createSealEngine()};
+    EnvInfo envInfo{blockHeader, lastBlockHashes, 0, se->chainParams().chainID};
+
+    u256 value = 0;
+    u256 gasPrice = 1;
+    u256 version = IstanbulSchedule.accountVersion;
+    int depth = 0;
+    bool isCreate = false;
+    bool staticCall = false;
+    u256 gas = 1000000;
+
+    std::unique_ptr<VMFace> vm;
+};
+
+class LegacyVMPrecompileCallFixture : public PrecompileCallFixture
+{
+public:
+    LegacyVMPrecompileCallFixture() : PrecompileCallFixture{new LegacyVM} {}
+};
 }  // namespace
 
 BOOST_FIXTURE_TEST_SUITE(LegacyVMSuite, TestOutputHelperFixture)
@@ -906,6 +1015,24 @@ BOOST_AUTO_TEST_CASE(LegacyVMSelfBalanceisInvalidBeforeIstanbul)
 }
 BOOST_AUTO_TEST_SUITE_END()
 
+BOOST_FIXTURE_TEST_SUITE(LegacyVMPrecompileCallSuite, LegacyVMPrecompileCallFixture)
+
+BOOST_AUTO_TEST_CASE(LegacyVMCallHasCorrectCost)
+{
+    testCallHasCorrectCost();
+}
+
+BOOST_AUTO_TEST_CASE(LegacyVMStaticCallCostEqualToCallBeforeIstanbul)
+{
+    testStaticCallCostEqualToCallBeforeIstanbul();
+}
+
+BOOST_AUTO_TEST_CASE(LegacyVMStaticCallHasCorrectCostInIstanbul)
+{
+    testStaticCallHasCorrectCostInIstanbul();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(AlethInterpreterSuite, TestOutputHelperFixture)


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-2046

~~Note that it puts repricing behind account versioning, i.e. reduced cost will be in effect only in contracts deployed with external transaction after Istanbul fork.~~

~~If it's decided that it should be in effect for version 0, we'll need to introduce another `EVMSchedule` ("between" current `ConstantinopleFixSchedule` and `IstanbulSchedule`)~~
Account versioning is disabled in Istanbul.