### PR TITLE
Improve database error logging

### DIFF
--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -74,6 +74,8 @@ DEV_SIMPLE_EXCEPTION(UnknownError);
 
 DEV_SIMPLE_EXCEPTION(InvalidDatabaseKind);
 DEV_SIMPLE_EXCEPTION(DatabaseAlreadyOpen);
+DEV_SIMPLE_EXCEPTION(DatabaseCorruption);
+
 DEV_SIMPLE_EXCEPTION(DAGCreationFailure);
 DEV_SIMPLE_EXCEPTION(DAGComputeFailure);
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -199,10 +199,6 @@ unsigned BlockChain::open(fs::path const& _path, WithExisting _we)
     fs::path const chainSubPathBlocks = chainPath / fs::path("blocks");
     fs::path const extrasPath = chainPath / fs::path(toString(c_databaseVersion));
     fs::path const extrasSubPathExtras = extrasPath / fs::path("extras");
-    fs::path const extrasSubPathOldExtras = extrasPath / fs::path("extras.old");
-    fs::path const extrasSubPathOldDetails = extrasPath / fs::path("details.old");
-    fs::path const extrasSubPathState = extrasPath / fs::path("state");
-    fs::path const extrasSubPathMinor = extrasPath / fs::path("minor");
     unsigned lastMinor = c_minorProtocolVersion;
 
     if (db::isDiskDatabase())
@@ -210,6 +206,7 @@ unsigned BlockChain::open(fs::path const& _path, WithExisting _we)
         fs::create_directories(extrasPath);
         DEV_IGNORE_EXCEPTIONS(fs::permissions(extrasPath, fs::owner_all));
 
+        fs::path const extrasSubPathMinor = extrasPath / fs::path("minor");
         bytes const status = contents(extrasSubPathMinor);
         if (!status.empty())
             DEV_IGNORE_EXCEPTIONS(lastMinor = (unsigned)RLP(status));
@@ -217,9 +214,9 @@ unsigned BlockChain::open(fs::path const& _path, WithExisting _we)
         {
             cnote << "Killing extras database " << extrasPath << " (DB minor version:" << lastMinor
                   << " != our minor version: " << c_minorProtocolVersion << ").";
-            DEV_IGNORE_EXCEPTIONS(fs::remove_all(extrasSubPathOldDetails));
-            fs::rename(extrasSubPathExtras, extrasSubPathOldExtras);
-            fs::remove_all(extrasSubPathState);
+            DEV_IGNORE_EXCEPTIONS(fs::remove_all(extrasPath / fs::path("details.old")));
+            fs::rename(extrasSubPathExtras, extrasPath / fs::path("extras.old"));
+            fs::remove_all(extrasPath / fs::path("state"));
             writeFile(extrasSubPathMinor, rlp(c_minorProtocolVersion));
             lastMinor = (unsigned)RLP(status);
         }

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -247,25 +247,25 @@ unsigned BlockChain::open(fs::path const& _path, WithExisting _we)
                 *boost::get_error_info<db::errinfo_dbStatusCode>(ex);
             if (fs::space(path).available < 1024)
             {
-                cwarn << "Failed to create database (" << dbPath
+                cerr << "Failed to create database (" << dbPath
                       << "). Not enough available space found on hard drive. Please free some up "
                          "and re-run.";
                 BOOST_THROW_EXCEPTION(NotEnoughAvailableSpace());
             }
             else if (dbStatus == db::DatabaseStatus::Corruption)
             {
-                cwarn << "Database corrupted (" << dbPath << ")";
+                cerr << "Database corrupted (" << dbPath << ")";
                 BOOST_THROW_EXCEPTION(DatabaseCorruption());
             }
             else if (dbStatus == db::DatabaseStatus::IOError)
             {
-                cwarn << "Database already open (" << dbPath
+                cerr << "Database already open (" << dbPath
                       << "). You appear to have another instance of ethereum running.";
                 BOOST_THROW_EXCEPTION(DatabaseAlreadyOpen());
             }
         }
 
-        cwarn << "Unknown error occurred when creating database (" << dbPath
+        cerr << "Unknown error occurred when creating database (" << dbPath
               << "). Exception details: " << ex.what();
         throw;
     }

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -239,32 +239,32 @@ unsigned BlockChain::open(fs::path const& _path, WithExisting _we)
     {
         // Determine which database open call failed
         auto const dbPath = !m_blocksDB.get() ? chainSubPathBlocks : extrasSubPathExtras;
-        cerr << "Error opening database: " << dbPath;
+        cerror << "Error opening database: " << dbPath;
 
         if (db::isDiskDatabase())
         {
             db::DatabaseStatus const dbStatus = *boost::get_error_info<db::errinfo_dbStatusCode>(ex);
             if (fs::space(path).available < 1024)
             {
-                cerr << "Not enough available space found on hard drive. Please free some up and "
+                cerror << "Not enough available space found on hard drive. Please free some up and "
                         "re-run.";
                 BOOST_THROW_EXCEPTION(NotEnoughAvailableSpace());
             }
             else if (dbStatus == db::DatabaseStatus::Corruption)
             {
-                cerr << "Database corruption detected. Please see the exception for corruption "
+                cerror << "Database corruption detected. Please see the exception for corruption "
                         "details. Exception: "
                     << ex.what();
                 BOOST_THROW_EXCEPTION(DatabaseCorruption());
             }
             else if (dbStatus == db::DatabaseStatus::IOError)
             {
-                cerr << "Database already open. You appear to have another instance of Aleth running.";
+                cerror << "Database already open. You appear to have another instance of Aleth running.";
                 BOOST_THROW_EXCEPTION(DatabaseAlreadyOpen());
             }
         }
         
-        cerr << "Unknown error occurred. Exception details: " << ex.what();
+        cerror << "Unknown error occurred. Exception details: " << ex.what();
         throw;
     }
 

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -87,7 +87,7 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
                 clog(VerbosityError, "statedb")
                     << "Database corruption detected. Please see the exception for corruption "
                        "details. Exception: "
-                    << ex.what();
+                    << boost::diagnostic_information(ex);
                 BOOST_THROW_EXCEPTION(DatabaseCorruption());
             }
             else if (dbStatus == db::DatabaseStatus::IOError)


### PR DESCRIPTION
Fix #5782, #5796 

Log error messages when database errors other than IO errors are detected during database opening/creation. Also improve existing error messages by including path to the database which triggered the error and the exception text (where appropriate).

What motivated these changes was that without them, Aleth exits silently when it tries to open a corrupted db. With these changes, Aleth logs the following:

```
aleth, a C++ Ethereum client
INFO  10-16 22:27:28 main net    Id: ##96f06434…
INFO  10-16 22:27:28 main net    ENR: [ seq=1 id=v4 key=0296f064… tcp=30303 udp=30303 ]
WARN  10-16 22:27:28 main warn   Database corrupted ("C:\Users\nilse\AppData\Roaming\Ethereum\d4e56740\blocks").
```