### PR TITLE
SSTORE SLOAD tests

### DIFF
--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -179,6 +179,8 @@ BOOST_AUTO_TEST_CASE(stCreate2){}
 BOOST_AUTO_TEST_CASE(stExtCodeHash){}
 BOOST_AUTO_TEST_CASE(stSStoreTest){}
 
+BOOST_AUTO_TEST_CASE(stEIP2200) {}
+
 //Stress Tests
 BOOST_AUTO_TEST_CASE(stAttackTest){}
 BOOST_AUTO_TEST_CASE(stMemoryStressTest){}

--- a/test/tools/jsontests/StateTests.cpp
+++ b/test/tools/jsontests/StateTests.cpp
@@ -180,6 +180,7 @@ BOOST_AUTO_TEST_CASE(stExtCodeHash){}
 BOOST_AUTO_TEST_CASE(stSStoreTest){}
 
 BOOST_AUTO_TEST_CASE(stEIP2200) {}
+BOOST_AUTO_TEST_CASE(stBlake2) {}
 
 //Stress Tests
 BOOST_AUTO_TEST_CASE(stAttackTest){}

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -806,13 +806,13 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
                 else if (_expects.count("hash"))
                 {
                     // checking filled state test against client
-                    BOOST_CHECK_MESSAGE(_expects.at("hash").get_str() ==
-                                        toHexPrefixed(tr.postState.rootHash().asBytes()),
-                                        TestOutputHelper::get().testName() + " on " +
-                                        test::netIdToString(tr.netId) +
-                                        ": Expected another postState hash! expected: " +
-                                        _expects.at("hash").get_str() + " actual: " +
-                                        toHexPrefixed(tr.postState.rootHash().asBytes()) + " in " + trInfo);
+                    BOOST_CHECK_MESSAGE(
+                        _expects.at("hash").get_str() == toHex(tr.postState.rootHash().asBytes()),
+                        TestOutputHelper::get().testName() + " on " +
+                            test::netIdToString(tr.netId) +
+                            ": Expected another postState hash! expected: " +
+                            _expects.at("hash").get_str() + " actual: " +
+                            toHexPrefixed(tr.postState.rootHash().asBytes()) + " in " + trInfo);
                     if (_expects.count("logs"))
                         BOOST_CHECK_MESSAGE(
                                     _expects.at("logs").get_str() == exportLog(tr.output.second.log()),

--- a/test/tools/libtesteth/TestHelper.cpp
+++ b/test/tools/libtesteth/TestHelper.cpp
@@ -224,7 +224,7 @@ string exportLog(eth::LogEntries const& _logs)
     s.appendList(_logs.size());
     for (LogEntry const& l : _logs)
         l.streamRLP(s);
-    return toHexPrefixed(sha3(s.out()));
+    return toHex(sha3(s.out()));
 }
 
 u256 toU256(json_spirit::mValue const& _v)
@@ -578,15 +578,16 @@ void requireJsonFields(json_spirit::mObject const& _o, string const& _section,
         BOOST_CHECK_MESSAGE(_validationMap.count(field.first),
             field.first + " should not be declared in " + _section + " section!");
 
-    // check field types with validation map
-    for (auto const vmap : _validationMap)
-    {
-        BOOST_REQUIRE_MESSAGE(
-            _o.count(vmap.first) > 0, vmap.first + " not found in " + _section + " section!");
-        BOOST_REQUIRE_MESSAGE(_o.at(vmap.first).type() == vmap.second,
-            _section + " " + vmap.first + " expected to be " + jsonTypeAsString(vmap.second) +
-                ", but set to " + jsonTypeAsString(_o.at(vmap.first).type()));
-    }
+    /*    // check field types with validation map
+        for (auto const vmap : _validationMap)
+        {
+            BOOST_REQUIRE_MESSAGE(
+                _o.count(vmap.first) > 0, vmap.first + " not found in " + _section + " section!");
+            BOOST_REQUIRE_MESSAGE(_o.at(vmap.first).type() == vmap.second,
+                _section + " " + vmap.first + " expected to be " + jsonTypeAsString(vmap.second) +
+                    ", but set to " + jsonTypeAsString(_o.at(vmap.first).type()));
+        }
+        */
 }
 
 string prepareVersionString()

--- a/test/tools/libtesteth/TestSuite.cpp
+++ b/test/tools/libtesteth/TestSuite.cpp
@@ -90,30 +90,30 @@ void addClientInfo(json_spirit::mValue& _v, fs::path const& _testSource, h256 co
 		o["_info"] = clientinfo;
 	}
 }
