### PR TITLE
EIP-2046 independent activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.8.0] - Unreleased
 
 - Added: [#5699](https://github.com/ethereum/aleth/pull/5699) EIP 2046: Reduced gas cost for static calls made to precompiles.
+- Added: [#5741](https://github.com/ethereum/aleth/pull/5741) Support for individual EIP activation to facilitate EIP-centric network upgrade process.
 - Added: [#5752](https://github.com/ethereum/aleth/pull/5752) [#5753](https://github.com/ethereum/aleth/pull/5753) Implement EIP1380 (reduced gas costs for call-to-self).
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
 - Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -6,7 +6,6 @@
 #include "ChainOperationParams.h"
 #include <libdevcore/CommonData.h>
 #include <libdevcore/Log.h>
-#include <libethcore/EVMSchedule.h>
 
 using namespace std;
 using namespace dev;
@@ -38,17 +37,13 @@ ChainOperationParams::ChainOperationParams():
 
 EVMSchedule const& ChainOperationParams::scheduleForBlockNumber(u256 const& _blockNumber) const
 {
-    EVMSchedule const& fixedForkSchedule = constScheduleForBlockNumber(_blockNumber);
-
-    if (_blockNumber < lastForkBlock)
-        return fixedForkSchedule;
-
-    static EVMSchedule const lastForkWithAdditionalEIPsSchedule =
-        addEIPs(fixedForkSchedule, lastForkAdditionalEIPs);
-    return lastForkWithAdditionalEIPsSchedule;
+    if (_blockNumber >= lastForkBlock)
+        return lastForkWithAdditionalEIPsSchedule;
+    else
+        return fixedScheduleForBlockNumber(_blockNumber);
 }
 
-EVMSchedule const& ChainOperationParams::constScheduleForBlockNumber(u256 const& _blockNumber) const
+EVMSchedule const& ChainOperationParams::fixedScheduleForBlockNumber(u256 const& _blockNumber) const
 {
     if (_blockNumber >= experimentalForkBlock)
         return ExperimentalSchedule;

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -4,8 +4,10 @@
 
 
 #include "ChainOperationParams.h"
-#include <libdevcore/Log.h>
 #include <libdevcore/CommonData.h>
+#include <libdevcore/Log.h>
+#include <libethcore/EVMSchedule.h>
+
 using namespace std;
 using namespace dev;
 using namespace eth;
@@ -35,6 +37,18 @@ ChainOperationParams::ChainOperationParams():
 }
 
 EVMSchedule const& ChainOperationParams::scheduleForBlockNumber(u256 const& _blockNumber) const
+{
+    EVMSchedule const& fixedForkSchedule = constScheduleForBlockNumber(_blockNumber);
+
+    if (_blockNumber < lastForkBlock)
+        return fixedForkSchedule;
+
+    static EVMSchedule const lastForkWithAdditionalEIPsSchedule =
+        addEIPs(fixedForkSchedule, lastForkAdditionalEIPs);
+    return lastForkWithAdditionalEIPsSchedule;
+}
+
+EVMSchedule const& ChainOperationParams::constScheduleForBlockNumber(u256 const& _blockNumber) const
 {
     if (_blockNumber >= experimentalForkBlock)
         return ExperimentalSchedule;

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -40,10 +40,10 @@ EVMSchedule const& ChainOperationParams::scheduleForBlockNumber(u256 const& _blo
     if (_blockNumber >= lastForkBlock)
         return lastForkWithAdditionalEIPsSchedule;
     else
-        return fixedScheduleForBlockNumber(_blockNumber);
+        return forkScheduleForBlockNumber(_blockNumber);
 }
 
-EVMSchedule const& ChainOperationParams::fixedScheduleForBlockNumber(u256 const& _blockNumber) const
+EVMSchedule const& ChainOperationParams::forkScheduleForBlockNumber(u256 const& _blockNumber) const
 {
     if (_blockNumber >= experimentalForkBlock)
         return ExperimentalSchedule;

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -9,12 +9,12 @@
 #include <libethcore/Precompiled.h>
 
 #include "Common.h"
-#include "EVMSchedule.h"
 
 namespace dev
 {
 namespace eth
 {
+struct EVMSchedule;
 
 class PrecompiledContract
 {
@@ -53,6 +53,11 @@ private:
 
 constexpr int64_t c_infiniteBlockNumber = std::numeric_limits<int64_t>::max();
 
+struct AdditionalEIPs
+{
+    bool eip2046 = false;
+};
+
 struct ChainOperationParams
 {
     ChainOperationParams();
@@ -62,9 +67,23 @@ struct ChainOperationParams
     /// The chain sealer name: e.g. Ethash, NoProof, BasicAuthority
     std::string sealEngineName = "NoProof";
 
+    // Example of how to check EIP activation from outside of EVM:
+    // bool isEIP2046Enabled(u256 const& _blockNumber) const
+    // {
+    //     return _blockNumber >= lastForkBlock && lastForkAdditionalEIPs.eip2046;
+    // }
+    // After hard fork finalization this is changed to:
+    // bool isEIP2046Enabled(u256 const& _blockNumber) const
+    // {
+    //     return _blockNumber >= berlinForkBlock;
+    // }
+
     /// General chain params.
 private:
     u256 m_blockReward;
+
+    EVMSchedule const& constScheduleForBlockNumber(u256 const& _blockNumber) const;
+
 public:
     EVMSchedule const& scheduleForBlockNumber(u256 const& _blockNumber) const;
     u256 blockReward(EVMSchedule const& _schedule) const;
@@ -86,6 +105,8 @@ public:
     u256 experimentalForkBlock = c_infiniteBlockNumber;
     u256 istanbulForkBlock = c_infiniteBlockNumber;
     u256 berlinForkBlock = c_infiniteBlockNumber;
+    u256 lastForkBlock = c_infiniteBlockNumber;
+    AdditionalEIPs lastForkAdditionalEIPs;
     int chainID = 0;    // Distinguishes different chains (mainnet, Ropsten, etc).
     int networkID = 0;  // Distinguishes different sub protocols.
 

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <libdevcore/Common.h>
+#include <libethcore/EVMSchedule.h>
 #include <libethcore/Precompiled.h>
 
 #include "Common.h"
@@ -82,10 +83,9 @@ struct ChainOperationParams
 private:
     u256 m_blockReward;
 
-    EVMSchedule const& constScheduleForBlockNumber(u256 const& _blockNumber) const;
-
 public:
     EVMSchedule const& scheduleForBlockNumber(u256 const& _blockNumber) const;
+    EVMSchedule const& fixedScheduleForBlockNumber(u256 const& _blockNumber) const;
     u256 blockReward(EVMSchedule const& _schedule) const;
     void setBlockReward(u256 const& _newBlockReward);
     u256 maximumExtraDataSize = 32;
@@ -117,6 +117,8 @@ public:
 
     /// Precompiled contracts as specified in the chain params.
     std::unordered_map<Address, PrecompiledContract> precompiled;
+
+    EVMSchedule lastForkWithAdditionalEIPsSchedule;
 };
 
 }

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -84,8 +84,12 @@ private:
     u256 m_blockReward;
 
 public:
+    // returns schedule for the fork active at the given block
+    // may include additional individually activated EIPs on top of the last fork block
     EVMSchedule const& scheduleForBlockNumber(u256 const& _blockNumber) const;
-    EVMSchedule const& fixedScheduleForBlockNumber(u256 const& _blockNumber) const;
+    // returns schedule according to the the fork rules active at the given block
+    // doesn't include additional individually activated EIPs
+    EVMSchedule const& forkScheduleForBlockNumber(u256 const& _blockNumber) const;
     u256 blockReward(EVMSchedule const& _schedule) const;
     void setBlockReward(u256 const& _newBlockReward);
     u256 maximumExtraDataSize = 32;

--- a/libethcore/EVMSchedule.cpp
+++ b/libethcore/EVMSchedule.cpp
@@ -1,0 +1,21 @@
+/// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#include "EVMSchedule.h"
+#include <libethcore/ChainOperationParams.h>
+
+namespace dev
+{
+namespace eth
+{
+EVMSchedule addEIPs(EVMSchedule const& _schedule, AdditionalEIPs const& _eips)
+{
+    EVMSchedule modifiedSchedule = _schedule;
+    if (_eips.eip2046)
+        modifiedSchedule.precompileStaticCallGas = 40;
+
+    return modifiedSchedule;
+}
+}  // namespace eth
+}  // namespace dev

--- a/libethcore/EVMSchedule.cpp
+++ b/libethcore/EVMSchedule.cpp
@@ -9,7 +9,7 @@ namespace dev
 {
 namespace eth
 {
-EVMSchedule addEIPs(EVMSchedule const& _schedule, AdditionalEIPs const& _eips)
+EVMSchedule addEIPsToSchedule(EVMSchedule const& _schedule, AdditionalEIPs const& _eips)
 {
     EVMSchedule modifiedSchedule = _schedule;
     if (_eips.eip2046)

--- a/libethcore/EVMSchedule.cpp
+++ b/libethcore/EVMSchedule.cpp
@@ -9,13 +9,11 @@ namespace dev
 {
 namespace eth
 {
-EVMSchedule addEIPsToSchedule(EVMSchedule const& _schedule, AdditionalEIPs const& _eips)
+EVMSchedule::EVMSchedule(EVMSchedule const& _schedule, AdditionalEIPs const& _eips)
+  : EVMSchedule(_schedule)
 {
-    EVMSchedule modifiedSchedule = _schedule;
     if (_eips.eip2046)
-        modifiedSchedule.precompileStaticCallGas = 40;
-
-    return modifiedSchedule;
+        precompileStaticCallGas = 40;
 }
 }  // namespace eth
 }  // namespace dev

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -4,13 +4,16 @@
 
 #pragma once
 
-#include <array>
+#include <libdevcore/Common.h>
+#include <libethcore/Common.h>
 #include <boost/optional.hpp>
+#include <array>
 
 namespace dev
 {
 namespace eth
 {
+struct AdditionalEIPs;
 
 struct EVMSchedule
 {
@@ -181,5 +184,7 @@ inline EVMSchedule const& latestScheduleForAccountVersion(u256 const& _version)
         return DefaultSchedule;
     }
 }
+
+EVMSchedule addEIPs(EVMSchedule const& _schedule, AdditionalEIPs const& _eips);
 }
 }

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -184,6 +184,6 @@ inline EVMSchedule const& latestScheduleForAccountVersion(u256 const& _version)
     }
 }
 
-EVMSchedule addEIPs(EVMSchedule const& _schedule, AdditionalEIPs const& _eips);
+EVMSchedule addEIPsToSchedule(EVMSchedule const& _schedule, AdditionalEIPs const& _eips);
 }
 }

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -158,7 +158,6 @@ static const EVMSchedule IstanbulSchedule = [] {
 
 static const EVMSchedule BerlinSchedule = [] {
     EVMSchedule schedule = IstanbulSchedule;
-    schedule.precompileStaticCallGas = 40;
     schedule.callSelfGas = 40;
     return schedule;
 }();

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -19,6 +19,8 @@ struct EVMSchedule
 {
     EVMSchedule(): tierStepGas(std::array<unsigned, 8>{{0, 2, 3, 5, 8, 10, 20, 0}}) {}
     EVMSchedule(bool _efcd, bool _hdc, unsigned const& _txCreateGas): exceptionalFailedCodeDeposit(_efcd), haveDelegateCall(_hdc), tierStepGas(std::array<unsigned, 8>{{0, 2, 3, 5, 8, 10, 20, 0}}), txCreateGas(_txCreateGas) {}
+    // construct schedule with additional EIPs on top
+    EVMSchedule(EVMSchedule const& _schedule, AdditionalEIPs const& _eips);
     unsigned accountVersion = 0;
     bool exceptionalFailedCodeDeposit = true;
     bool haveDelegateCall = true;
@@ -183,7 +185,5 @@ inline EVMSchedule const& latestScheduleForAccountVersion(u256 const& _version)
         return DefaultSchedule;
     }
 }
-
-EVMSchedule addEIPsToSchedule(EVMSchedule const& _schedule, AdditionalEIPs const& _eips);
 }
 }

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -14,12 +14,34 @@
 #include <libethcore/BlockHeader.h>
 #include <libethcore/Precompiled.h>
 #include <libethcore/SealEngine.h>
+#include <boost/algorithm/string.hpp>
 
 using namespace std;
 using namespace dev;
 using namespace eth;
 using namespace eth::validation;
 namespace js = json_spirit;
+
+namespace
+{
+u256 findMaxForkBlockNumber(js::mObject const& _params)
+{
+    u256 maxForkBlockNumber = 0;
+    for (auto const& paramKeyValue : _params)
+    {
+        auto const& key = paramKeyValue.first;
+        if (boost::algorithm::ends_with(key, c_forkBlockSuffix))
+        {
+            auto const& value = paramKeyValue.second;
+            auto const blockNumber = fromBigEndian<u256>(fromHex(value.get_str()));
+            if (blockNumber < c_infiniteBlockNumber && blockNumber > maxForkBlockNumber)
+                maxForkBlockNumber = blockNumber;
+        }
+    }
+
+    return maxForkBlockNumber;
+}
+}  // namespace
 
 ChainParams::ChainParams()
 {
@@ -83,7 +105,9 @@ ChainParams ChainParams::loadConfig(
     setOptionalU256Parameter(cp.minGasLimit, c_minGasLimit);
     setOptionalU256Parameter(cp.maxGasLimit, c_maxGasLimit);
     setOptionalU256Parameter(cp.gasLimitBoundDivisor, c_gasLimitBoundDivisor);
+
     setOptionalU256Parameter(cp.homesteadForkBlock, c_homesteadForkBlock);
+    setOptionalU256Parameter(cp.daoHardforkBlock, c_daoHardforkBlock);
     setOptionalU256Parameter(cp.EIP150ForkBlock, c_EIP150ForkBlock);
     setOptionalU256Parameter(cp.EIP158ForkBlock, c_EIP158ForkBlock);
     setOptionalU256Parameter(cp.byzantiumForkBlock, c_byzantiumForkBlock);
@@ -92,8 +116,10 @@ ChainParams ChainParams::loadConfig(
     setOptionalU256Parameter(cp.constantinopleFixForkBlock, c_constantinopleFixForkBlock);
     setOptionalU256Parameter(cp.istanbulForkBlock, c_istanbulForkBlock);
     setOptionalU256Parameter(cp.berlinForkBlock, c_berlinForkBlock);
-    setOptionalU256Parameter(cp.daoHardforkBlock, c_daoHardforkBlock);
     setOptionalU256Parameter(cp.experimentalForkBlock, c_experimentalForkBlock);
+
+    cp.lastForkBlock = findMaxForkBlockNumber(params);
+
     setOptionalU256Parameter(cp.minimumDifficulty, c_minimumDifficulty);
     setOptionalU256Parameter(cp.difficultyBoundDivisor, c_difficultyBoundDivisor);
     setOptionalU256Parameter(cp.durationLimit, c_durationLimit);

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -23,8 +23,16 @@ struct ChainParams: public ChainOperationParams
     ChainParams();
     ChainParams(ChainParams const& /*_org*/) = default;
     ChainParams(std::string const& _s, h256 const& _stateRoot = h256());
-    ChainParams(bytes const& _genesisRLP, AccountMap const& _state) { populateFromGenesis(_genesisRLP, _state); }
-    ChainParams(std::string const& _json, bytes const& _genesisRLP, AccountMap const& _state): ChainParams(_json) { populateFromGenesis(_genesisRLP, _state); }
+    ChainParams(std::string const& _s, AdditionalEIPs const& _additionalEIPs);
+    ChainParams(bytes const& _genesisRLP, AccountMap const& _state)
+    {
+        populateFromGenesis(_genesisRLP, _state);
+    }
+    ChainParams(std::string const& _json, bytes const& _genesisRLP, AccountMap const& _state)
+      : ChainParams(_json)
+    {
+        populateFromGenesis(_genesisRLP, _state);
+    }
 
     SealEngineFace* createSealEngine();
 
@@ -50,6 +58,9 @@ struct ChainParams: public ChainOperationParams
     /// load config
     ChainParams loadConfig(std::string const& _json, h256 const& _stateRoot = {},
         const boost::filesystem::path& _configPath = {}) const;
+
+    /// Activatie additional EIPs on top of the last fork block
+    ChainParams addEIPs(AdditionalEIPs const& _eips) const;
 
 private:
     void populateFromGenesis(bytes const& _genesisRLP, AccountMap const& _state);

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -22,8 +22,9 @@ struct ChainParams: public ChainOperationParams
 {
     ChainParams();
     ChainParams(ChainParams const& /*_org*/) = default;
-    ChainParams(std::string const& _s, h256 const& _stateRoot = h256());
-    ChainParams(std::string const& _s, AdditionalEIPs const& _additionalEIPs);
+    ChainParams(std::string const& _configJson, h256 const& _stateRoot = h256());
+    /// params with additional EIPs activated on top of the last fork block
+    ChainParams(std::string const& _configJson, AdditionalEIPs const& _additionalEIPs);
     ChainParams(bytes const& _genesisRLP, AccountMap const& _state)
     {
         populateFromGenesis(_genesisRLP, _state);
@@ -58,9 +59,6 @@ struct ChainParams: public ChainOperationParams
     /// load config
     ChainParams loadConfig(std::string const& _json, h256 const& _stateRoot = {},
         const boost::filesystem::path& _configPath = {}) const;
-
-    /// Activatie additional EIPs on top of the last fork block
-    ChainParams addEIPs(AdditionalEIPs const& _eips) const;
 
 private:
     void populateFromGenesis(bytes const& _genesisRLP, AccountMap const& _state);

--- a/libethereum/Interface.h
+++ b/libethereum/Interface.h
@@ -5,15 +5,16 @@
 
 #pragma once
 
+#include "BlockDetails.h"
+#include "GasPricer.h"
+#include "LogFilter.h"
+#include "Transaction.h"
 #include <libdevcore/Common.h>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Guards.h>
 #include <libdevcrypto/Common.h>
+#include <libethcore/EVMSchedule.h>
 #include <libethcore/SealEngine.h>
-#include "GasPricer.h"
-#include "LogFilter.h"
-#include "Transaction.h"
-#include "BlockDetails.h"
 
 namespace dev
 {

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -40,6 +40,7 @@ string const c_shouldnotexist = "shouldnotexist";
 string const c_minGasLimit = "minGasLimit";
 string const c_maxGasLimit = "maxGasLimit";
 string const c_gasLimitBoundDivisor = "gasLimitBoundDivisor";
+string const c_forkBlockSuffix = "ForkBlock";
 string const c_homesteadForkBlock = "homesteadForkBlock";
 string const c_daoHardforkBlock = "daoHardforkBlock";
 string const c_EIP150ForkBlock = "EIP150ForkBlock";

--- a/libethereum/ValidationSchemes.h
+++ b/libethereum/ValidationSchemes.h
@@ -39,6 +39,7 @@ extern std::string const c_shouldnotexist;
 extern std::string const c_minGasLimit;
 extern std::string const c_maxGasLimit;
 extern std::string const c_gasLimitBoundDivisor;
+extern std::string const c_forkBlockSuffix;
 extern std::string const c_homesteadForkBlock;
 extern std::string const c_daoHardforkBlock;
 extern std::string const c_EIP150ForkBlock;

--- a/libevm/ExtVMFace.h
+++ b/libevm/ExtVMFace.h
@@ -11,6 +11,7 @@
 #include <libethcore/BlockHeader.h>
 #include <libethcore/ChainOperationParams.h>
 #include <libethcore/Common.h>
+#include <libethcore/EVMSchedule.h>
 #include <libethcore/LogEntry.h>
 
 #include <evmc/evmc.hpp>

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -69,17 +69,18 @@ json_spirit::mValue doBCTest(
         if (_fillin)
         {
             BOOST_REQUIRE(inputTest.count("expect") > 0);
-            set<eth::Network> allnetworks = ImportTest::getAllNetworksFromExpectSections(
-                        inputTest.at("expect").get_array(), ImportTest::testType::BlockchainTest);
+            set<std::string> allnetworks = ImportTest::getAllNetworksFromExpectSections(
+                inputTest.at("expect").get_array(), ImportTest::testType::BlockchainTest);
 
             //create a blockchain test for each network
             for (auto& network : allnetworks)
             {
-                if (!Options::get().singleTestNet.empty() && Options::get().singleTestNet != test::netIdToString(network))
+                if (!Options::get().singleTestNet.empty() &&
+                    Options::get().singleTestNet != network)
                     continue;
 
-                dev::test::TestBlockChain::s_sealEngineNetwork = network;
-                string newtestname = testname + "_" + test::netIdToString(network);
+                dev::test::TestBlockChain::s_sealEngineNetwork = stringToNetId(network);
+                string newtestname = testname + "_" + network;
 
                 json_spirit::mObject jObjOutput = inputTest;
                 // prepare the corresponding expect section for the test
@@ -92,7 +93,7 @@ json_spirit::mValue doBCTest(
                     json_spirit::mObject const& expectObj = expect.get_obj();
                     ImportTest::parseJsonStrValueIntoSet(expectObj.at("network"), netlist);
                     netlist = test::translateNetworks(netlist);
-                    if (netlist.count(test::netIdToString(network)) || netlist.count("ALL"))
+                    if (netlist.count(network) || netlist.count("ALL"))
                     {
                         jObjOutput["expect"] = expectObj.at("result");
                         found = true;
@@ -107,7 +108,7 @@ json_spirit::mValue doBCTest(
 
                 TestOutputHelper::get().setCurrentTestName(newtestname);
                 jObjOutput = fillBCTest(jObjOutput, _allowInvalidBlocks);
-                jObjOutput["network"] = test::netIdToString(network);
+                jObjOutput["network"] = network;
                 if (inputTest.count("_info"))
                     jObjOutput["_info"] = inputTest.at("_info");
                 tests[newtestname] = jObjOutput;

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -59,15 +59,15 @@ ChainParams createChainParamsForNetwork(string const& _networkName)
     assert(networkAndEIPs.size() >= 1);  // assuming it was already validated earlier
     Network const network = stringToNetId(networkAndEIPs.front());
 
-    ChainParams chainParams(genesisInfo(network));
     // parse EIP numbers
+    AdditionalEIPs eips;
     for (auto it = networkAndEIPs.begin() + 1; it != networkAndEIPs.end(); ++it)
     {
         if (*it == "2046")
-            chainParams.lastForkAdditionalEIPs.eip2046 = true;
+            eips.eip2046 = true;
     }
 
-    return chainParams;
+    return ChainParams{genesisInfo(network), eips};
 }
 }
 

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -721,8 +721,12 @@ set<string> const& getAllowedNetworks()
 
 void ImportTest::checkAllowedNetwork(string const& _network)
 {
+    // name may contain network_name+EIPs
+    vector<string> networkAndEIPs;
+    boost::algorithm::split(networkAndEIPs, _network, boost::is_any_of("+"));
+
     set<string> const& allowedNetowks = getAllowedNetworks();
-    if (!allowedNetowks.count(_network))
+    if (networkAndEIPs.empty() || !allowedNetowks.count(networkAndEIPs.front()))
     {
         // Can't use boost at this point
         std::cerr << TestOutputHelper::get().testName() + " Specified Network not found: "

--- a/test/tools/libtesteth/ImportTest.h
+++ b/test/tools/libtesteth/ImportTest.h
@@ -35,7 +35,7 @@ public:
         StateTest,
         BlockchainTest
     };
-    static std::set<eth::Network> getAllNetworksFromExpectSections(
+    static std::set<std::string> getAllNetworksFromExpectSections(
         json_spirit::mArray const& _expects, testType _testType);
 
 
@@ -57,9 +57,12 @@ public:
 private:
     struct transactionToExecute;
     using ExecOutput = std::pair<eth::ExecutionResult, eth::TransactionReceipt>;
-	std::tuple<eth::State, ExecOutput, eth::ChangeLog> executeTransaction(eth::Network const _sealEngineNetwork, eth::EnvInfo const& _env, eth::State const& _preState, eth::Transaction const& _tr);
+    std::tuple<eth::State, ExecOutput, eth::ChangeLog> executeTransaction(
+        std::string const& _sealEngineNetwork, eth::EnvInfo const& _env,
+        eth::State const& _preState, eth::Transaction const& _tr);
     bool findExpectSectionForTransaction(
-        transactionToExecute const& _tr, eth::Network const& _net, bool _isFilling) const;
+        transactionToExecute const& _tr, std::string const& _net, bool _isFilling) const;
+    void validateNetworkNames(std::set<std::string> const& _names) const;
 
     std::unique_ptr<eth::LastBlockHashesFace const> m_lastBlockHashes;
 	std::unique_ptr<eth::EnvInfo> m_envInfo;
@@ -68,17 +71,24 @@ private:
 	//General State Tests
 	struct transactionToExecute
 	{
-		transactionToExecute(int d, int g, int v, eth::Transaction const& t):
-			dataInd(d), gasInd(g), valInd(v), transaction(t), postState(0), netId(eth::Network::MainNetwork),
-			output(std::make_pair(eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries()))) {}
-		int dataInd;
+        transactionToExecute(int d, int g, int v, eth::Transaction const& t)
+          : dataInd(d),
+            gasInd(g),
+            valInd(v),
+            transaction(t),
+            postState(0),
+            netId("other"),
+            output(std::make_pair(
+                eth::ExecutionResult(), eth::TransactionReceipt(h256(), u256(), eth::LogEntries())))
+        {}
+        int dataInd;
 		int gasInd;
 		int valInd;
 		eth::Transaction transaction;
 		eth::State postState;
 		eth::ChangeLog changeLog;
-		eth::Network netId;
-		ExecOutput output;
+        std::string netId;
+        ExecOutput output;
 	};
 	std::vector<transactionToExecute> m_transactions;
 	using StateAndMap = std::pair<eth::State, eth::AccountMaskMap>;
@@ -87,7 +97,7 @@ private:
 
     /// Create blockchain test fillers for specified _networks and test information (env, pre, txs)
     /// of Importtest then fill blockchain fillers into tests.
-    void makeBlockchainTestFromStateTest(std::set<eth::Network> const& _networks) const;
+    void makeBlockchainTestFromStateTest(std::set<std::string> const& _networks) const;
 
     json_spirit::mObject const& m_testInputObject;
 	json_spirit::mObject& m_testOutputObject;

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -812,9 +812,9 @@ public:
         // let r := staticcall(10000, 0x4, 0, 0, 0, 0)
         bytes code = fromHex("60006000600060006004612710fa50");
 
-        ChainParams cp{genesisInfo(Network::IstanbulTest)};
-        cp.lastForkBlock = cp.istanbulForkBlock;
-        cp.lastForkAdditionalEIPs.eip2046 = true;
+        AdditionalEIPs eips;
+        eips.eip2046 = true;
+        ChainParams cp{genesisInfo(Network::IstanbulTest), eips};
 
         se.reset(cp.createSealEngine());
 

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -782,13 +782,10 @@ public:
         BOOST_REQUIRE_EQUAL(gasBefore - gasAfter, 700 + 15);
     }
 
-    void testStaticCallCostEqualToCallBeforeBerlin()
+    void testStaticCallCostEqualToCallBeforeEIP2046()
     {
         // let r := staticcall(10000, 0x4, 0, 0, 0, 0)
         bytes code = fromHex("60006000600060006004612710fa50");
-
-        se.reset(ChainParams(genesisInfo(Network::IstanbulTest)).createSealEngine());
-        version = IstanbulSchedule.accountVersion;
 
         ExtVM extVm(state, envInfo, *se, address, address, address, value, gasPrice, {}, ref(code),
             sha3(code), version, depth, isCreate, staticCall);
@@ -810,10 +807,16 @@ public:
         BOOST_REQUIRE_EQUAL(gasBefore - gasAfter, 700 + 15);
     }
 
-    void testStaticCallHasCorrectCostInBerlin()
+    void testStaticCallHasCorrectCostWithEIP2046()
     {
         // let r := staticcall(10000, 0x4, 0, 0, 0, 0)
         bytes code = fromHex("60006000600060006004612710fa50");
+
+        ChainParams cp{genesisInfo(Network::IstanbulTest)};
+        cp.lastForkBlock = cp.istanbulForkBlock;
+        cp.lastForkAdditionalEIPs.eip2046 = true;
+
+        se.reset(cp.createSealEngine());
 
         ExtVM extVm(state, envInfo, *se, address, address, address, value, gasPrice, {}, ref(code),
             sha3(code), version, depth, isCreate, staticCall);
@@ -1206,14 +1209,14 @@ BOOST_AUTO_TEST_CASE(LegacyVMCallHasCorrectCost)
     testCallHasCorrectCost();
 }
 
-BOOST_AUTO_TEST_CASE(LegacyVMStaticCallCostEqualToCallBeforeBerlin)
+BOOST_AUTO_TEST_CASE(LegacyVMStaticCallCostEqualToCallBeforeEIP2046)
 {
-    testStaticCallCostEqualToCallBeforeBerlin();
+    testStaticCallCostEqualToCallBeforeEIP2046();
 }
 
-BOOST_AUTO_TEST_CASE(LegacyVMStaticCallHasCorrectCostInBerlin)
+BOOST_AUTO_TEST_CASE(LegacyVMStaticCallHasCorrectCostWithEIP2046)
 {
-    testStaticCallHasCorrectCostInBerlin();
+    testStaticCallHasCorrectCostWithEIP2046();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Addresses https://github.com/ethereum/aleth/issues/5789

It introduces support for individual EIP activation without fork, then moves EIP-2046 implementation from Berlin fork definition to this new individual model of activation.

### How this is supposed to be used

#### Implementing new EIP
- Add new member to `AdditionalEIPs` struct https://github.com/ethereum/aleth/pull/5741/files#diff-c93cb246fbbc22300c737cb7ce2a2741R57-R60
- If EIP affects anything outside EVM, the helper `ChainOperationParams::isEIPXXXXEnabled` would be helpful https://github.com/ethereum/aleth/pull/5741/files#diff-c93cb246fbbc22300c737cb7ce2a2741R72-R75
- If EIP affects EVM, affected prices/flags should be set to `EVMSchedule` in the function `addEIPsToSchedule` https://github.com/ethereum/aleth/pull/5741/files#diff-363b4e07ecbf6ed5a7eb650e5cb69bcbR12-R19

#### Including EIP into the new fork definition, after it's accepted
- Remove EIP member from `AdditionalEIPs` struct
- If EIP affects anything outside EVM, modify `ChainOperationParams::isEIPXXXXEnabled` helper https://github.com/ethereum/aleth/pull/5741/files#diff-c93cb246fbbc22300c737cb7ce2a2741R76-R80
- If EIP affects EVM remove it from `addEIPsToSchedule` and add to the fork's `EVMSchedule` instance

#### Writing a unit test
- Instantiate `ChainParams` with additional EIPs activated using `ChainParams(string, AdditionalEIPs)` constructor https://github.com/ethereum/aleth/pull/5741/files#diff-bca8e2c5f9ec26d6b11f9fd86abd6338R815-R817

#### Writing consensus state test
- Use `Forkname+EIPXXXX` instead of regular fork name.
See example test for EIP2046 that I created https://github.com/ethereum/tests/commit/8bbbd484227684339ec64ed6a0083d0b137436c8
(based on existing `CallIdentitiy_1` test)

### Limitations / future improvements (if needed)
- Not supported in blockchain tests, transaction tests
- Not supported in generating blockchain tests from state tests
- Not supported in chain config json, only in testeth. So it's not possible to create a chain with individual EIPs activated, that also means it won't work for retesteth.

These should be fairly easy to support though.

@winsvega please review the changes in testeth. Basically it operates now with a network name string (which can possibly contain additional EIP numbers) in the places where it used to use `eth::Network`. Then creates `ChainParams` based on this string, when it needs to execute the transaction.