### PR TITLE
Populate legacy block's state from database instead of executing transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Added: [#5699](https://github.com/ethereum/aleth/pull/5699) EIP 2046: Reduced gas cost for static calls made to precompiles.
 - Added: [#5752](https://github.com/ethereum/aleth/pull/5752) [#5753](https://github.com/ethereum/aleth/pull/5753) Implement EIP1380 (reduced gas costs for call-to-self).
-- Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14. 
+- Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
+- Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).
 
 ## [1.7.0] - Unreleased
 

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -140,15 +140,14 @@ void Block::populateFromChain(BlockChain const& _bc, h256 const& _h)
 {
     if (!_bc.isKnown(_h))
     {
-        cerr << "Invalid block given for state population: " << _h;
+        cwarn << "Invalid block given for state population: " << _h;
         BOOST_THROW_EXCEPTION(BlockNotFound() << errinfo_target(_h));
     }
 
     auto const& blockBytes = _bc.block(_h);
-    m_currentBytes = blockBytes;
 
     // Set block headers
-    auto const& blockHeader = BlockHeader{blockBytes};
+    auto const blockHeader = BlockHeader{blockBytes};
     m_currentBlock = blockHeader;
 
     if (blockHeader.number())

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -182,8 +182,6 @@ void Block::populateFromChain(BlockChain const& _bc, h256 const& _h)
     }
     m_receipts = _bc.receipts(_h).receipts;
 
-    m_currentTxs = txListRLP.data().toBytes();
-    m_currentUncles = blockRLP[2].data().toBytes();
     m_author = blockHeader.author();
 
     m_committedToSeal = false;

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -138,45 +138,44 @@ void Block::noteChain(BlockChain const& _bc)
 
 PopulationStatistics Block::populateFromChain(BlockChain const& _bc, h256 const& _h, ImportRequirements::value _ir)
 {
-    noteChain(_bc);
-
-    PopulationStatistics ret { 0.0, 0.0 };
-
     if (!_bc.isKnown(_h))
     {
-        // Might be worth throwing here.
-        cwarn << "Invalid block given for state population: " << _h;
+        cerr << "Invalid block given for state population: " << _h;
         BOOST_THROW_EXCEPTION(BlockNotFound() << errinfo_target(_h));
     }
 
-    auto b = _bc.block(_h);
-    BlockHeader bi(b);		// No need to check - it's already in the DB.
-    if (bi.number())
-    {
-        // Non-genesis:
+    auto const& blockBytes = _bc.block(_h);
+    m_currentBytes = blockBytes;
 
-        // 1. Start at parent's end state (state root).
-        BlockHeader bip(_bc.block(bi.parentHash()));
-        sync(_bc, bi.parentHash(), bip);
+    auto const& blockHeader = BlockHeader{blockBytes};
+    m_currentBlock = blockHeader;
 
-        // 2. Enact the block's transactions onto this state.
-        m_author = bi.author();
-        Timer t;
-        auto vb = _bc.verifyBlock(&b, function<void(Exception&)>(), _ir | ImportRequirements::TransactionBasic);
-        ret.verify = t.elapsed();
-        t.restart();
-        enact(vb, _bc);
-        ret.enact = t.elapsed();
-    }
+    // Set state root and precommit state
+    m_state.setRoot(blockHeader.stateRoot());
+    m_precommit = m_state;
+
+    if (blockHeader.number())
+        m_previousBlock = _bc.info(blockHeader.hash());
     else
-    {
-        // Genesis required:
-        // We know there are no transactions, so just populate directly.
-        m_state = State(m_state.accountStartNonce(), m_state.db(), BaseState::Empty);	// TODO: try with PreExisting.
-        sync(_bc, _h, bi);
-    }
+        m_previousBlock = m_currentBlock;
 
-    return ret;
+    RLP blockRLP{blockBytes};
+    auto const& txListRLP = blockRLP[1];
+    for (auto const& txRLP : txListRLP)
+    {
+        m_transactions.push_back(Transaction{txRLP.data(), CheckTransaction::None});
+        m_transactionSet.insert(m_transactions.back().sha3());
+    }
+    m_receipts = _bc.receipts(_h).receipts;
+
+    m_currentTxs = txListRLP.data().toBytes();
+    m_currentUncles = blockRLP[2].data().toBytes();
+    m_author = blockHeader.author();
+
+    m_committedToSeal = false;
+    m_sealEngine = _bc.sealEngine();
+
+    return PopulationStatistics{};
 }
 
 bool Block::sync(BlockChain const& _bc)

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -243,10 +243,6 @@ public:
     /// @returns true if sealed - in this case you can no longer append transactions.
     bool isSealed() const { return !m_currentBytes.empty(); }
 
