### PR TITLE
Refactor transaction replay protection implementation

### DIFF
--- a/libethashseal/Ethash.cpp
+++ b/libethashseal/Ethash.cpp
@@ -131,12 +131,9 @@ void Ethash::verifyTransaction(ImportRequirements::value _ir, TransactionBase co
     if (_ir & ImportRequirements::TransactionSignatures)
     {
         if (_header.number() >= chainParams().EIP158ForkBlock)
-        {
-            int chainID = chainParams().chainID;
-            _t.checkChainId(chainID);
-        }
-        else
-            _t.checkChainId(-4);
+            _t.checkChainId(chainParams().chainID);
+        else if (_t.isReplayProtected())
+            BOOST_THROW_EXCEPTION(InvalidSignature());
     }
 }
 

--- a/libethcore/TransactionBase.cpp
+++ b/libethcore/TransactionBase.cpp
@@ -51,25 +51,26 @@ TransactionBase::TransactionBase(bytesConstRef _rlpData, CheckTransaction _check
 
         m_data = rlp[5].toBytes();
 
-        int const v = rlp[6].toInt<int>();
+        u256 const v = rlp[6].toInt<u256>();
         h256 const r = rlp[7].toInt<u256>();
         h256 const s = rlp[8].toInt<u256>();
 
         if (isZeroSignature(r, s))
         {
-            m_chainId = v;
+            m_chainId = static_cast<uint64_t>(v);
             m_vrs = SignatureStruct{r, s, 0};
         }
         else
         {
             if (v > 36)
-                m_chainId = (v - 35) / 2; 
-            else if (v == 27 || v == 28)
-                m_chainId = -4;
-            else
+                m_chainId = (v - 35) / 2;
+            // only values 27 and 28 are allowed for non-replay protected transactions
+            else if (v != 27 && v != 28)
                 BOOST_THROW_EXCEPTION(InvalidSignature());
 
-            m_vrs = SignatureStruct{r, s, static_cast<byte>(v - (m_chainId * 2 + 35))};
+            auto const recoveryID =
+                m_chainId.has_value() ? byte{v - (*m_chainId * 2 + 35)} : byte{v - 27};
+            m_vrs = SignatureStruct{r, s, recoveryID};
 
             if (_checkSig >= CheckTransaction::Cheap && !m_vrs->isValid())
                 BOOST_THROW_EXCEPTION(InvalidSignature());
@@ -155,16 +156,16 @@ void TransactionBase::streamRLP(RLPStream& _s, IncludeSignature _sig, bool _forE
             BOOST_THROW_EXCEPTION(TransactionIsUnsigned());
 
         if (hasZeroSignature())
-            _s << m_chainId;
+            _s << *m_chainId;
         else
         {
-            int const vOffset = m_chainId * 2 + 35;
+            int const vOffset = m_chainId.has_value() ? *m_chainId * 2 + 35 : 27;
             _s << (m_vrs->v + vOffset);
         }
         _s << (u256)m_vrs->r << (u256)m_vrs->s;
     }
     else if (_forEip155hash)
-        _s << m_chainId << 0 << 0;
+        _s << *m_chainId << 0 << 0;
 }
 
 static const u256 c_secp256k1n("115792089237316195423570985008687907852837564279074904382605163141518161494337");
@@ -178,9 +179,9 @@ void TransactionBase::checkLowS() const
         BOOST_THROW_EXCEPTION(InvalidSignature());
 }
 
-void TransactionBase::checkChainId(int chainId) const
+void TransactionBase::checkChainId(uint64_t _chainId) const
 {
-    if (m_chainId != chainId && m_chainId != -4)
+    if (m_chainId.has_value() && *m_chainId != _chainId)
         BOOST_THROW_EXCEPTION(InvalidSignature());
 }
 
@@ -202,7 +203,7 @@ h256 TransactionBase::sha3(IncludeSignature _sig) const
         return m_hashWith;
 
     RLPStream s;
-    streamRLP(s, _sig, m_chainId > 0 && _sig == WithoutSignature);
+    streamRLP(s, _sig, isReplayProtected() && _sig == WithoutSignature);
 
     auto ret = dev::sha3(s.out());
     if (_sig == WithSignature)

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -39,15 +39,15 @@ BOOST_AUTO_TEST_CASE(TransactionGasRequired)
     BOOST_CHECK_EQUAL(tr.baseGasRequired(IstanbulSchedule), 14 * 16 + 21000);
 }
 
