### PR TITLE
Optimize SELFDESTRUCT opcode in LegacyVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added: [#5699](https://github.com/ethereum/aleth/pull/5699) EIP 2046: Reduced gas cost for static calls made to precompiles.
 - Added: [#5752](https://github.com/ethereum/aleth/pull/5752) [#5753](https://github.com/ethereum/aleth/pull/5753) Implement EIP1380 (reduced gas costs for call-to-self).
+- Changed: [#5807](https://github.com/ethereum/aleth/pull/5807) Optimize selfdestruct opcode in LegacyVM by reducing state accesses in certain out-of-gas scenarios.
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
 - Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).
 

--- a/libevm/LegacyVM.cpp
+++ b/libevm/LegacyVM.cpp
@@ -323,6 +323,7 @@ void LegacyVM::interpretCases()
 
             // Self-destructs only have gas cost starting with EIP 150
             m_runGas = toInt63(m_schedule->selfdestructGas);
+            updateIOGas();
 
             Address const dest = asAddress(m_SP[0]);
             // Starting with EIP150, self-destructs need to pay both gas cost and account creation
@@ -332,10 +333,12 @@ void LegacyVM::interpretCases()
                 (!m_schedule->eip158Mode || m_ext->balance(m_ext->myAddress) > 0))
             {
                 if (!m_ext->exists(dest))
-                    m_runGas += m_schedule->callNewAccountGas;
+                {
+                    m_runGas = m_schedule->callNewAccountGas;
+                    updateIOGas();
+                }
             }
 
-            updateIOGas();
             m_ext->selfdestruct(dest);
             m_bounce = 0;
         }


### PR DESCRIPTION
Check if transaction has enough gas to fund base gas cost for SELFDESTRUCT opcode before checking Ethereum state