### PR TITLE
Implement EIP-1884: Repricing for trie-size-dependent opcodes in LegacyVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added: [#5640](https://github.com/ethereum/aleth/pull/5640) Support EIP-1702 Generalized Account Versioning Scheme (active only in Experimental fork.)
 - Added: [#5691](https://github.com/ethereum/aleth/pull/5691) Istanbul support: EIP-2028 Transaction data gas cost reduction.
 - Added: [#5696](https://github.com/ethereum/aleth/pull/5696) [#5708](https://github.com/ethereum/aleth/pull/5708) Istanbul support: EIP-1344 ChainID opcode.
+- Added: [#5700](https://github.com/ethereum/aleth/pull/5700) Istanbul support: EIP 1884 Repricing for trie-size-dependent opcodes.
 - Added: [#5701](https://github.com/ethereum/aleth/issues/5701) Outputs ENR text representation in admin.nodeInfo RPC.
 - Added: [#5705](https://github.com/ethereum/aleth/pull/5705) Istanbul support: EIP 1108 Reduce alt_bn128 precompile gas costs.
 - Added: [#5707](https://github.com/ethereum/aleth/pull/5707) Aleth waits for 2 seconds after sending disconnect to peer before closing socket.

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -151,6 +151,9 @@ static const EVMSchedule ConstantinopleFixSchedule = [] {
 static const EVMSchedule IstanbulSchedule = [] {
     EVMSchedule schedule = ConstantinopleFixSchedule;
     schedule.txDataNonZeroGas = 16;
+    schedule.sloadGas = 800;
+    schedule.balanceGas = 700;
+    schedule.extcodehashGas = 700;
     schedule.haveChainID = true;
     return schedule;
 }();

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -42,6 +42,7 @@ struct EVMSchedule
     bool haveCreate2 = false;
     bool haveExtcodehash = false;
     bool haveChainID = false;
+    bool haveSelfbalance = false;
     std::array<unsigned, 8> tierStepGas;
     unsigned expGas = 10;
     unsigned expByteGas = 10;
@@ -155,6 +156,7 @@ static const EVMSchedule IstanbulSchedule = [] {
     schedule.balanceGas = 700;
     schedule.extcodehashGas = 700;
     schedule.haveChainID = true;
+    schedule.haveSelfbalance = true;
     return schedule;
 }();
 

--- a/libevm/Instruction.cpp
+++ b/libevm/Instruction.cpp
@@ -75,6 +75,7 @@ static const std::map<Instruction,  InstructionInfo> c_instructionInfo =
     { Instruction::DIFFICULTY,   { "DIFFICULTY",          0,    1,  Tier::Base } },
     { Instruction::GASLIMIT,     { "GASLIMIT",            0,    1,  Tier::Base } },
     { Instruction::CHAINID,      { "CHAINID",             0,    1,  Tier::Base } },
+    { Instruction::SELFBALANCE,  { "SELFBALANCE",         0,    1,  Tier::Low } },   
     { Instruction::POP,          { "POP",                 1,    0,  Tier::Base } },
     { Instruction::MLOAD,        { "MLOAD",               1,    1,  Tier::VeryLow } },
     { Instruction::MSTORE,       { "MSTORE",              2,    0,  Tier::VeryLow } },

--- a/libevm/Instruction.h
+++ b/libevm/Instruction.h
@@ -75,13 +75,14 @@ enum class Instruction : uint8_t
     RETURNDATACOPY = 0x3e,  ///< copy data returned from previous call to memory
     EXTCODEHASH = 0x3f,     ///< get external code hash
 
-    BLOCKHASH = 0x40,  ///< get hash of most recent complete block
-    COINBASE,          ///< get the block's coinbase address
-    TIMESTAMP,         ///< get the block's timestamp
-    NUMBER,            ///< get the block's number
-    DIFFICULTY,        ///< get the block's difficulty
-    GASLIMIT,          ///< get the block's gas limit
-    CHAINID,           ///< get the network's ChainID
+    BLOCKHASH = 0x40, ///< get hash of most recent complete block
+    COINBASE,         ///< get the block's coinbase address
+    TIMESTAMP,        ///< get the block's timestamp
+    NUMBER,           ///< get the block's number
+    DIFFICULTY,       ///< get the block's difficulty
+    GASLIMIT,         ///< get the block's gas limit
+    CHAINID,          ///< get the network's ChainID
+    SELFBALANCE,      ///< get balance of the current address
 
     POP = 0x50,  ///< remove item from stack
     MLOAD,       ///< load word from memory

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -1452,6 +1452,19 @@ void LegacyVM::interpretCases()
         }
         NEXT
 
+        CASE(SELFBALANCE)
+        {
+            ON_OP();
+
+            if (!m_schedule->haveSelfbalance)
+                throwBadInstruction();
+
+            updateIOGas();
+
+            m_SPP[0] = m_ext->balance(m_ext->myAddress);
+        }
+        NEXT
+
         CASE(POP)
         {
             ON_OP();

--- a/libevm/LegacyVMConfig.h
+++ b/libevm/LegacyVMConfig.h
@@ -234,7 +234,7 @@ namespace dev
         &&DIFFICULTY,                           \
         &&GASLIMIT,                             \
         &&CHAINID,                              \
-        &&INVALID,                              \
+        &&SELFBALANCE,                          \
         &&INVALID,                              \
         &&INVALID,                              \
         &&INVALID,                              \


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-1884

~~Note that it puts repricing and `SELFBALANCE` behind account versioning, i.e. reduced costs and the new opcode will be active only in contracts deployed with external transaction after Istanbul fork.~~

~~If it's decided that it should be in effect for version 0, we'll need to introduce another `EVMSchedule` ("between" current `ConstantinopleFixSchedule` and `IstanbulSchedule`)~~
Account versioning is disabled in Istanbul.