### PR TITLE
ChainID support in testeth

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -57,6 +57,13 @@ vector<int> parseJsonIntValueIntoVector(json_spirit::mValue const& _json)
         out.push_back(_json.get_int());
     return out;
 }
+
+int mainnetChainID()
+{
+    static auto const c_mainnetChainID =
+        ChainParams(genesisInfo(eth::Network::MainNetworkTest)).chainID;
+    return c_mainnetChainID;
+}
 }
 
 ImportTest::ImportTest(json_spirit::mObject const& _input, json_spirit::mObject& _output):
@@ -460,7 +467,8 @@ void ImportTest::importEnv(json_spirit::mObject const& _o)
     header.setAuthor(Address(_o.at("currentCoinbase").get_str()));
 
     m_lastBlockHashes.reset(new TestLastBlockHashes(lastHashes(header.number())));
-    m_envInfo.reset(new EnvInfo(header, *m_lastBlockHashes, 0, 0));
+
+    m_envInfo.reset(new EnvInfo(header, *m_lastBlockHashes, 0, mainnetChainID()));
 }
 
 // import state from not fully declared json_spirit::mObject, writing to _stateOptionsMap which fields were defined in json


### PR DESCRIPTION
With this fix testeth passes ChainID tests from https://github.com/ethereum/tests/pull/627

The simple fix is to always use the same ChainID from the mainnet config, assuming all network configs use only this ChainID.

Note: VM tests still always return 0 ChainID, I didn't bother to fix it as VM tests are not maintained anyway.
https://github.com/ethereum/aleth/blob/1e25be81a72f3a3c285ea0c33d38c2e6ac33c8d7/test/tools/jsontests/vm.cpp#L113
https://github.com/ethereum/aleth/blob/1e25be81a72f3a3c285ea0c33d38c2e6ac33c8d7/test/tools/jsontests/vm.cpp#L446