### PR TITLE
Move LegacyVM EIP-1380 implementation from Berlin to individual activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added: [#5699](https://github.com/ethereum/aleth/pull/5699) EIP 2046: Reduced gas cost for static calls made to precompiles.
 - Added: [#5741](https://github.com/ethereum/aleth/pull/5741) Support for individual EIP activation to facilitate EIP-centric network upgrade process.
-- Added: [#5752](https://github.com/ethereum/aleth/pull/5752) [#5753](https://github.com/ethereum/aleth/pull/5753) Implement EIP1380 (reduced gas costs for call-to-self).
+- Added: [#5752](https://github.com/ethereum/aleth/pull/5752) [#5753](https://github.com/ethereum/aleth/pull/5753) [#5809](https://github.com/ethereum/aleth/pull/5809) Implement EIP1380 (reduced gas costs for call-to-self).
 - Changed: [#5750](https://github.com/ethereum/aleth/pull/5750) Use `testeth -t <SUITE_NAME> -- --testfile <PATH>` to run the tests from file at any path. Use `testeth -t <SUITE_NAME> -- --testfile <PATH> --singletest <TEST_NAME>` to run only single test from any file.
 - Changed: [#5801](https://github.com/ethereum/aleth/pull/5801) `testeth -t BlockchainTests` command now doesn't run the tests for the forks before Istanbul. To run those tests use a separate LegacyTests suite with command `testeth -t LegacyTests/Constantinople/BlockchainTests`.
 - Changed: [#5807](https://github.com/ethereum/aleth/pull/5807) Optimize selfdestruct opcode in LegacyVM by reducing state accesses in certain out-of-gas scenarios.

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -56,6 +56,7 @@ constexpr int64_t c_infiniteBlockNumber = std::numeric_limits<int64_t>::max();
 
 struct AdditionalEIPs
 {
+    bool eip1380 = false;
     bool eip2046 = false;
 };
 

--- a/libethcore/EVMSchedule.cpp
+++ b/libethcore/EVMSchedule.cpp
@@ -12,6 +12,8 @@ namespace eth
 EVMSchedule::EVMSchedule(EVMSchedule const& _schedule, AdditionalEIPs const& _eips)
   : EVMSchedule(_schedule)
 {
+    if (_eips.eip1380)
+        callSelfGas = 40;
     if (_eips.eip2046)
         precompileStaticCallGas = 40;
 }

--- a/libethcore/EVMSchedule.h
+++ b/libethcore/EVMSchedule.h
@@ -160,7 +160,6 @@ static const EVMSchedule IstanbulSchedule = [] {
 
 static const EVMSchedule BerlinSchedule = [] {
     EVMSchedule schedule = IstanbulSchedule;
-    schedule.callSelfGas = 40;
     return schedule;
 }();
 

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -63,6 +63,8 @@ ChainParams createChainParamsForNetwork(string const& _networkName)
     AdditionalEIPs eips;
     for (auto it = networkAndEIPs.begin() + 1; it != networkAndEIPs.end(); ++it)
     {
+        if (*it == "1380")
+            eips.eip1380 = true;
         if (*it == "2046")
             eips.eip2046 = true;
     }


### PR DESCRIPTION
I've created one test to check this (only for CALL)
https://github.com/ethereum/tests/commit/b7dfd94d252714f53557260421e52eed8d76c0e2