-
+/*
 void checkFillerHash(fs::path const& _compiledTest, fs::path const& _sourceTest)
 {
     json_spirit::mValue filledTest;
     string const s = dev::contentsString(_compiledTest);
-	BOOST_REQUIRE_MESSAGE(s.length() > 0, "Contents of " + _compiledTest.string() + " is empty.");
+    BOOST_REQUIRE_MESSAGE(s.length() > 0, "Contents of " + _compiledTest.string() + " is empty.");
     json_spirit::read_string(s, filledTest);
 
     TestFileData fillerData = readTestFile(_sourceTest);
     for (auto& i: filledTest.get_obj())
-	{
-		BOOST_REQUIRE_MESSAGE(i.second.type() == json_spirit::obj_type, i.first + " should contain an object under a test name.");
-		json_spirit::mObject const& obj = i.second.get_obj();
-		BOOST_REQUIRE_MESSAGE(obj.count("_info") > 0, "_info section not set! " + _compiledTest.string());
-		json_spirit::mObject const& info = obj.at("_info").get_obj();
-		BOOST_REQUIRE_MESSAGE(info.count("sourceHash") > 0, "sourceHash not found in " + _compiledTest.string() + " in " + i.first);
-		h256 const sourceHash = h256(info.at("sourceHash").get_str());
-        BOOST_CHECK_MESSAGE(sourceHash == fillerData.hash,
-            "Test " + _compiledTest.string() + " in " + i.first +
-                " is outdated. Filler hash is different! ( '" + sourceHash.hex().substr(0, 4) +
+    {
+        BOOST_REQUIRE_MESSAGE(i.second.type() == json_spirit::obj_type, i.first + " should contain
+an object under a test name."); json_spirit::mObject const& obj = i.second.get_obj();
+        BOOST_REQUIRE_MESSAGE(obj.count("_info") > 0, "_info section not set! " +
+_compiledTest.string()); json_spirit::mObject const& info = obj.at("_info").get_obj();
+        BOOST_REQUIRE_MESSAGE(info.count("sourceHash") > 0, "sourceHash not found in " +
+_compiledTest.string() + " in " + i.first); h256 const sourceHash =
+h256(info.at("sourceHash").get_str()); BOOST_CHECK_MESSAGE(sourceHash == fillerData.hash, "Test " +
+_compiledTest.string() + " in " + i.first + " is outdated. Filler hash is different! ( '" +
+sourceHash.hex().substr(0, 4) +
                 "' != '" + fillerData.hash.hex().substr(0, 4) + "') ");
     }
 }
-
+*/
 }
 
 namespace dev
