### PR TITLE
Upgrade Hunter to 0.23.211 to enable use of Visual Studio 2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Changed: [#5678](https://github.com/ethereum/aleth/pull/5678) Enable optimizer in aleth-interpreter by default.
 - Changed: [#5675](https://github.com/ethereum/aleth/pull/5675) Disconnect from peer when syncing is disabled for peer.
 - Changed: [#5676](https://github.com/ethereum/aleth/pull/5676) When receiving large batches of new block hashes, process up to 1024 hashes instead of disabling the peer.
+- Changed: [#5719](https://github.com/ethereum/aleth/pull/5719) Enable support for Visual Studio 2017 on Windows.
 - Removed: [#5631](https://github.com/ethereum/aleth/pull/5631) Removed PARANOID build option.
 - Fixed: [#5562](https://github.com/ethereum/aleth/pull/5562) Don't send header request messages to peers that haven't sent us Status yet.
 - Fixed: [#5581](https://github.com/ethereum/aleth/pull/5581) Fixed finding neighbour nodes in Discovery.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ option(HUNTER_RUN_UPLOAD "Upload binaries to the cache server" ${run_upload})
 
 include(HunterGate)
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.178.tar.gz"
-    SHA1 "3511e5f2382d43cfa92b7f2a6f316fbdd1b81a92"
+    URL "https://github.com/ruslo/hunter/archive/v0.23.211.tar.gz"
+    SHA1 "c022f0c2480e835a6bafdd734035ec2071b51897"
     LOCAL
 )
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,13 @@ cmake ..               # Configure the project.
 cmake --build .        # Build all default targets.
 ```
 
-On **Windows** Visual Studio 2015 is required. You should generate Visual Studio
-solution file (.sln) for 64-bit architecture by adding
-`-G "Visual Studio 14 2015 Win64"` argument to the CMake configure command.
+On **Windows** we support up to Visual Studio 2017. You should generate a Visual Studio solution file (.sln) for the 64-bit architecture by adding
+`-G "Visual Studio 15 2017 Win64"` argument to the CMake configuration command.
 After configuration is completed, the `aleth.sln` can be found in the
 `build` directory.
 
 ```shell
-cmake .. -G "Visual Studio 14 2015 Win64"
+cmake .. -G "Visual Studio 15 2017 Win64"
 ```
 #### Common Issues Building on Windows
 ##### LINK : fatal error LNK1158: cannot run 'rc.exe'


### PR DESCRIPTION
Fix #5516 

Upgrade Hunter to get YAML-CPP fix which enables use of Visual Studio
2017 to build Aleth. Notable package updates are:
* YAML-CPP (0.6.2-p0 -> 0.6.2-p1)
* ethash (0.4.4 -> 0.5.0)