-    /// Clears the block bytes - typically used in cases where we want to mutate a sealed
-    /// block's state (e.g. eth_call)
-    void unseal() { m_currentBytes.clear(); }
-
     /// Get the complete current block, including valid nonce.
     /// Only valid when isSealed() is true.
     bytes const& blockData() const { return m_currentBytes; }

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -35,12 +35,6 @@ class TransactionQueue;
 struct VerifiedBlockRef;
 class LastBlockHashesFace;
 
-struct PopulationStatistics
-{
-    double verify;
-    double enact;
-};
-
 DEV_SIMPLE_EXCEPTION(ChainOperationWithUnknownBlockChain);
 DEV_SIMPLE_EXCEPTION(InvalidOperationOnSealedBlock);
 
@@ -190,7 +184,7 @@ public:
     // State-change operations
 
     /// Construct state object from arbitrary point in blockchain.
-    PopulationStatistics populateFromChain(BlockChain const& _bc, h256 const& _hash, ImportRequirements::value _ir = ImportRequirements::None);
+    void populateFromChain(BlockChain const& _bc, h256 const& _hash);
 
     /// Execute a given transaction.
     /// This will append @a _t to the transaction list and change the state accordingly.

--- a/libethereum/Block.h
+++ b/libethereum/Block.h
@@ -243,6 +243,10 @@ public:
     /// @returns true if sealed - in this case you can no longer append transactions.
     bool isSealed() const { return !m_currentBytes.empty(); }
 