@@ -137,31 +137,37 @@ void TestSuite::runAllTestsInFolder(string const& _testFolder) const
 {
 	// check that destination folder test files has according Filler file in src folder
 	string const filter = test::Options::get().singleTestName.empty() ? string() : test::Options::get().singleTestName;
-	vector<fs::path> const compiledFiles = test::getFiles(getFullPath(_testFolder), {".json", ".yml"} ,filter);
-	for (auto const& file: compiledFiles)
-	{
-		fs::path const expectedFillerName = getFullPathFiller(_testFolder) / fs::path(file.stem().string() + c_fillerPostf + ".json");
-		fs::path const expectedFillerName2 = getFullPathFiller(_testFolder) / fs::path(file.stem().string() + c_fillerPostf + ".yml");
-		fs::path const expectedCopierName = getFullPathFiller(_testFolder) / fs::path(file.stem().string() + c_copierPostf + ".json");
-		BOOST_REQUIRE_MESSAGE(fs::exists(expectedFillerName) || fs::exists(expectedFillerName2) || fs::exists(expectedCopierName), "Compiled test folder contains test without Filler: " + file.filename().string());
-		BOOST_REQUIRE_MESSAGE(!(fs::exists(expectedFillerName) && fs::exists(expectedFillerName2) && fs::exists(expectedCopierName)), "Src test could either be Filler.json, Filler.yml or Copier.json: " + file.filename().string());
+    /*	vector<fs::path> const compiledFiles = test::getFiles(getFullPath(_testFolder), {".json",
+       ".yml"} ,filter); for (auto const& file: compiledFiles)
+        {
+            fs::path const expectedFillerName = getFullPathFiller(_testFolder) /
+       fs::path(file.stem().string() + c_fillerPostf + ".json"); fs::path const expectedFillerName2
+       = getFullPathFiller(_testFolder) / fs::path(file.stem().string() + c_fillerPostf + ".yml");
+            fs::path const expectedCopierName = getFullPathFiller(_testFolder) /
+       fs::path(file.stem().string() + c_copierPostf + ".json");
+            BOOST_REQUIRE_MESSAGE(fs::exists(expectedFillerName) || fs::exists(expectedFillerName2)
+       || fs::exists(expectedCopierName), "Compiled test folder contains test without Filler: " +
+       file.filename().string()); BOOST_REQUIRE_MESSAGE(!(fs::exists(expectedFillerName) &&
+       fs::exists(expectedFillerName2) && fs::exists(expectedCopierName)), "Src test could either be
+       Filler.json, Filler.yml or Copier.json: " + file.filename().string());
 
-		// Check that filled tests created from actual fillers
-		if (Options::get().filltests == false)
-		{
-			if (fs::exists(expectedFillerName))
-				checkFillerHash(file, expectedFillerName);
-			if (fs::exists(expectedFillerName2))
-				checkFillerHash(file, expectedFillerName2);
-			if (fs::exists(expectedCopierName))
-				checkFillerHash(file, expectedCopierName);
-		}
-	}
+            // Check that filled tests created from actual fillers
+            if (Options::get().filltests == false)
+            {
+                if (fs::exists(expectedFillerName))
+                    checkFillerHash(file, expectedFillerName);
+                if (fs::exists(expectedFillerName2))
+                    checkFillerHash(file, expectedFillerName2);
+                if (fs::exists(expectedCopierName))
+                    checkFillerHash(file, expectedCopierName);
+            }
+        }
+    */
+    // run all tests
+    vector<fs::path> const files = test::getFiles(getFullPathFiller(_testFolder), {".json", ".yml"},
+        filter.empty() ? filter : filter + "Copier");
 
-	// run all tests
-	vector<fs::path> const files = test::getFiles(getFullPathFiller(_testFolder), {".json", ".yml"}, filter.empty() ? filter : filter + "Filler");
-
-	auto& testOutput = test::TestOutputHelper::get();
+    auto& testOutput = test::TestOutputHelper::get();
 	testOutput.initTest(files.size());
 	for (auto const& file: files)
 	{


### PR DESCRIPTION
I used this patch to coerce testeth to run the tests generated by Martin with fuzzer https://github.com/holiman/goevmlab/tree/master/cmd/sstoresload-generator
Tests: https://pynchon.swende.se/sstore/tests.zip
To run it I put the tests into `GeneralStateTests/stEIP2200` folder, and the copies of them into `src/GeneralStateTests/stEIP2200`, adding `Copier` suffix to each file name.

This might be also useful when we run the tests for Blake2 precompile (https://github.com/holiman/goevmlab/tree/master/cmd/blake-generator)