### PR TITLE
Fix database rebuild functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).
 - Fixed: [#5811](https://github.com/ethereum/aleth/pull/5811) RPC methods querying transactions (`eth_getTransactionByHash`, `eth_getBlockByNumber`) return correct `v` value.
 - Fixed: [#5821](https://github.com/ethereum/aleth/pull/5821) `test_setChainParams` correctly initializes custom configuration of precompiled contracts.
+- Fixed: [#5826](https://github.com/ethereum/aleth/pull/5826) Fix blocking bug in database rebuild functionality - users can now rebuild their databases via Aleth's '-R' switch.
 
 ## [1.7.0] - 2019-11-14
 

--- a/aleth/main.cpp
+++ b/aleth/main.cpp
@@ -217,8 +217,10 @@ int main(int argc, char** argv)
     addClientOption("admin", po::value<string>()->value_name("<password>"),
         "Specify admin session key for JSON-RPC (default: auto-generated and printed at "
         "start-up)");
-    addClientOption("kill,K", "Kill the blockchain first");
-    addClientOption("rebuild,R", "Rebuild the blockchain from the existing database");
+    addClientOption("kill,K", "Kill the blockchain first. This will remove all blocks and state.");
+    addClientOption("rebuild,R",
+        "Rebuild the blockchain from the existing database. This involves reimporting all blocks "
+        "and will probably take a while.");
     addClientOption("rescue", "Attempt to rescue a corrupt database\n");
     addClientOption("import-presale", po::value<string>()->value_name("<file>"),
         "Import a pre-sale key; you'll need to specify the password to this key");

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -67,6 +67,7 @@ DEV_SIMPLE_EXCEPTION(PendingTransactionAlreadyExists);
 DEV_SIMPLE_EXCEPTION(TransactionAlreadyInChain);
 DEV_SIMPLE_EXCEPTION(BlockNotFound);
 DEV_SIMPLE_EXCEPTION(UnknownParent);
+DEV_SIMPLE_EXCEPTION(DisjointChain);
 DEV_SIMPLE_EXCEPTION(AddressAlreadyUsed);
 DEV_SIMPLE_EXCEPTION(ZeroSignatureTransaction);
 DEV_SIMPLE_EXCEPTION(UnknownTransactionValidationError);

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -328,27 +328,31 @@ void BlockChain::rebuild(fs::path const& _path, std::function<void(unsigned, uns
 {
     if (!db::isDiskDatabase())
     {
-        cwarn <<"In-memory database detected, skipping rebuild (since there's no existing database to rebuild)";
+        LOG(m_loggerWarn) << "In-memory database detected, skipping rebuild (since there's no "
+                             "existing database to rebuild)";
         return;
     }
 
     fs::path path = _path.empty() ? db::databasePath() : _path;
-    fs::path chainPath = path / fs::path(toHex(m_genesisHash.ref().cropped(0, 4)));
-    fs::path extrasPath = chainPath / fs::path(toString(c_databaseVersion));
+    auto const chainPath = path / fs::path(toHex(m_genesisHash.ref().cropped(0, 4)));
+    auto const extrasPath = chainPath / fs::path(toString(c_databaseVersion));
+    auto const extrasSubPathExtras = extrasPath / fs::path("extras");
+    auto const extrasSubPathOldExtras = extrasPath / fs::path("extras.old");
 
-    unsigned originalNumber = m_lastBlockNumber;
+    unsigned const originalNumber = m_lastBlockNumber;
 
     ///////////////////////////////
-    // TODO
     // - KILL ALL STATE/CHAIN
     // - REINSERT ALL BLOCKS
     ///////////////////////////////
 
     // Keep extras DB around, but under a temp name
     m_extrasDB.reset();
-    fs::rename(extrasPath / fs::path("extras"), extrasPath / fs::path("extras.old"));
-    std::unique_ptr<db::DatabaseFace> oldExtrasDB(db::DBFactory::create(extrasPath / fs::path("extras.old")));
-    m_extrasDB = db::DBFactory::create(extrasPath / fs::path("extras"));
+    LOG(m_loggerDetail) << "Renaming extras path " << extrasSubPathExtras << " to "
+                        << extrasSubPathOldExtras;
+    fs::rename(extrasSubPathExtras, extrasSubPathOldExtras);
+    std::unique_ptr<db::DatabaseFace> oldExtrasDB(db::DBFactory::create(extrasSubPathOldExtras));
+    m_extrasDB = db::DBFactory::create(extrasSubPathExtras);
 
     // Open a fresh state DB
     Block s = genesisBlock(State::openDB(path.string(), m_genesisHash, WithExisting::Kill));
@@ -369,13 +373,20 @@ void BlockChain::rebuild(fs::path const& _path, std::function<void(unsigned, uns
     m_extrasDB->insert(toSlice(m_lastBlockHash, ExtraDetails),
         (db::Slice)dev::ref(m_details[m_lastBlockHash].rlp()));
 
+    // Manually insert the genesis block details so that they're available during import of the
+    // first block
+    m_details[m_genesisHash] = BlockDetails{0, s.info().difficulty(), h256(), {}};
+
+    LOG(m_loggerInfo) << "Rebuilding the extras and state databases by reimporting blocks 0 -> "
+                      << originalNumber << ", this will probably take a while";
     h256 lastHash = m_lastBlockHash;
     Timer t;
     for (unsigned d = 1; d <= originalNumber; ++d)
     {
         if (!(d % 1000))
         {
-            cerr << "\n1000 blocks in " << t.elapsed() << "s = " << (1000.0 / t.elapsed()) << "b/s" << endl;
+            LOG(m_loggerInfo) << "\n1000 blocks in " << t.elapsed()
+                              << "s = " << (1000.0 / t.elapsed()) << "b/s" << endl;
             t.restart();
         }
         try
@@ -388,23 +399,31 @@ void BlockChain::rebuild(fs::path const& _path, std::function<void(unsigned, uns
 
             if (bi.parentHash() != lastHash)
             {
-                cwarn << "DISJOINT CHAIN DETECTED; " << bi.hash() << "#" << d << " -> parent is" << bi.parentHash() << "; expected" << lastHash << "#" << (d - 1);
-                return;
+                LOG(m_loggerError)
+                    << "DISJOINT CHAIN DETECTED; " << bi.hash() << "#" << d << " -> parent is"
+                    << bi.parentHash() << "; expected" << lastHash << "#" << (d - 1);
+                BOOST_THROW_EXCEPTION(DisjointChain());
             }
             lastHash = bi.hash();
             import(b, s.db(), 0);
         }
         catch (...)
         {
-            // Failed to import - stop here.
+            LOG(m_loggerError) << "Rebuild failed with error: "
+                               << boost::current_exception_diagnostic_information();
+            LOG(m_loggerError)
+                << "Please re-run Aleth with --kill option to delete all databases. This will "
+                   "remove all local chain data and require you to resync from genesis.";
             break;
         }
 
         if (_progress)
             _progress(d, originalNumber);
     }
-
-    fs::remove_all(path / fs::path("extras.old"));
+    LOG(m_loggerInfo) << "Rebuild complete! Reimported " << originalNumber << " blocks!";
+    LOG(m_loggerDetail) << "Removing old extras database: " << extrasSubPathOldExtras;
+    oldExtrasDB.reset();
+    fs::remove_all(extrasSubPathOldExtras);
 }
 
 string BlockChain::dumpDatabase() const
@@ -680,7 +699,8 @@ ImportRoute BlockChain::import(VerifiedBlockRef const& _block, OverlayDB const& 
     // Verify parent-critical parts
     verifyBlock(_block.block, m_onBad, ImportRequirements::InOrderChecks);
 
-    LOG(m_loggerDetail) << "Attempting import of " << _block.info.hash() << " ...";
+    LOG(m_loggerDetail) << "Attempting import of block " << _block.info.hash() << " (#"
+                        << _block.info.number() << ") ...";
 
     performanceLogger.onStageFinished("preliminaryChecks");
 

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -374,8 +374,12 @@ void BlockChain::rebuild(fs::path const& _path, std::function<void(unsigned, uns
         (db::Slice)dev::ref(m_details[m_lastBlockHash].rlp()));
 
     // Manually insert the genesis block details so that they're available during import of the
-    // first block
-    m_details[m_genesisHash] = BlockDetails{0, s.info().difficulty(), h256(), {}};
+    // first block.
+    auto const genesisDetails = BlockDetails{0, s.info().difficulty(), h256(), {}};
+    m_details[m_genesisHash] = genesisDetails;
+    auto const genesisDetailsRlp = genesisDetails.rlp();
+    m_extrasDB->insert(
+        toSlice(m_genesisHash, ExtraDetails), (db::Slice)dev::ref(genesisDetailsRlp));
 
     LOG(m_loggerInfo) << "Rebuilding the extras and state databases by reimporting blocks 0 -> "
                       << originalNumber << ", this will probably take a while";

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -414,6 +414,8 @@ private:
 
     mutable Logger m_logger{createLogger(VerbosityDebug, "chain")};
     mutable Logger m_loggerDetail{createLogger(VerbosityTrace, "chain")};
+    mutable Logger m_loggerWarn{createLogger(VerbosityWarning, "chain")};
+    mutable Logger m_loggerInfo{createLogger(VerbosityInfo, "chain")};
     mutable Logger m_loggerError{createLogger(VerbosityError, "chain")};
 
     friend std::ostream& operator<<(std::ostream& _out, BlockChain const& _bc);


### PR DESCRIPTION
Fix #5823 

One can now initiate a rebuild via `-R ` and have it complete successfully, whereas prior to these changes it would fail with a database corruption error. The problem was that importing the first block would fail because it required the genesis block details, which weren't re-inserted into the `m_details `cache after it was cleared in preparation for rebuild.