+    /// Clears the block bytes - typically used in cases where we want to mutate a sealed
+    /// block's state (e.g. eth_call)
+    void unseal() { m_currentBytes.clear(); }
+
     /// Get the complete current block, including valid nonce.
     /// Only valid when isSealed() is true.
     bytes const& blockData() const { return m_currentBytes; }

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -901,6 +901,7 @@ ExecutionResult Client::call(Address const& _from, u256 _value, Address _dest, b
     try
     {
         Block temp = blockByNumber(_blockNumber);
+        temp.unseal();  // Unseal block since we're going to be executing a transaction
         u256 nonce = max<u256>(temp.transactionsFrom(_from), m_tq.maxNonce(_from));
         u256 gas = _gas == Invalid256 ? gasLimitRemaining() : _gas;
         u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -759,37 +759,19 @@ void Client::prepareForTransaction()
     startWorking();
 }
 
-Block Client::block(h256 const& _block) const
+Block Client::block(h256 const& _blockHash) const
 {
     try
     {
-        Block ret(bc(), m_stateDB);
-        ret.populateFromChain(bc(), _block);
-        return ret;
-    }
-    catch (Exception& ex)
-    {
-        ex << errinfo_block(bc().block(_block));
-        onBadBlock(ex);
-        return Block(bc());
-    }
-}
-
-Block Client::block(h256 const& _blockHash, PopulationStatistics* o_stats) const
-{
-    try
-    {
-        Block ret(bc(), m_stateDB);
-        PopulationStatistics s = ret.populateFromChain(bc(), _blockHash);
-        if (o_stats)
-            swap(s, *o_stats);
+        Block ret{bc(), m_stateDB};
+        ret.populateFromChain(bc(), _blockHash);
         return ret;
     }
     catch (Exception& ex)
     {
         ex << errinfo_block(bc().block(_blockHash));
         onBadBlock(ex);
-        return Block(bc());
+        return Block{bc()};
     }
 }
 

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -901,7 +901,6 @@ ExecutionResult Client::call(Address const& _from, u256 _value, Address _dest, b
     try
     {
         Block temp = blockByNumber(_blockNumber);
-        temp.unseal();  // Unseal block since we're going to be executing a transaction
         u256 nonce = max<u256>(temp.transactionsFrom(_from), m_tq.maxNonce(_from));
         u256 gas = _gas == Invalid256 ? gasLimitRemaining() : _gas;
         u256 gasPrice = _gasPrice == Invalid256 ? gasBidPrice() : _gasPrice;

--- a/libethereum/Client.h
+++ b/libethereum/Client.h
@@ -100,10 +100,6 @@ public:
     /// Get the gas bid price
     u256 gasBidPrice() const override { return m_gp->bid(); }
 
-    // [PRIVATE API - only relevant for base clients, not available in general]
-    /// Get the block.
-    dev::eth::Block block(h256 const& _blockHash, PopulationStatistics* o_stats) const;
-
     /// Get the object representing the current state of Ethereum.
     dev::eth::Block postState() const { ReadGuard l(x_postSeal); return m_postSeal; }
     /// Get the object representing the current canonical blockchain.

--- a/libweb3jsonrpc/AdminEth.cpp
+++ b/libweb3jsonrpc/AdminEth.cpp
@@ -179,18 +179,6 @@ h256 AdminEth::blockHash(string const& _blockNumberOrHash) const
     }
 }
 
-Json::Value AdminEth::admin_eth_reprocess(string const& _blockNumberOrHash, string const& _session)
-{
-    RPC_ADMIN;
-    Json::Value ret;
-    PopulationStatistics ps;
-    m_eth.block(blockHash(_blockNumberOrHash), &ps);
-    ret["enact"] = ps.enact;
-    ret["verify"] = ps.verify;
-    ret["total"] = ps.verify + ps.enact;
-    return ret;
-}
-
 Json::Value AdminEth::admin_eth_vmTrace(string const& _blockNumberOrHash, int _txIndex, string const& _session)
 {
     RPC_ADMIN;

--- a/libweb3jsonrpc/AdminEth.h
+++ b/libweb3jsonrpc/AdminEth.h
@@ -38,7 +38,6 @@ public:
 	virtual Json::Value admin_eth_newAccount(const Json::Value& _info, std::string const& _session) override;
 	virtual bool admin_eth_setMiningBenefactor(std::string const& _uuidOrAddress, std::string const& _session) override;
 	virtual Json::Value admin_eth_inspect(std::string const& _address, std::string const& _session) override;
-	virtual Json::Value admin_eth_reprocess(std::string const& _blockNumberOrHash, std::string const& _session) override;
 	virtual Json::Value admin_eth_vmTrace(std::string const& _blockNumberOrHash, int _txIndex, std::string const& _session) override;
 	virtual Json::Value admin_eth_getReceiptByHashAndIndex(std::string const& _blockNumberOrHash, int _txIndex, std::string const& _session) override;
 	virtual bool miner_start(int _threads) override;

--- a/libweb3jsonrpc/AdminEthFace.h
+++ b/libweb3jsonrpc/AdminEthFace.h
@@ -25,7 +25,6 @@ namespace dev {
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_eth_newAccount", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_OBJECT,"param2",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminEthFace::admin_eth_newAccountI);
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_eth_setMiningBenefactor", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminEthFace::admin_eth_setMiningBenefactorI);
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_eth_inspect", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminEthFace::admin_eth_inspectI);
-                    this->bindAndAddMethod(jsonrpc::Procedure("admin_eth_reprocess", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminEthFace::admin_eth_reprocessI);
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_eth_vmTrace", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER,"param3",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminEthFace::admin_eth_vmTraceI);
                     this->bindAndAddMethod(jsonrpc::Procedure("admin_eth_getReceiptByHashAndIndex", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, "param1",jsonrpc::JSON_STRING,"param2",jsonrpc::JSON_INTEGER,"param3",jsonrpc::JSON_STRING, NULL), &dev::rpc::AdminEthFace::admin_eth_getReceiptByHashAndIndexI);
                     this->bindAndAddMethod(jsonrpc::Procedure("miner_start", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_BOOLEAN, "param1",jsonrpc::JSON_INTEGER, NULL), &dev::rpc::AdminEthFace::miner_startI);
@@ -80,10 +79,6 @@ namespace dev {
                 {
                     response = this->admin_eth_inspect(request[0u].asString(), request[1u].asString());
                 }
-                inline virtual void admin_eth_reprocessI(const Json::Value &request, Json::Value &response)
-                {
-                    response = this->admin_eth_reprocess(request[0u].asString(), request[1u].asString());
-                }
                 inline virtual void admin_eth_vmTraceI(const Json::Value &request, Json::Value &response)
                 {
                     response = this->admin_eth_vmTrace(request[0u].asString(), request[1u].asInt(), request[2u].asString());
@@ -129,7 +124,6 @@ namespace dev {
                 virtual Json::Value admin_eth_newAccount(const Json::Value& param1, const std::string& param2) = 0;
                 virtual bool admin_eth_setMiningBenefactor(const std::string& param1, const std::string& param2) = 0;
                 virtual Json::Value admin_eth_inspect(const std::string& param1, const std::string& param2) = 0;
-                virtual Json::Value admin_eth_reprocess(const std::string& param1, const std::string& param2) = 0;
                 virtual Json::Value admin_eth_vmTrace(const std::string& param1, int param2, const std::string& param3) = 0;
                 virtual Json::Value admin_eth_getReceiptByHashAndIndex(const std::string& param1, int param2, const std::string& param3) = 0;
                 virtual bool miner_start(int param1) = 0;

--- a/libweb3jsonrpc/admin_eth.json
+++ b/libweb3jsonrpc/admin_eth.json
@@ -10,7 +10,6 @@
 { "name": "admin_eth_newAccount", "params": [{}, ""], "returns": {} },
 { "name": "admin_eth_setMiningBenefactor", "params": ["", ""], "returns": true },
 { "name": "admin_eth_inspect", "params": ["", ""], "returns": {} },
-{ "name": "admin_eth_reprocess", "params": ["", ""], "returns": {} },
 { "name": "admin_eth_vmTrace", "params": ["", 0, ""], "returns": {} },
 { "name": "admin_eth_getReceiptByHashAndIndex", "params": ["", 0, ""], "returns": {} },
 { "name": "miner_start", "params": [0], "returns": true },

--- a/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
+++ b/test/unittests/libweb3jsonrpc/WebThreeStubClient.h
@@ -924,17 +924,6 @@ class WebThreeStubClient : public jsonrpc::Client
             else
                 throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
         }
-        Json::Value admin_eth_reprocess(const std::string& param1, const std::string& param2) throw (jsonrpc::JsonRpcException)
-        {
-            Json::Value p;
-            p.append(param1);
-            p.append(param2);
-            Json::Value result = this->CallMethod("admin_eth_reprocess",p);
-            if (result.isObject())
-                return result;
-            else
-                throw jsonrpc::JsonRpcException(jsonrpc::Errors::ERROR_CLIENT_INVALID_RESPONSE, result.toStyledString());
-        }
         Json::Value admin_eth_vmTrace(const std::string& param1, int param2, const std::string& param3) throw (jsonrpc::JsonRpcException)
         {
             Json::Value p;


### PR DESCRIPTION
Fix #5034 

### Description
These changes optimize the function that the client calls to initialize a `Block `object with blockchain data (`Block::populateFromChain`). Note that `Block::populateFromChain` is called by numerous RPC functions e.g. `eth_call`, `eth_getBalance`, `eth_sendTransaction`.

For context, the Client calls `Block::populateFromChain` to create a new `Block `object that's initialized with data from a blockchain block with a specific hash - this initialized `Block `can then be queried for specific data (e.g. `eth_getBalance`) or used to execute a transaction (`eth_call` and `eth_sendTransaction`). 

Prior to these changes, `Block::populateFromChain` populated a block by retrieving the target block's  header and parent's block header and block bytes from the blockchain and initializing various block fields using this information (e.g. current block header `Block::m_currentBlock`, parent block header `Block::m_previousBlock`). It would also verify the target block's header and build the target block's state trie and generate the transaction receipts by setting the block being populated's state root to the parent's state and executing all of the transactions (retrieved from the target block's bytes). The verification step and tx execution steps are obviously unnecessary - rather, we can simply retrieve the state root from the state database and retrieve the transactions and receipts from the block bytes (which we get from the block database). 

My changes retrieve the block headers and block bytes from the database as before - however, I don't verify the block (not necessary since it was already verified during import) and I don't execute the transactions..rather I read the tx receipts from the block bytes and read the state root from the state database. 

### Validation
I validated my changes by retrieving the genesis block and a block with several transactions ([64999](https://etherscan.io/block/64999)) via RPC (web3.eth.getBlock) and comparing the results against a "stock" Aleth and verifying the results were identical. Results:

**Genesis Block**
Without Changes
```
  author: "0x0000000000000000000000000000000000000000",
  boundary: "0x0000000040000000000000000000000000000000000000000000000000000000",
  difficulty: 17179869184,
  extraData: "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
  gasLimit: 5000,
  gasUsed: 0,
  hash: "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  miner: "0x0000000000000000000000000000000000000000",
  mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
  nonce: "0x0000000000000042",
  number: 0,
  parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
  receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  seedHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  size: 76,
  stateRoot: "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544",
  timestamp: 0,
  totalDifficulty: 17179869184,
  transactions: [],
  transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  uncles: []
```

With Changes
```
  author: "0x0000000000000000000000000000000000000000",
  boundary: "0x0000000040000000000000000000000000000000000000000000000000000000",
  difficulty: 17179869184,
  extraData: "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
  gasLimit: 5000,
  gasUsed: 0,
  hash: "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  miner: "0x0000000000000000000000000000000000000000",
  mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
  nonce: "0x0000000000000042",
  number: 0,
  parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
  receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  seedHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  size: 76,
  stateRoot: "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544",
  timestamp: 0,
  totalDifficulty: 17179869184,
  transactions: [],
  transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  uncles: []
```

**Block 64999**
Without Changes
```
 author: "0xf927a40c8b7f6e07c5af7fa2155b4864a4112b13",
  boundary: "0x0000000000932bb9e4d20f331c0fd1eda100ae03dd36d33a9b2a6a0e9cd3915e",
  difficulty: 1912573463224,
  extraData: "",
  gasLimit: 3141592,
  gasUsed: 118496,
  hash: "0x650ec59d844817aff623efdc7a976e2f7005b17035e5ac5e7025747fbc4091ad",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  miner: "0xf927a40c8b7f6e07c5af7fa2155b4864a4112b13",
  mixHash: "0xdfe2a94512f29e4363b48d0e8661a78f11d41e6fd36d9f2cd91e0c77ba0d8082",
  nonce: "0x5f7c213366edf1ef",
  number: 64999,
  parentHash: "0x23ee2f4a420e1ce4beb6d5902fafa232c0d5718146e53a31b179c86949191b85",
  receiptsRoot: "0x61b8587e6a557ecefb87f0091be5b894c197a5b43d3960093bd051589351bc32",
  seedHash: "0x510e4e770828ddbf7f7b00ab00a9f6adaf81c0dc9cc85f1f8249c256942d61d9",
  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  size: 0,
  stateRoot: "0x4db358e5d7eca7ead868e622e560b2c4d4588147aee681905ad7acc17e8fd8ec",
  timestamp: 1439229736,
  totalDifficulty: 73588533123492323,
  transactions: ["0xa047af96f2342ff7bc1a061b6d83a9f00af0c7986bb24924391bf0e83de22f85", "0x49be91905241a1bac6e9cfd2568be07aa4c2c13aec5c2ce4f63f27068a5836b1", "0x9acb4b6573444ed7ed12cd8920fdcded1beadacb1872228ce09b34ccfce8e008"],
  transactionsRoot: "0xac021c3d56771233aebe36ebb0442373812b0489c3b478309339991d6dd51a71",
  uncles: []
```

With Changes 
```
  author: "0xf927a40c8b7f6e07c5af7fa2155b4864a4112b13",
  boundary: "0x0000000000932bb9e4d20f331c0fd1eda100ae03dd36d33a9b2a6a0e9cd3915e",
  difficulty: 1912573463224,
  extraData: "",
  gasLimit: 3141592,
  gasUsed: 118496,
  hash: "0x650ec59d844817aff623efdc7a976e2f7005b17035e5ac5e7025747fbc4091ad",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  miner: "0xf927a40c8b7f6e07c5af7fa2155b4864a4112b13",
  mixHash: "0xdfe2a94512f29e4363b48d0e8661a78f11d41e6fd36d9f2cd91e0c77ba0d8082",
  nonce: "0x5f7c213366edf1ef",
  number: 64999,
  parentHash: "0x23ee2f4a420e1ce4beb6d5902fafa232c0d5718146e53a31b179c86949191b85",
  receiptsRoot: "0x61b8587e6a557ecefb87f0091be5b894c197a5b43d3960093bd051589351bc32",
  seedHash: "0x510e4e770828ddbf7f7b00ab00a9f6adaf81c0dc9cc85f1f8249c256942d61d9",
  sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
  size: 0,
  stateRoot: "0x4db358e5d7eca7ead868e622e560b2c4d4588147aee681905ad7acc17e8fd8ec",
  timestamp: 1439229736,
  totalDifficulty: 73588533123492323,
  transactions: ["0xa047af96f2342ff7bc1a061b6d83a9f00af0c7986bb24924391bf0e83de22f85", "0x49be91905241a1bac6e9cfd2568be07aa4c2c13aec5c2ce4f63f27068a5836b1", "0x9acb4b6573444ed7ed12cd8920fdcded1beadacb1872228ce09b34ccfce8e008"],
  transactionsRoot: "0xac021c3d56771233aebe36ebb0442373812b0489c3b478309339991d6dd51a71",
  uncles: []
```
