### PR TITLE
Fix reported client version string (in RPC and devp2p)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Fixed: [#5706](https://github.com/ethereum/aleth/pull/5706) Stop tracking sent transactions after they've been imported into the blockchain.
 - Fixed: [#5687](https://github.com/ethereum/aleth/pull/5687) Limit transaction queue's dropped transaction history to 1024 transactions.
 - Fixed: [#5718](https://github.com/ethereum/aleth/pull/5718) Avoid checking contract balance or destination account existence when executing self-destruct operations on Frontier and Homestead.
+- Fixed: [#5803](https://github.com/ethereum/aleth/pull/5803) Client version string reported by RPC and devp2p now better matches the format used by other clients. This will allow aleth to be correctly listed on ethernodes.org.
 
 ## [1.6.0] - 2019-04-16
 

--- a/libwebthree/WebThree.cpp
+++ b/libwebthree/WebThree.cpp
@@ -61,7 +61,7 @@ WebThreeDirect::~WebThreeDirect()
 std::string WebThreeDirect::composeClientVersion(std::string const& _client)
 {
     const auto* buildinfo = aleth_get_buildinfo();
-    return _client + "/" + buildinfo->project_version + "/" + buildinfo->system_name + "/" +
+    return _client + "/v" + buildinfo->project_version + "/" + buildinfo->system_name + "/" +
            buildinfo->compiler_id + buildinfo->compiler_version + "/" + buildinfo->build_type;
 }
 


### PR DESCRIPTION
Now the version is for example `aleth/v1.8.0-alpha.0-14+commit.5c76154e.dirty/linux/clang9.0.0/debug`

I suggest to include this fix into 1.7 branch.

Resolves https://github.com/ethereum/aleth/issues/5785