### PR TITLE
Implement EIP-1884: Repricing for trie-size-dependent opcodes in aleth-interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Added: [#5640](https://github.com/ethereum/aleth/pull/5640) Support EIP-1702 Generalized Account Versioning Scheme (active only in Experimental fork.)
 - Added: [#5691](https://github.com/ethereum/aleth/pull/5691) Istanbul support: EIP-2028 Transaction data gas cost reduction.
 - Added: [#5696](https://github.com/ethereum/aleth/pull/5696) [#5708](https://github.com/ethereum/aleth/pull/5708) Istanbul support: EIP-1344 ChainID opcode.
-- Added: [#5700](https://github.com/ethereum/aleth/pull/5700) Istanbul support: EIP 1884 Repricing for trie-size-dependent opcodes.
+- Added: [#5700](https://github.com/ethereum/aleth/pull/5700) [#5725](https://github.com/ethereum/aleth/pull/5725) Istanbul support: EIP 1884 Repricing for trie-size-dependent opcodes.
 - Added: [#5701](https://github.com/ethereum/aleth/issues/5701) Outputs ENR text representation in admin.nodeInfo RPC.
 - Added: [#5705](https://github.com/ethereum/aleth/pull/5705) Istanbul support: EIP 1108 Reduce alt_bn128 precompile gas costs.
 - Added: [#5707](https://github.com/ethereum/aleth/pull/5707) Aleth waits for 2 seconds after sending disconnect to peer before closing socket.

--- a/libaleth-interpreter/VM.cpp
+++ b/libaleth-interpreter/VM.cpp
@@ -1164,6 +1164,19 @@ void VM::interpretCases()
         }
         NEXT
 
+        CASE(SELFBALANCE)
+        {
+            ON_OP();
+
+            if (m_rev < EVMC_ISTANBUL)
+                throwBadInstruction();
+
+            updateIOGas();
+
+            m_SPP[0] = fromEvmC(m_context->host->get_balance(m_context, &m_message->destination));
+        }
+        NEXT
+
         CASE(POP)
         {
             ON_OP();

--- a/libaleth-interpreter/VMConfig.h
+++ b/libaleth-interpreter/VMConfig.h
@@ -223,7 +223,7 @@ namespace eth
         &&DIFFICULTY,                           \
         &&GASLIMIT,                             \
         &&CHAINID,                              \
-        &&INVALID,                              \
+        &&SELFBALANCE,                          \
         &&INVALID,                              \
         &&INVALID,                              \
         &&INVALID,                              \

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -655,6 +655,12 @@ public:
     LegacyVMSelfBalanceFixture() : SelfBalanceFixture{new LegacyVM} {}
 };
 
+class AlethInterpreterSelfBalanceFixture : public SelfBalanceFixture
+{
+public:
+    AlethInterpreterSelfBalanceFixture() : SelfBalanceFixture{new EVMC{evmc_create_interpreter()}}
+    {}
+};
 }  // namespace
 
 BOOST_FIXTURE_TEST_SUITE(LegacyVMSuite, TestOutputHelperFixture)
@@ -1050,6 +1056,19 @@ BOOST_AUTO_TEST_CASE(AlethInterpreterChainIDworksInIstanbul)
 BOOST_AUTO_TEST_CASE(AlethInterpreterChainIDisInvalidBeforeIstanbul)
 {
     testChainIDisInvalidBeforeIstanbul();
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(AlethInterpreterSelfBalanceSuite, AlethInterpreterSelfBalanceFixture)
+
+BOOST_AUTO_TEST_CASE(AlethInterpreterSelfBalanceworksInIstanbul)
+{
+    testSelfBalanceWorksInIstanbul();
+}
+
+BOOST_AUTO_TEST_CASE(AlethInterpreterSelfBalanceisInvalidBeforeIstanbul)
+{
+    testSelfBalanceisInvalidBeforeIstanbul();
 }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-1884

It includes SELFBALANCE implementation; opcode repricing is enabled automagically via EVMC instruction metrics.