### PR TITLE
[WIP] fix testeth stateTests transaction execution on expectSections

### DIFF
--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -73,7 +73,7 @@ private:
     using ExecOutput = std::pair<eth::ExecutionResult, eth::TransactionReceipt>;
 	std::tuple<eth::State, ExecOutput, eth::ChangeLog> executeTransaction(eth::Network const _sealEngineNetwork, eth::EnvInfo const& _env, eth::State const& _preState, eth::Transaction const& _tr);
     bool findExpectSectionForTransaction(
-        transactionToExecute const& _tr, eth::Network const& _net, bool _isFilling);
+        transactionToExecute const& _tr, eth::Network const& _net, bool _isFilling) const;
 
     std::unique_ptr<eth::LastBlockHashesFace const> m_lastBlockHashes;
 	std::unique_ptr<eth::EnvInfo> m_envInfo;

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -69,10 +69,13 @@ public:
 	eth::State m_statePost;
 
 private:
-	using ExecOutput = std::pair<eth::ExecutionResult, eth::TransactionReceipt>;
+    struct transactionToExecute;
+    using ExecOutput = std::pair<eth::ExecutionResult, eth::TransactionReceipt>;
 	std::tuple<eth::State, ExecOutput, eth::ChangeLog> executeTransaction(eth::Network const _sealEngineNetwork, eth::EnvInfo const& _env, eth::State const& _preState, eth::Transaction const& _tr);
+    bool findExpectSectionForTransaction(
+        transactionToExecute const& _tr, eth::Network const& _net, bool _isFilling);
 
-	std::unique_ptr<eth::LastBlockHashesFace const> m_lastBlockHashes;
+    std::unique_ptr<eth::LastBlockHashesFace const> m_lastBlockHashes;
 	std::unique_ptr<eth::EnvInfo> m_envInfo;
 	eth::Transaction m_transaction;
 


### PR DESCRIPTION
Depends on: 
https://github.com/ethereum/aleth/pull/5618
https://github.com/ethereum/aleth/pull/5714

fix testeth statetests transaction execution on expect sections


This is the aleth version I use with retesteth. 
I've noticed that testeth generate transactions on expect sections that are not described. The sorting was done only on networks. So if transaction has gasIndex  0,  but there was no expect section with gasIndex0 it would still generate the test with it, leading to unwanted transaction being executed in some tests. 


