### PR TITLE
Write database minor version to disk and fix rebuild on minor version mismatch bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed: [#5811](https://github.com/ethereum/aleth/pull/5811) RPC methods querying transactions (`eth_getTransactionByHash`, `eth_getBlockByNumber`) return correct `v` value.
 - Fixed: [#5821](https://github.com/ethereum/aleth/pull/5821) `test_setChainParams` correctly initializes custom configuration of precompiled contracts.
 - Fixed: [#5826](https://github.com/ethereum/aleth/pull/5826) Fix blocking bug in database rebuild functionality - users can now rebuild their databases via Aleth's '-R' switch.
+- Fixed: [#5827](https://github.com/ethereum/aleth/pull/5827) Detect database upgrades and automatically rebuild the database when they occur.
 
 ## [1.7.0] - 2019-11-14
 

--- a/libethcore/Common.cpp
+++ b/libethcore/Common.cpp
@@ -23,11 +23,11 @@ namespace eth
 
 const unsigned c_protocolVersion = 63;
 #if ETH_FATDB
-const unsigned c_minorProtocolVersion = 3;
+const unsigned c_databaseMinorVersion = 3;
 const unsigned c_databaseBaseVersion = 9;
 const unsigned c_databaseVersionModifier = 1;
 #else
-const unsigned c_minorProtocolVersion = 2;
+const unsigned c_databaseMinorVersion = 2;
 const unsigned c_databaseBaseVersion = 9;
 const unsigned c_databaseVersionModifier = 0;
 #endif

--- a/libethcore/Common.h
+++ b/libethcore/Common.h
@@ -23,8 +23,8 @@ namespace eth
 /// Current protocol version.
 extern const unsigned c_protocolVersion;
 
-/// Current minor protocol version.
-extern const unsigned c_minorProtocolVersion;
+/// Current minor database version (for the extras database).
+extern const unsigned c_databaseMinorVersion;
 
 /// Current database version.
 extern const unsigned c_databaseVersion;

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -314,8 +314,8 @@ private:
 
     /// Initialise everything and ready for openning the database.
     void init(ChainParams const& _p);
-    /// Open the database.
-    unsigned open(boost::filesystem::path const& _path, WithExisting _we);
+    /// Open the database. Returns whether or not the database needs to be rebuilt.
+    bool open(boost::filesystem::path const& _path, WithExisting _we);
     /// Open the database, rebuilding if necessary.
     void open(boost::filesystem::path const& _path, WithExisting _we, ProgressCallback const& _pc);
     /// Finalise everything and close the database.


### PR DESCRIPTION
Fix #5822, #5813 

Built ontop of #5826 so will wait to merge this until that has been merged.

This PR fixes two bugs:
* It writes the database minor version to disk (if it's not already present such as when you launch Aleth with a new database path) - this is required to detect database minor version changes which occur during extras database upgrades (5822)
* It doesn't remove the extras or state databases on minor version mismatch (5813) - removing these databases breaks the rebuild functionality because the rebuild functionality uses the last hash to determine chain tip (and therefore the range of blocks which must be reimported) - however, `BlockChain::open` populates this after renaming extras -> extras.old so since it can't find the "best" block in the extras DB it just uses the genesis hash.