### PR TITLE
Fix ChainParams::loadConfig not loading precompile configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
 - Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).
 - Fixed: [#5811](https://github.com/ethereum/aleth/pull/5811) RPC methods querying transactions (`eth_getTransactionByHash`, `eth_getBlockByNumber`) return correct `v` value.
+- Fixed: [#5821](https://github.com/ethereum/aleth/pull/5821) `test_setChainParams` correctly initializes custom configuration of precompiled contracts.
 
 ## [1.7.0] - 2019-11-14
 

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -677,7 +677,7 @@ int main(int argc, char** argv)
     {
         try
         {
-            chainParams = chainParams.loadConfig(configJSON, {}, configPath);
+            chainParams = ChainParams{configJSON, {}, configPath};
             chainConfigIsSet = true;
         }
         catch (...)

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -54,9 +54,10 @@ ChainParams::ChainParams()
     precompiled.insert(make_pair(Address(4), PrecompiledContract(15, 3, PrecompiledRegistrar::executor("identity"))));
 }
 
-ChainParams::ChainParams(string const& _json, h256 const& _stateRoot)
+ChainParams::ChainParams(
+    string const& _json, h256 const& _stateRoot, boost::filesystem::path const& _configPath)
 {
-    *this = loadConfig(_json, _stateRoot);
+    loadConfig(_json, _stateRoot, _configPath);
 }
 
 ChainParams::ChainParams(std::string const& _configJson, AdditionalEIPs const& _additionalEIPs)
@@ -69,10 +70,9 @@ ChainParams::ChainParams(std::string const& _configJson, AdditionalEIPs const& _
     lastForkWithAdditionalEIPsSchedule = EVMSchedule{lastForkSchedule, _additionalEIPs};
 }
 
-ChainParams ChainParams::loadConfig(
-        string const& _json, h256 const& _stateRoot, const boost::filesystem::path& _configPath) const
+void ChainParams::loadConfig(
+    string const& _json, h256 const& _stateRoot, boost::filesystem::path const& _configPath)
 {
-    ChainParams cp(*this);
     js::mValue val;
 
     try
@@ -93,95 +93,94 @@ ChainParams ChainParams::loadConfig(
     validateConfigJson(obj);
 
     // params
-    cp.sealEngineName = obj[c_sealEngine].get_str();
+    sealEngineName = obj[c_sealEngine].get_str();
     js::mObject params = obj[c_params].get_obj();
 
     // Params that are not required and could be set to default value
     if (params.count(c_accountStartNonce))
-        cp.accountStartNonce = fromBigEndian<u256>(fromHex(params[c_accountStartNonce].get_str()));
+        accountStartNonce = fromBigEndian<u256>(fromHex(params[c_accountStartNonce].get_str()));
     if (params.count(c_maximumExtraDataSize))
-        cp.maximumExtraDataSize =
+        maximumExtraDataSize =
             fromBigEndian<u256>(fromHex(params[c_maximumExtraDataSize].get_str()));
 
-    cp.tieBreakingGas = params.count(c_tieBreakingGas) ? params[c_tieBreakingGas].get_bool() : true;
+    tieBreakingGas = params.count(c_tieBreakingGas) ? params[c_tieBreakingGas].get_bool() : true;
     if (params.count(c_blockReward))
-        cp.setBlockReward(fromBigEndian<u256>(fromHex(params[c_blockReward].get_str())));
+        setBlockReward(fromBigEndian<u256>(fromHex(params[c_blockReward].get_str())));
 
     auto setOptionalU256Parameter = [&params](u256 &_destination, string const& _name)
     {
         if (params.count(_name))
             _destination = fromBigEndian<u256>(fromHex(params.at(_name).get_str()));
     };
-    setOptionalU256Parameter(cp.minGasLimit, c_minGasLimit);
-    setOptionalU256Parameter(cp.maxGasLimit, c_maxGasLimit);
-    setOptionalU256Parameter(cp.gasLimitBoundDivisor, c_gasLimitBoundDivisor);
+    setOptionalU256Parameter(minGasLimit, c_minGasLimit);
+    setOptionalU256Parameter(maxGasLimit, c_maxGasLimit);
+    setOptionalU256Parameter(gasLimitBoundDivisor, c_gasLimitBoundDivisor);
 
-    setOptionalU256Parameter(cp.homesteadForkBlock, c_homesteadForkBlock);
-    setOptionalU256Parameter(cp.daoHardforkBlock, c_daoHardforkBlock);
-    setOptionalU256Parameter(cp.EIP150ForkBlock, c_EIP150ForkBlock);
-    setOptionalU256Parameter(cp.EIP158ForkBlock, c_EIP158ForkBlock);
-    setOptionalU256Parameter(cp.byzantiumForkBlock, c_byzantiumForkBlock);
-    setOptionalU256Parameter(cp.eWASMForkBlock, c_eWASMForkBlock);
-    setOptionalU256Parameter(cp.constantinopleForkBlock, c_constantinopleForkBlock);
-    setOptionalU256Parameter(cp.constantinopleFixForkBlock, c_constantinopleFixForkBlock);
-    setOptionalU256Parameter(cp.istanbulForkBlock, c_istanbulForkBlock);
-    setOptionalU256Parameter(cp.berlinForkBlock, c_berlinForkBlock);
-    setOptionalU256Parameter(cp.experimentalForkBlock, c_experimentalForkBlock);
+    setOptionalU256Parameter(homesteadForkBlock, c_homesteadForkBlock);
+    setOptionalU256Parameter(daoHardforkBlock, c_daoHardforkBlock);
+    setOptionalU256Parameter(EIP150ForkBlock, c_EIP150ForkBlock);
+    setOptionalU256Parameter(EIP158ForkBlock, c_EIP158ForkBlock);
+    setOptionalU256Parameter(byzantiumForkBlock, c_byzantiumForkBlock);
+    setOptionalU256Parameter(eWASMForkBlock, c_eWASMForkBlock);
+    setOptionalU256Parameter(constantinopleForkBlock, c_constantinopleForkBlock);
+    setOptionalU256Parameter(constantinopleFixForkBlock, c_constantinopleFixForkBlock);
+    setOptionalU256Parameter(istanbulForkBlock, c_istanbulForkBlock);
+    setOptionalU256Parameter(berlinForkBlock, c_berlinForkBlock);
+    setOptionalU256Parameter(experimentalForkBlock, c_experimentalForkBlock);
 
-    cp.lastForkBlock = findMaxForkBlockNumber(params);
-    cp.lastForkWithAdditionalEIPsSchedule = cp.forkScheduleForBlockNumber(cp.lastForkBlock);
+    lastForkBlock = findMaxForkBlockNumber(params);
+    lastForkWithAdditionalEIPsSchedule = forkScheduleForBlockNumber(lastForkBlock);
 
-    setOptionalU256Parameter(cp.minimumDifficulty, c_minimumDifficulty);
-    setOptionalU256Parameter(cp.difficultyBoundDivisor, c_difficultyBoundDivisor);
-    setOptionalU256Parameter(cp.durationLimit, c_durationLimit);
+    setOptionalU256Parameter(minimumDifficulty, c_minimumDifficulty);
+    setOptionalU256Parameter(difficultyBoundDivisor, c_difficultyBoundDivisor);
+    setOptionalU256Parameter(durationLimit, c_durationLimit);
 
     if (params.count(c_chainID))
-        cp.chainID = int(fromBigEndian<u256>(fromHex(params.at(c_chainID).get_str())));
+        chainID = int(fromBigEndian<u256>(fromHex(params.at(c_chainID).get_str())));
     if (params.count(c_networkID))
-        cp.networkID = int(fromBigEndian<u256>(fromHex(params.at(c_networkID).get_str())));
-    cp.allowFutureBlocks = params.count(c_allowFutureBlocks);
+        networkID = int(fromBigEndian<u256>(fromHex(params.at(c_networkID).get_str())));
+    allowFutureBlocks = params.count(c_allowFutureBlocks);
 
     // genesis
     string genesisStr = js::write_string(obj[c_genesis], false);
-    cp = cp.loadGenesis(genesisStr, _stateRoot);
+    loadGenesis(genesisStr, _stateRoot);
     // genesis state
     string genesisStateStr = js::write_string(obj[c_accounts], false);
 
-    cp.genesisState = jsonToAccountMap(
-                genesisStateStr, cp.accountStartNonce, nullptr, &cp.precompiled, _configPath);
+    genesisState =
+        jsonToAccountMap(genesisStateStr, accountStartNonce, nullptr, &precompiled, _configPath);
 
-    cp.stateRoot = _stateRoot ? _stateRoot : cp.calculateStateRoot(true);
-    return cp;
+    stateRoot = _stateRoot ? _stateRoot : calculateStateRoot(true);
 }
 
-ChainParams ChainParams::loadGenesis(string const& _json, h256 const& _stateRoot) const
+void ChainParams::loadGenesis(string const& _json, h256 const& _stateRoot)
 {
-    ChainParams cp(*this);
-
     js::mValue val;
     js::read_string(_json, val);
     js::mObject genesis = val.get_obj();
 
-    cp.parentHash = h256(0); // required by the YP
-    cp.author = genesis.count(c_coinbase) ? h160(genesis[c_coinbase].get_str()) : h160(genesis[c_author].get_str());
-    cp.difficulty = genesis.count(c_difficulty) ?
-                u256(fromBigEndian<u256>(fromHex(genesis[c_difficulty].get_str()))) :
-                cp.minimumDifficulty;
-    cp.gasLimit = u256(fromBigEndian<u256>(fromHex(genesis[c_gasLimit].get_str())));
-    cp.gasUsed = genesis.count(c_gasUsed) ? u256(fromBigEndian<u256>(fromHex(genesis[c_gasUsed].get_str()))) : 0;
-    cp.timestamp = u256(fromBigEndian<u256>(fromHex(genesis[c_timestamp].get_str())));
-    cp.extraData = bytes(fromHex(genesis[c_extraData].get_str()));
+    parentHash = h256(0);  // required by the YP
+    author = genesis.count(c_coinbase) ? h160(genesis[c_coinbase].get_str()) :
+                                         h160(genesis[c_author].get_str());
+    difficulty = genesis.count(c_difficulty) ?
+                     u256(fromBigEndian<u256>(fromHex(genesis[c_difficulty].get_str()))) :
+                     minimumDifficulty;
+    gasLimit = u256(fromBigEndian<u256>(fromHex(genesis[c_gasLimit].get_str())));
+    gasUsed = genesis.count(c_gasUsed) ?
+                  u256(fromBigEndian<u256>(fromHex(genesis[c_gasUsed].get_str()))) :
+                  0;
+    timestamp = u256(fromBigEndian<u256>(fromHex(genesis[c_timestamp].get_str())));
+    extraData = bytes(fromHex(genesis[c_extraData].get_str()));
 
     // magic code for handling ethash stuff:
     if (genesis.count(c_mixHash) && genesis.count(c_nonce))
     {
         h256 mixHash(genesis[c_mixHash].get_str());
         h64 nonce(genesis[c_nonce].get_str());
-        cp.sealFields = 2;
-        cp.sealRLP = rlp(mixHash) + rlp(nonce);
+        sealFields = 2;
+        sealRLP = rlp(mixHash) + rlp(nonce);
     }
-    cp.stateRoot = _stateRoot ? _stateRoot : cp.calculateStateRoot();
-    return cp;
+    stateRoot = _stateRoot ? _stateRoot : calculateStateRoot();
 }
 
 SealEngineFace* ChainParams::createSealEngine()

--- a/libethereum/ChainParams.h
+++ b/libethereum/ChainParams.h
@@ -22,7 +22,8 @@ struct ChainParams: public ChainOperationParams
 {
     ChainParams();
     ChainParams(ChainParams const& /*_org*/) = default;
-    ChainParams(std::string const& _configJson, h256 const& _stateRoot = h256());
+    ChainParams(std::string const& _configJson, h256 const& _stateRoot = {},
+        boost::filesystem::path const& _configPath = {});
     /// params with additional EIPs activated on top of the last fork block
     ChainParams(std::string const& _configJson, AdditionalEIPs const& _additionalEIPs);
     ChainParams(bytes const& _genesisRLP, AccountMap const& _state)
@@ -56,15 +57,15 @@ struct ChainParams: public ChainOperationParams
     /// Genesis block info.
     bytes genesisBlock() const;
 
-    /// load config
-    ChainParams loadConfig(std::string const& _json, h256 const& _stateRoot = {},
-        const boost::filesystem::path& _configPath = {}) const;
-
 private:
+    /// load config
+    void loadConfig(std::string const& _json, h256 const& _stateRoot,
+        boost::filesystem::path const& _configPath);
+
     void populateFromGenesis(bytes const& _genesisRLP, AccountMap const& _state);
 
     /// load genesis
-    ChainParams loadGenesis(std::string const& _json, h256 const& _stateRoot = {}) const;
+    void loadGenesis(std::string const& _json, h256 const& _stateRoot);
 };
 
 }

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -44,7 +44,7 @@ void ClientTest::setChainParams(string const& _genesis)
     ChainParams params;
     try
     {
-        params = params.loadConfig(_genesis);
+        params = ChainParams{_genesis};
         if (params.sealEngineName != NoProof::name() && params.sealEngineName != Ethash::name() &&
             params.sealEngineName != NoReward::name())
             BOOST_THROW_EXCEPTION(

--- a/libethereum/ClientTest.cpp
+++ b/libethereum/ClientTest.cpp
@@ -41,10 +41,9 @@ ClientTest::~ClientTest()
 
 void ClientTest::setChainParams(string const& _genesis)
 {
-    ChainParams params;
     try
     {
-        params = ChainParams{_genesis};
+        ChainParams const params{_genesis};
         if (params.sealEngineName != NoProof::name() && params.sealEngineName != Ethash::name() &&
             params.sealEngineName != NoReward::name())
             BOOST_THROW_EXCEPTION(

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -91,4 +91,49 @@ BOOST_AUTO_TEST_CASE(ClientTest_setChainParamsAuthor)
     BOOST_CHECK_EQUAL(testClient->author(), Address("0000000000000010000000000000000000000000"));
 }
 
+BOOST_AUTO_TEST_CASE(ClientTest_setChainParamsCustomPrecompiles)
+{
+    ClientTest* testClient = asClientTest(getWeb3()->ethereum());
+    testClient->setChainParams(c_configString);
+
+    auto const ecrecoverAddress = Address{0x01};
+    auto const sha256Address = Address{0x02};
+
+    BOOST_CHECK_EQUAL(
+        testClient->chainParams().precompiled.at(ecrecoverAddress).startingBlock(), 0);
+    BOOST_CHECK(contains(testClient->chainParams().precompiled, sha256Address));
+
+    std::string const configWithCustomPrecompiles = R"({
+        "sealEngine": "NoProof",
+        "params": {
+            "accountStartNonce": "0x00",
+            "maximumExtraDataSize": "0x1000000",
+            "blockReward": "0x",
+            "allowFutureBlocks": true,
+            "homesteadForkBlock": "0x118c30",
+            "daoHardforkBlock": "0x1d4c00",
+            "EIP150ForkBlock": "0x259518",
+            "EIP158ForkBlock": "0x28d138"
+        },
+        "genesis": {
+            "nonce": "0x0000000000000042",
+            "author": "0000000000000010000000000000000000000000",
+            "timestamp": "0x00",
+            "extraData": "0x",
+            "gasLimit": "0x1000000000000",
+            "difficulty": "0x020000",
+            "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "accounts": {
+            "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 }, "startingBlock": "0x28d138" } }
+        }
+    })";
+
+    testClient->setChainParams(configWithCustomPrecompiles);
+
+    BOOST_CHECK_EQUAL(
+        testClient->chainParams().precompiled.at(ecrecoverAddress).startingBlock(), 0x28d138);
+    BOOST_CHECK(!contains(testClient->chainParams().precompiled, sha256Address));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This gets rid of a weird pattern where `ChainParams::loadConfig` first created another `ChainParams` instance by copying `*this`, then applied config values from JSON on top of it, then `ChainParams` constuctor assigned result of `loadConfig` to `*this`.

Instead of this, there's now just a normal `ChainParams` constructor taking JSON string. `loadConfig` is made private and modifies members of current object. The same with `loadGenesis`.

Fixes https://github.com/ethereum/aleth/issues/5819