### PR TITLE
Stop tracking sent transactions once they've been imported into the blockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fixed: [#5664](https://github.com/ethereum/aleth/pull/5664) Behavior in corner case tests about touching empty Precompiles now agrees with geth's results.
 - Fixed: [#5662](https://github.com/ethereum/aleth/pull/5662) Correct depth value when aleth-interpreter invokes `evmc_host_interface::call` callback.
 - Fixed: [#5666](https://github.com/ethereum/aleth/pull/5666) aleth-interpreter returns `EVMC_INVALID_INSTRUCTION` when `INVALID` opcode is encountered and `EVMC_UNKNOWN_INSTRUCTION` for undefined opcodes.
+- Fixed: [#5706](https://github.com/ethereum/aleth/pull/5706) Stop tracking sent transactions after they've been imported into the blockchain.
 
 ## [1.6.0] - 2019-04-16
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -565,7 +565,7 @@ void Client::onChainChanged(ImportRoute const& _ir)
         goodTransactions.push_back(t.sha3());
     }
     auto h = m_host.lock();
-    if (h && goodTransactions.size())
+    if (h)
         h->removeSentTransactions(goodTransactions);
     onNewBlocks(_ir.liveBlocks, changeds);
     if (!isMajorSyncing())

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -556,11 +556,17 @@ void Client::onChainChanged(ImportRoute const& _ir)
 //  ctrace << "onChainChanged()";
     h256Hash changeds;
     onDeadBlocks(_ir.deadBlocks, changeds);
+    vector<h256> goodTransactions;
+    goodTransactions.reserve(_ir.goodTranactions.size());
     for (auto const& t: _ir.goodTranactions)
     {
         LOG(m_loggerDetail) << "Safely dropping transaction " << t.sha3();
         m_tq.dropGood(t);
+        goodTransactions.push_back(t.sha3());
     }
+    auto h = m_host.lock();
+    if (h && goodTransactions.size())
+        h->removeSentTransactions(goodTransactions);
     onNewBlocks(_ir.liveBlocks, changeds);
     if (!isMajorSyncing())
         resyncStateFromChain();

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -937,6 +937,16 @@ void EthereumCapability::disablePeer(NodeID const& _peerID, std::string const& _
     m_host->disableCapability(_peerID, name(), _problem);
 }
 
+void EthereumCapability::removeSentTransactions(std::vector<h256> const& _txHashes)
+{
+    // Function can be called from the client thread so we need to ensure that
+    // m_transactionsSent modifications occur on the network thread
+    m_host->postWork([_txHashes, this]() {
+        for (auto const& txHash : _txHashes)
+            m_transactionsSent.erase(txHash);
+    });
+}
+
 EthereumPeer const& EthereumCapability::peer(NodeID const& _peerID) const
 {
     return const_cast<EthereumCapability*>(this)->peer(_peerID);

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -939,12 +939,15 @@ void EthereumCapability::disablePeer(NodeID const& _peerID, std::string const& _
 
 void EthereumCapability::removeSentTransactions(std::vector<h256> const& _txHashes)
 {
-    // Function can be called from the client thread so we need to ensure that
-    // m_transactionsSent modifications occur on the network thread
-    m_host->postWork([_txHashes, this]() {
-        for (auto const& txHash : _txHashes)
-            m_transactionsSent.erase(txHash);
-    });
+    if (!_txHashes.empty())
+    {
+        // Function can be called from the client thread so we need to ensure that
+        // m_transactionsSent modifications occur on the network thread
+        m_host->postWork([_txHashes, this]() {
+            for (auto const& txHash : _txHashes)
+                m_transactionsSent.erase(txHash);
+        });
+    }
 }
 
 EthereumPeer const& EthereumCapability::peer(NodeID const& _peerID) const

--- a/libethereum/EthereumCapability.h
+++ b/libethereum/EthereumCapability.h
@@ -136,6 +136,12 @@ public:
     EthereumPeer& peer(NodeID const& _peerID);
     void disablePeer(NodeID const& _peerID, std::string const& _problem);
 
+    /// Remove the supplied transaction hashes from the sent transactions list. Done when
+    /// the transactions have been confirmed to be a part of the blockchain so we no longer
+    /// need to explicitly track them to prevent sending them out to peers. Can be called safely
+    /// from any thread.
+    void removeSentTransactions(std::vector<h256> const& _txHashes);
+
 private:
     static char const* const c_stateNames[static_cast<int>(SyncState::Size)];
     static constexpr std::chrono::milliseconds c_backgroundWorkInterval{1000};


### PR DESCRIPTION
Fix #5686 