-BOOST_AUTO_TEST_CASE(TransactionWithEmptyRecepient)
+BOOST_AUTO_TEST_CASE(TransactionWithEmptyRecipient)
 {
-    // recepient RLP is 0x80 (empty array)
+    // recipient RLP is 0x80 (empty array)
     auto txRlp = fromHex(
         "0xf84c8014830493e080808026a02f23977c68f851bbec8619510a4acdd34805270d97f5714b003efe7274914c"
         "a2a05874022b26e0d88807bdcc59438f86f5a82e24afefad5b6a67ae853896fe2b37");
     Transaction tx(txRlp, CheckTransaction::None);  // shouldn't throw
 
-    // recepient RLP is 0xc0 (empty list)
+    // recipient RLP is 0xc0 (empty list)
     txRlp = fromHex(
         "0xf84c8014830493e0c0808026a02f23977c68f851bbec8619510a4acdd34805270d97f5714b003efe7274914c"
         "a2a05874022b26e0d88807bdcc59438f86f5a82e24afefad5b6a67ae853896fe2b37");

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -41,17 +41,46 @@ BOOST_AUTO_TEST_CASE(TransactionGasRequired)
 
 BOOST_AUTO_TEST_CASE(TransactionWithEmptyRecepient)
 {
-    // recipient RLP is 0x80 (empty array)
+    // recepient RLP is 0x80 (empty array)
     auto txRlp = fromHex(
         "0xf84c8014830493e080808026a02f23977c68f851bbec8619510a4acdd34805270d97f5714b003efe7274914c"
         "a2a05874022b26e0d88807bdcc59438f86f5a82e24afefad5b6a67ae853896fe2b37");
     Transaction tx(txRlp, CheckTransaction::None);  // shouldn't throw
 
-    // recipient RLP is 0xc0 (empty list)
+    // recepient RLP is 0xc0 (empty list)
     txRlp = fromHex(
         "0xf84c8014830493e0c0808026a02f23977c68f851bbec8619510a4acdd34805270d97f5714b003efe7274914c"
         "a2a05874022b26e0d88807bdcc59438f86f5a82e24afefad5b6a67ae853896fe2b37");
     BOOST_REQUIRE_THROW(Transaction(txRlp, CheckTransaction::None), InvalidTransactionFormat);
+}
+
+BOOST_AUTO_TEST_CASE(TransactionNotReplayProtected)
+{
+    auto txRlp = fromHex(
+        "0xf86d800182521c94095e7baea6a6c7c4c2dfeb977efac326af552d870a8e0358ac39584bc98a7c979f984b03"
+        "1ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3"
+        "b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804");
+    Transaction tx(txRlp, CheckTransaction::None);
+    tx.checkChainId(1234);  // any chain ID is accepted for not replay protected tx
+
+    RLPStream txRlpStream;
+    tx.streamRLP(txRlpStream);
+    BOOST_REQUIRE(txRlpStream.out() == txRlp);
+}
+
+BOOST_AUTO_TEST_CASE(TransactionReplayProtected)
+{
+    auto txRlp = fromHex(
+        "0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025"
+        "a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703"
+        "304b3800ccf555c9f3dc64214b297fb1966a3b6d83");
+    Transaction tx(txRlp, CheckTransaction::None);
+    tx.checkChainId(1);
+    BOOST_REQUIRE_THROW(tx.checkChainId(123), InvalidSignature);
+
+    RLPStream txRlpStream;
+    tx.streamRLP(txRlpStream);
+    BOOST_REQUIRE(txRlpStream.out() == txRlp);
 }
 
 BOOST_AUTO_TEST_CASE(ExecutionResultOutput)

--- a/test/unittests/libethereum/Transaction.cpp
+++ b/test/unittests/libethereum/Transaction.cpp
@@ -68,6 +68,42 @@ BOOST_AUTO_TEST_CASE(TransactionNotReplayProtected)
     BOOST_REQUIRE(txRlpStream.out() == txRlp);
 }
 
+BOOST_AUTO_TEST_CASE(TransactionChainIDMax64Bit)
+{
+    // recoveryID = 0, v = 36893488147419103265
+    auto txRlp1 = fromHex(
+        "0xf86e808698852840a46f82d6d894095e7baea6a6c7c4c2dfeb977efac326af552d8780808902000000000000"
+        "0021a098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa01887321be575c8095f"
+        "789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3");
+    Transaction tx1{txRlp1, CheckTransaction::None};
+    tx1.checkChainId(std::numeric_limits<uint64_t>::max());
+
+    // recoveryID = 1, v = 36893488147419103266
+    auto txRlp2 = fromHex(
+        "0xf86e808698852840a46f82d6d894095e7baea6a6c7c4c2dfeb977efac326af552d8780808902000000000000"
+        "0022a098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa01887321be575c8095f"
+        "789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3");
+    Transaction tx2{txRlp2, CheckTransaction::None};
+    tx2.checkChainId(std::numeric_limits<uint64_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(TransactionChainIDBiggerThan64Bit)
+{
+    // recoveryID = 0, v = 184467440737095516439
+    auto txRlp1 = fromHex(
+        "0xf86a03018255f094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544890a0000000000000117a098"
+        "ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c7"
+        "43dfe42c1820f9231f98a962b210e3ac2452a3");
+    BOOST_REQUIRE_THROW(Transaction(txRlp1, CheckTransaction::None), InvalidSignature);
+
+    // recoveryID = 1, v = 184467440737095516440
+    auto txRlp2 = fromHex(
+        "0xf86a03018255f094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544890a0000000000000118a098"
+        "ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c7"
+        "43dfe42c1820f9231f98a962b210e3ac2452a3");
+    BOOST_REQUIRE_THROW(Transaction(txRlp2, CheckTransaction::None), InvalidSignature);
+}
+
 BOOST_AUTO_TEST_CASE(TransactionReplayProtected)
 {
     auto txRlp = fromHex(


### PR DESCRIPTION
I got rid of the magic value `-4` which was used to represent transactions without replay protection (`-4` was used because inserting it into formulas `CHAIN_ID * 2 + 35` / `CHAIN_ID * 2 + 35` conveniently produced valid values `27` / `28` for transactions without replay protection)
Instead of this I represent `chainID` with `optional<uint64_t>`


For reference replay protection spec is in https://eips.ethereum.org/EIPS/eip-155


This is quite independent of the change to 64 bit in EVMC and CHAINID implementation https://github.com/ethereum/aleth/pull/5740 (works and passes the tests without it), but I'd merge this after the Chain ID size decision is finalized.