### PR TITLE
Enable Istanbule on TransactionTests and Update the tests

### DIFF
--- a/test/tools/jsontests/TransactionTests.cpp
+++ b/test/tools/jsontests/TransactionTests.cpp
@@ -59,6 +59,9 @@ mObject getExpectSection(mValue const& _expect, eth::Network _network)
         if (networks.count(test::netIdToString(_network)))
             objVector.push_back(obj);
     }
+    if (objVector.size() == 0)
+        BOOST_ERROR("Expect network '" + test::netIdToString(_network) +
+                    "' not found with getExpectSection()");
     BOOST_REQUIRE_MESSAGE(objVector.size() == 1, "Expect network should occur once in expect section of transaction test filler! (" + test::netIdToString(_network) + ") " + TestOutputHelper::get().testName());
     return objVector.at(0);
 }
@@ -239,5 +242,6 @@ BOOST_AUTO_TEST_CASE(ttValue){}
 BOOST_AUTO_TEST_CASE(ttVValue){}
 BOOST_AUTO_TEST_CASE(ttSignature){}
 BOOST_AUTO_TEST_CASE(ttWrongRLP){}
+BOOST_AUTO_TEST_CASE(ttEIP2028) {}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -114,6 +114,8 @@ string netIdToString(eth::Network _netId)
         return "Constantinople";
     case eth::Network::ConstantinopleFixTest:
         return "ConstantinopleFix";
+    case eth::Network::IstanbulTest:
+        return "Istanbul";
     case eth::Network::FrontierToHomesteadAt5:
         return "FrontierToHomesteadAt5";
     case eth::Network::HomesteadToDaoAt5:
@@ -138,10 +140,10 @@ eth::Network stringToNetId(string const& _netname)
     static vector<eth::Network> const networks{
         {eth::Network::FrontierTest, eth::Network::HomesteadTest, eth::Network::EIP150Test,
             eth::Network::EIP158Test, eth::Network::ByzantiumTest, eth::Network::ConstantinopleTest,
-            eth::Network::ConstantinopleFixTest, eth::Network::FrontierToHomesteadAt5,
-            eth::Network::HomesteadToDaoAt5, eth::Network::HomesteadToEIP150At5,
-            eth::Network::EIP158ToByzantiumAt5, eth::Network::ByzantiumToConstantinopleFixAt5,
-            eth::Network::TransitionnetTest}};
+            eth::Network::ConstantinopleFixTest, eth::Network::IstanbulTest,
+            eth::Network::FrontierToHomesteadAt5, eth::Network::HomesteadToDaoAt5,
+            eth::Network::HomesteadToEIP150At5, eth::Network::EIP158ToByzantiumAt5,
+            eth::Network::ByzantiumToConstantinopleFixAt5, eth::Network::TransitionnetTest}};
 
     for (auto const& net : networks)
         if (netIdToString(net) == _netname)
@@ -179,7 +181,7 @@ set<eth::Network> const& getNetworks()
     static set<eth::Network> const networks{
         {eth::Network::FrontierTest, eth::Network::HomesteadTest, eth::Network::EIP150Test,
             eth::Network::EIP158Test, eth::Network::ByzantiumTest, eth::Network::ConstantinopleTest,
-            eth::Network::ConstantinopleFixTest}};
+            eth::Network::ConstantinopleFixTest, eth::Network::IstanbulTest}};
     return networks;
 }
 

--- a/test/unittests/libtesteth/testHelperTest.cpp
+++ b/test/unittests/libtesteth/testHelperTest.cpp
@@ -29,6 +29,13 @@ using namespace dev::test;
 BOOST_FIXTURE_TEST_SUITE(TestHelperSuite, TestOutputHelperFixture)
 
 BOOST_AUTO_TEST_SUITE(TranslateNetworks)
+BOOST_AUTO_TEST_CASE(translateNetworks_gteIstanbul)
+{
+    set<string> networks = {">=Istanbul"};
+    networks = test::translateNetworks(networks);
+    BOOST_CHECK(contains(networks, "Istanbul"));
+}
+
 BOOST_AUTO_TEST_CASE(translateNetworks_gtConstantinople)
 {
     set<string> networks = {">Constantinople"};


### PR DESCRIPTION
* Enables Istanbul for transaction tests
* Update the test repo
    - All StateTests from <=constantinople are disabled (moved to LegacyTests folder)
    - The BCGeneralStateTests outdated and removed
    - Recent tests and updates to GeneralStateTests supported by geth + retesteth

