### PR TITLE
Return size of block (in bytes) from web3.eth.getBlock RPC function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed: [#5826](https://github.com/ethereum/aleth/pull/5826) Fix blocking bug in database rebuild functionality - users can now rebuild their databases via Aleth's '-R' switch.
 - Fixed: [#5827](https://github.com/ethereum/aleth/pull/5827) Detect database upgrades and automatically rebuild the database when they occur.
 - Fixed: [#5852](https://github.com/ethereum/aleth/pull/5852) Output correct original opcodes instead of synthetic `PUSHC`/`JUMPC`/`JUMPCI` in VM trace.
+- Fixed: [#5829](https://github.com/ethereum/aleth/pull/5829) web3.eth.getBlock now returns block size in bytes. This requires a (automatic) database rebuild which can take a while depending on how many blocks are in the local chain.
 
 ## [1.7.2] - 2019-11-22
 

--- a/libethcore/Common.cpp
+++ b/libethcore/Common.cpp
@@ -23,11 +23,11 @@ namespace eth
 
 const unsigned c_protocolVersion = 63;
 #if ETH_FATDB
-const unsigned c_databaseMinorVersion = 3;
+const unsigned c_databaseMinorVersion = 4;
 const unsigned c_databaseBaseVersion = 9;
 const unsigned c_databaseVersionModifier = 1;
 #else
-const unsigned c_databaseMinorVersion = 2;
+const unsigned c_databaseMinorVersion = 3;
 const unsigned c_databaseBaseVersion = 9;
 const unsigned c_databaseVersionModifier = 0;
 #endif

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -76,6 +76,8 @@ DEV_SIMPLE_EXCEPTION(UnknownError);
 DEV_SIMPLE_EXCEPTION(InvalidDatabaseKind);
 DEV_SIMPLE_EXCEPTION(DatabaseAlreadyOpen);
 DEV_SIMPLE_EXCEPTION(DatabaseCorruption);
+DEV_SIMPLE_EXCEPTION(DatabaseExists);
+DEV_SIMPLE_EXCEPTION(DatabaseRebuildFailed);
 
 DEV_SIMPLE_EXCEPTION(DAGCreationFailure);
 DEV_SIMPLE_EXCEPTION(DAGComputeFailure);

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -57,6 +57,7 @@ DEV_SIMPLE_EXCEPTION(InvalidLogBloom);
 DEV_SIMPLE_EXCEPTION(InvalidNonce);
 DEV_SIMPLE_EXCEPTION(InvalidBlockHeaderItemCount);
 DEV_SIMPLE_EXCEPTION(InvalidBlockNonce);
+DEV_SIMPLE_EXCEPTION(InvalidHash);
 DEV_SIMPLE_EXCEPTION(InvalidParentHash);
 DEV_SIMPLE_EXCEPTION(InvalidUncleParentHash);
 DEV_SIMPLE_EXCEPTION(InvalidNumber);
@@ -78,6 +79,7 @@ DEV_SIMPLE_EXCEPTION(DatabaseAlreadyOpen);
 DEV_SIMPLE_EXCEPTION(DatabaseCorruption);
 DEV_SIMPLE_EXCEPTION(DatabaseExists);
 DEV_SIMPLE_EXCEPTION(DatabaseRebuildFailed);
+DEV_SIMPLE_EXCEPTION(DatabasePathsNotSet);
 
 DEV_SIMPLE_EXCEPTION(DAGCreationFailure);
 DEV_SIMPLE_EXCEPTION(DAGComputeFailure);

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -57,7 +57,6 @@ DEV_SIMPLE_EXCEPTION(InvalidLogBloom);
 DEV_SIMPLE_EXCEPTION(InvalidNonce);
 DEV_SIMPLE_EXCEPTION(InvalidBlockHeaderItemCount);
 DEV_SIMPLE_EXCEPTION(InvalidBlockNonce);
-DEV_SIMPLE_EXCEPTION(InvalidHash);
 DEV_SIMPLE_EXCEPTION(InvalidParentHash);
 DEV_SIMPLE_EXCEPTION(InvalidUncleParentHash);
 DEV_SIMPLE_EXCEPTION(InvalidNumber);
@@ -79,7 +78,6 @@ DEV_SIMPLE_EXCEPTION(DatabaseAlreadyOpen);
 DEV_SIMPLE_EXCEPTION(DatabaseCorruption);
 DEV_SIMPLE_EXCEPTION(DatabaseExists);
 DEV_SIMPLE_EXCEPTION(DatabaseRebuildFailed);
-DEV_SIMPLE_EXCEPTION(DatabasePathsNotSet);
 
 DEV_SIMPLE_EXCEPTION(DAGCreationFailure);
 DEV_SIMPLE_EXCEPTION(DAGComputeFailure);

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -720,7 +720,8 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
                               << ", parent = " << m_previousBlock.parentHash();
         h256Hash excluded = _bc.allKinFrom(m_currentBlock.parentHash(), 6);
         auto p = m_previousBlock.parentHash();
-        for (unsigned gen = 0; gen < 6 && p != _bc.genesisHash() && unclesCount < 2; ++gen, p = _bc.details(p).parentHash)
+        for (unsigned gen = 0; gen < 6 && p != _bc.genesisHash() && unclesCount < 2;
+             ++gen, p = _bc.details(p).parentHash)
         {
             auto us = _bc.details(p).childHashes;
             assert(us.size() >= 1);	// must be at least 1 child of our grandparent - it's our own parent!

--- a/libethereum/Block.cpp
+++ b/libethereum/Block.cpp
@@ -574,8 +574,8 @@ u256 Block::enact(VerifiedBlockRef const& _block, BlockChain const& _bc)
                 // cB.p^6	-----------/  6
                 // cB.p^7	-------------/
                 // cB.p^8
-                auto expectedUncleParent = _bc.details(m_currentBlock.parentHash()).parent;
-                for (unsigned i = 1; i < depth; expectedUncleParent = _bc.details(expectedUncleParent).parent, ++i) {}
+                auto expectedUncleParent = _bc.details(m_currentBlock.parentHash()).parentHash;
+                for (unsigned i = 1; i < depth; expectedUncleParent = _bc.details(expectedUncleParent).parentHash, ++i) {}
                 if (expectedUncleParent != uncleParent.hash())
                 {
                     UncleParentNotInChain ex;
@@ -720,9 +720,9 @@ void Block::commitToSeal(BlockChain const& _bc, bytes const& _extraData)
                               << ", parent = " << m_previousBlock.parentHash();
         h256Hash excluded = _bc.allKinFrom(m_currentBlock.parentHash(), 6);
         auto p = m_previousBlock.parentHash();
-        for (unsigned gen = 0; gen < 6 && p != _bc.genesisHash() && unclesCount < 2; ++gen, p = _bc.details(p).parent)
+        for (unsigned gen = 0; gen < 6 && p != _bc.genesisHash() && unclesCount < 2; ++gen, p = _bc.details(p).parentHash)
         {
-            auto us = _bc.details(p).children;
+            auto us = _bc.details(p).childHashes;
             assert(us.size() >= 1);	// must be at least 1 child of our grandparent - it's our own parent!
             for (auto const& u: us)
                 if (!excluded.count(u))	// ignore any uncles/mainline blocks that we know about.

--- a/libethereum/BlockChain.cpp
+++ b/libethereum/BlockChain.cpp
@@ -230,6 +230,13 @@ bool BlockChain::open(fs::path const& _path, WithExisting _we)
                                   << ") != Aleth's version (" << c_databaseMinorVersion << ")";
             }
         }
+        else if (fs::exists(extrasSubPathExtras))
+        {
+            LOG(m_loggerInfo) << "Database minor version file not found (" << extrasSubPathMinor
+                              << ") but extras database exists (" << extrasSubPathExtras
+                              << "), assuming extras database needs to be upgraded.";
+            rebuildNeeded = true;
+        }
         else
         {
             LOG(m_loggerDetail) << "Creating database minor version file: " << extrasSubPathMinor

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -232,7 +232,8 @@ public:
 
     /// Run through database and verify all blocks by reevaluating.
     /// Will call _progress with the progress in this operation first param done, second total.
-    void rebuild(boost::filesystem::path const& _path, ProgressCallback const& _progress = std::function<void(unsigned, unsigned)>());
+    void rebuild(boost::filesystem::path const& _path,
+        ProgressCallback const& _progress = std::function<void(unsigned, unsigned)>());
 
     /// Alter the head of the chain to some prior block along it.
     void rewind(unsigned _newHead);
@@ -409,8 +410,6 @@ private:
 
     std::function<void(Exception&)> m_onBad;                                    ///< Called if we have a block that doesn't verify.
     std::function<void(BlockHeader const&)> m_onBlockImport;                                        ///< Called if we have imported a new block into the db
-
-    boost::filesystem::path m_dbPath;
 
     mutable Logger m_logger{createLogger(VerbosityDebug, "chain")};
     mutable Logger m_loggerDetail{createLogger(VerbosityTrace, "chain")};

--- a/libethereum/BlockChain.h
+++ b/libethereum/BlockChain.h
@@ -8,22 +8,23 @@
 #include "BlockDetails.h"
 #include "BlockQueue.h"
 #include "ChainParams.h"
+#include "DatabasePaths.h"
 #include "LastBlockHashesFace.h"
 #include "State.h"
 #include "Transaction.h"
 #include "VerifiedBlock.h"
-#include <libdevcore/db.h>
 #include <libdevcore/Exceptions.h>
-#include <libdevcore/Log.h>
 #include <libdevcore/Guards.h>
+#include <libdevcore/Log.h>
+#include <libdevcore/db.h>
 #include <libethcore/BlockHeader.h>
 #include <libethcore/Common.h>
 #include <libethcore/SealEngine.h>
+#include <boost/filesystem/path.hpp>
 #include <chrono>
 #include <deque>
 #include <unordered_map>
 #include <unordered_set>
-#include <boost/filesystem/path.hpp>
 
 namespace std
 {
@@ -407,6 +408,8 @@ private:
     mutable BlockHeader m_genesis;  // mutable because they're effectively memos.
     mutable bytes m_genesisHeaderBytes; // mutable because they're effectively memos.
     mutable h256 m_genesisHash;     // mutable because they're effectively memos.
+
+    std::unique_ptr<DatabasePaths> m_dbPaths; // Paths for various databases (e.g. blocks, extras)
 
     std::function<void(Exception&)> m_onBad;                                    ///< Called if we have a block that doesn't verify.
     std::function<void(BlockHeader const&)> m_onBlockImport;                                        ///< Called if we have imported a new block into the db

--- a/libethereum/BlockDetails.cpp
+++ b/libethereum/BlockDetails.cpp
@@ -12,12 +12,12 @@ using namespace dev::eth;
 
 BlockDetails::BlockDetails(RLP const& _r)
 {
-	number = _r[0].toInt<unsigned>();
-	totalDifficulty = _r[1].toInt<u256>();
-	parentHash = _r[2].toHash<h256>();
-	childHashes = _r[3].toVector<h256>();
-	size = _r.size();
-	blockSizeBytes = _r[4].toInt<unsigned>();
+    number = _r[0].toInt<unsigned>();
+    totalDifficulty = _r[1].toInt<u256>();
+    parentHash = _r[2].toHash<h256>();
+    childHashes = _r[3].toVector<h256>();
+    size = _r.size();
+    blockSizeBytes = _r[4].toInt<size_t>();
 }
 
 bytes BlockDetails::rlp() const

--- a/libethereum/BlockDetails.cpp
+++ b/libethereum/BlockDetails.cpp
@@ -14,14 +14,13 @@ BlockDetails::BlockDetails(RLP const& _r)
 {
 	number = _r[0].toInt<unsigned>();
 	totalDifficulty = _r[1].toInt<u256>();
-	parent = _r[2].toHash<h256>();
-	children = _r[3].toVector<h256>();
+	parentHash = _r[2].toHash<h256>();
+	childHashes = _r[3].toVector<h256>();
 	size = _r.size();
+	blockSizeBytes = _r[4].toInt<unsigned>();
 }
 
 bytes BlockDetails::rlp() const
 {
-	auto ret = rlpList(number, totalDifficulty, parent, children);
-	size = ret.size();
-	return ret;
+    return rlpList(number, totalDifficulty, parentHash, childHashes, blockSizeBytes);
 }

--- a/libethereum/BlockDetails.cpp
+++ b/libethereum/BlockDetails.cpp
@@ -22,5 +22,8 @@ BlockDetails::BlockDetails(RLP const& _r)
 
 bytes BlockDetails::rlp() const
 {
-    return rlpList(number, totalDifficulty, parentHash, childHashes, blockSizeBytes);
+    auto const detailsRlp =
+        rlpList(number, totalDifficulty, parentHash, childHashes, blockSizeBytes);
+    size = detailsRlp.size();
+    return detailsRlp;
 }

--- a/libethereum/BlockDetails.h
+++ b/libethereum/BlockDetails.h
@@ -24,81 +24,87 @@ constexpr unsigned c_invalidNumber = (unsigned)-1;
 
 struct BlockDetails
 {
-	BlockDetails(): number(c_invalidNumber), totalDifficulty(Invalid256) {}
-	BlockDetails(unsigned _number, u256 _totalDifficulty, h256 _parentHash, h256s _childHashes, unsigned _blockSizeBytes) : number{ _number }, totalDifficulty{ _totalDifficulty }, parentHash{ _parentHash }, childHashes{ _childHashes
-	}, blockSizeBytes{_blockSizeBytes}{}
-	BlockDetails(RLP const& _r);
-	bytes rlp() const;
+    BlockDetails(): number(c_invalidNumber), totalDifficulty(Invalid256) {}
+    BlockDetails(unsigned _number, u256 const& _totalDifficulty, h256 const& _parentHash, h256s const& _childHashes,
+        size_t _blockSizeBytes)
+      : number{_number},
+        totalDifficulty{_totalDifficulty},
+        parentHash{_parentHash},
+        childHashes{_childHashes},
+        blockSizeBytes{_blockSizeBytes}
+    {}
+    BlockDetails(RLP const& _r);
+    bytes rlp() const;
 
-	bool isNull() const { return number == c_invalidNumber; }
-	explicit operator bool() const { return !isNull(); }
+    bool isNull() const { return number == c_invalidNumber; }
+    explicit operator bool() const { return !isNull(); }
 
-	unsigned number = c_invalidNumber;
-	u256 totalDifficulty = Invalid256;
-	h256 parentHash;
-	h256s childHashes;
+    unsigned number = c_invalidNumber;
+    u256 totalDifficulty = Invalid256;
+    h256 parentHash;
+    h256s childHashes;
 
     // Size of the BlockDetails RLP (in bytes). Used for computing blockchain memory usage
     // statistics. Field name must be 'size' as BlockChain::getHashSize depends on this
     mutable unsigned size;
 
     // Size of the block RLP data in bytes
-    unsigned blockSizeBytes;
+    size_t blockSizeBytes;
 };
 
 struct BlockLogBlooms
 {
-	BlockLogBlooms() {}
-	BlockLogBlooms(RLP const& _r) { blooms = _r.toVector<LogBloom>(); size = _r.data().size(); }
-	bytes rlp() const { bytes r = dev::rlp(blooms); size = r.size(); return r; }
+    BlockLogBlooms() {}
+    BlockLogBlooms(RLP const& _r) { blooms = _r.toVector<LogBloom>(); size = _r.data().size(); }
+    bytes rlp() const { bytes r = dev::rlp(blooms); size = r.size(); return r; }
 
-	LogBlooms blooms;
-	mutable unsigned size;
+    LogBlooms blooms;
+    mutable unsigned size;
 };
 
 struct BlocksBlooms
 {
-	BlocksBlooms() {}
-	BlocksBlooms(RLP const& _r) { blooms = _r.toArray<LogBloom, c_bloomIndexSize>(); size = _r.data().size(); }
-	bytes rlp() const { bytes r = dev::rlp(blooms); size = r.size(); return r; }
+    BlocksBlooms() {}
+    BlocksBlooms(RLP const& _r) { blooms = _r.toArray<LogBloom, c_bloomIndexSize>(); size = _r.data().size(); }
+    bytes rlp() const { bytes r = dev::rlp(blooms); size = r.size(); return r; }
 
-	std::array<LogBloom, c_bloomIndexSize> blooms;
-	mutable unsigned size;
+    std::array<LogBloom, c_bloomIndexSize> blooms;
+    mutable unsigned size;
 };
 
 struct BlockReceipts
 {
-	BlockReceipts() {}
-	BlockReceipts(RLP const& _r) { for (auto const& i: _r) receipts.emplace_back(i.data()); size = _r.data().size(); }
-	bytes rlp() const { RLPStream s(receipts.size()); for (TransactionReceipt const& i: receipts) i.streamRLP(s); size = s.out().size(); return s.out(); }
+    BlockReceipts() {}
+    BlockReceipts(RLP const& _r) { for (auto const& i: _r) receipts.emplace_back(i.data()); size = _r.data().size(); }
+    bytes rlp() const { RLPStream s(receipts.size()); for (TransactionReceipt const& i: receipts) i.streamRLP(s); size = s.out().size(); return s.out(); }
 
-	TransactionReceipts receipts;
-	mutable unsigned size = 0;
+    TransactionReceipts receipts;
+    mutable unsigned size = 0;
 };
 
 struct BlockHash
 {
-	BlockHash() {}
-	BlockHash(h256 const& _h): value(_h) {}
-	BlockHash(RLP const& _r) { value = _r.toHash<h256>(); }
-	bytes rlp() const { return dev::rlp(value); }
+    BlockHash() {}
+    BlockHash(h256 const& _h): value(_h) {}
+    BlockHash(RLP const& _r) { value = _r.toHash<h256>(); }
+    bytes rlp() const { return dev::rlp(value); }
 
-	h256 value;
-	static const unsigned size = 65;
+    h256 value;
+    static const unsigned size = 65;
 };
 
 struct TransactionAddress
 {
-	TransactionAddress() {}
-	TransactionAddress(RLP const& _rlp) { blockHash = _rlp[0].toHash<h256>(); index = _rlp[1].toInt<unsigned>(); }
-	bytes rlp() const { RLPStream s(2); s << blockHash << index; return s.out(); }
+    TransactionAddress() {}
+    TransactionAddress(RLP const& _rlp) { blockHash = _rlp[0].toHash<h256>(); index = _rlp[1].toInt<unsigned>(); }
+    bytes rlp() const { RLPStream s(2); s << blockHash << index; return s.out(); }
 
-	explicit operator bool() const { return !!blockHash; }
+    explicit operator bool() const { return !!blockHash; }
 
-	h256 blockHash;
-	unsigned index = 0;
+    h256 blockHash;
+    unsigned index = 0;
 
-	static const unsigned size = 67;
+    static const unsigned size = 67;
 };
 
 using BlockDetailsHash = std::unordered_map<h256, BlockDetails>;

--- a/libethereum/BlockDetails.h
+++ b/libethereum/BlockDetails.h
@@ -17,15 +17,16 @@ namespace eth
 
 // TODO: OPTIMISE: constructors take bytes, RLP used only in necessary classes.
 
-static const unsigned c_bloomIndexSize = 16;
-static const unsigned c_bloomIndexLevels = 2;
+constexpr unsigned c_bloomIndexSize = 16;
+constexpr unsigned c_bloomIndexLevels = 2;
 
-static const unsigned c_invalidNumber = (unsigned)-1;
+constexpr unsigned c_invalidNumber = (unsigned)-1;
 
 struct BlockDetails
 {
 	BlockDetails(): number(c_invalidNumber), totalDifficulty(Invalid256) {}
-	BlockDetails(unsigned _n, u256 _tD, h256 _p, h256s _c): number(_n), totalDifficulty(_tD), parent(_p), children(_c) {}
+	BlockDetails(unsigned _number, u256 _totalDifficulty, h256 _parentHash, h256s _childHashes, unsigned _blockSizeBytes) : number{ _number }, totalDifficulty{ _totalDifficulty }, parentHash{ _parentHash }, childHashes{ _childHashes
+	}, blockSizeBytes{_blockSizeBytes}{}
 	BlockDetails(RLP const& _r);
 	bytes rlp() const;
 
@@ -34,10 +35,15 @@ struct BlockDetails
 
 	unsigned number = c_invalidNumber;
 	u256 totalDifficulty = Invalid256;
-	h256 parent;
-	h256s children;
+	h256 parentHash;
+	h256s childHashes;
 
-	mutable unsigned size;
+    // Size of the BlockDetails RLP (in bytes). Used for computing blockchain memory usage
+    // statistics. Field name must be 'size' as BlockChain::getHashSize depends on this
+    mutable unsigned size;
+
+    // Size of the block RLP data in bytes
+    unsigned blockSizeBytes;
 };
 
 struct BlockLogBlooms

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -417,11 +417,11 @@ BlockHeader ClientBase::pendingInfo() const
 
 BlockDetails ClientBase::pendingDetails() const
 {
-    auto pendingHeader = postSeal().info();
-    auto latestDetails = Interface::blockDetails(LatestBlock);
-    return BlockDetails{(unsigned)pendingHeader.number(),
+    auto const pendingHeader = postSeal().info();
+    auto const latestDetails = Interface::blockDetails(LatestBlock);
+    return BlockDetails{static_cast<unsigned>(pendingHeader.number()),
         latestDetails.totalDifficulty + pendingHeader.difficulty(), pendingHeader.parentHash(),
-        h256s{} /* children */, static_cast<unsigned>(postSeal().blockData().size())};
+        h256s{} /* children */, postSeal().blockData().size()};
 }
 
 Addresses ClientBase::addresses(BlockNumber _block) const

--- a/libethereum/ClientBase.cpp
+++ b/libethereum/ClientBase.cpp
@@ -417,9 +417,11 @@ BlockHeader ClientBase::pendingInfo() const
 
 BlockDetails ClientBase::pendingDetails() const
 {
-    auto pm = postSeal().info();
-    auto li = Interface::blockDetails(LatestBlock);
-    return BlockDetails((unsigned)pm.number(), li.totalDifficulty + pm.difficulty(), pm.parentHash(), h256s{});
+    auto pendingHeader = postSeal().info();
+    auto latestDetails = Interface::blockDetails(LatestBlock);
+    return BlockDetails{(unsigned)pendingHeader.number(),
+        latestDetails.totalDifficulty + pendingHeader.difficulty(), pendingHeader.parentHash(),
+        h256s{} /* children */, static_cast<unsigned>(postSeal().blockData().size())};
 }
 
 Addresses ClientBase::addresses(BlockNumber _block) const

--- a/libethereum/DatabasePaths.cpp
+++ b/libethereum/DatabasePaths.cpp
@@ -30,11 +30,8 @@ bool databasePathsSet()
 
 void setDatabasePaths(fs::path const& _rootPath, h256 const& _genesisHash)
 {
-    if (_genesisHash == h256{})
-    {
-        BOOST_THROW_EXCEPTION(InvalidHash());
-    }
-
+    // Allow empty hashes since they are required by tests
+    
     g_rootPath = _rootPath.empty() ? db::databasePath() : _rootPath;
     g_chainPath = g_rootPath / fs::path(toHex(_genesisHash.ref().cropped(0, 4)));
     g_stateDbPath = g_chainPath / fs::path("state");

--- a/libethereum/DatabasePaths.cpp
+++ b/libethereum/DatabasePaths.cpp
@@ -4,79 +4,61 @@
 
 #include "DatabasePaths.h"
 #include "libdevcore/CommonIO.h"
-#include "libdevcore/DBFactory.h"
-#include "libethcore/Exceptions.h"
+#include "libethcore/Common.h"
 
 namespace dev
 {
 namespace eth
 {
-namespace database_paths
-{
 namespace fs = boost::filesystem;
 
-fs::path g_rootPath;
-fs::path g_chainPath;
-fs::path g_blocksDbPath;
-fs::path g_stateDbPath;
-fs::path g_extrasDbPath;
-fs::path g_extrasDbTempPath;
-fs::path g_extrasDbMinorVersionPath;
-
-bool databasePathsSet()
+DatabasePaths::DatabasePaths(fs::path const& _rootPath, h256 const& _genesisHash) noexcept
 {
-    return !g_rootPath.empty();
+    // Allow an empty root path and empty genesis hash since they are required by the tests
+    m_rootPath = _rootPath;
+    m_chainPath = m_rootPath / fs::path(toHex(_genesisHash.ref().cropped(0, 4)));
+    m_statePath = m_chainPath / fs::path("state");
+    m_blocksPath = m_chainPath / fs::path("blocks");
+
+    auto const extrasRootPath = m_chainPath / fs::path(toString(c_databaseVersion));
+    m_extrasPath = extrasRootPath / fs::path("extras");
+    m_extrasTemporaryPath = extrasRootPath / fs::path("extras.old");
+    m_extrasMinorVersionPath = m_extrasPath / fs::path("minor");
 }
 
-void setDatabasePaths(fs::path const& _rootPath, h256 const& _genesisHash)
+fs::path const& DatabasePaths::rootPath() const noexcept
 {
-    // Allow empty hashes since they are required by tests
-    
-    g_rootPath = _rootPath.empty() ? db::databasePath() : _rootPath;
-    g_chainPath = g_rootPath / fs::path(toHex(_genesisHash.ref().cropped(0, 4)));
-    g_stateDbPath = g_chainPath / fs::path("state");
-    g_blocksDbPath = g_chainPath / fs::path("blocks");
-
-    auto const extrasRootPath = g_chainPath / fs::path(toString(c_databaseVersion));
-    g_extrasDbPath = extrasRootPath / fs::path("extras");
-    g_extrasDbTempPath = extrasRootPath / fs::path("extras.old");
-    g_extrasDbMinorVersionPath = g_extrasDbPath / fs::path("minor");
+    return m_rootPath;
 }
 
-fs::path rootPath()
+fs::path const& DatabasePaths::chainPath() const noexcept
 {
-    return g_rootPath;
+    return m_chainPath;
 }
 
-fs::path chainPath()
+fs::path const& DatabasePaths::statePath() const noexcept
 {
-    return g_chainPath;
+    return m_statePath;
 }
 
-fs::path stateDatabasePath()
+fs::path const& DatabasePaths::blocksPath() const noexcept
 {
-    return g_stateDbPath;
+    return m_blocksPath;
 }
 
-fs::path blocksDatabasePath()
+fs::path const& DatabasePaths::extrasPath() const noexcept
 {
-    return g_blocksDbPath;
+    return m_extrasPath;
 }
 
-fs::path extrasDatabasePath()
+fs::path const& DatabasePaths::extrasTemporaryPath() const noexcept
 {
-    return g_extrasDbPath;
+    return m_extrasTemporaryPath;
 }
 
-fs::path extrasDatabaseTemporaryPath()
+fs::path const& DatabasePaths::extrasMinorVersionPath() const noexcept
 {
-    return g_extrasDbTempPath;
+    return m_extrasMinorVersionPath;
 }
-
-fs::path extrasDatabaseMinorVersionPath()
-{
-    return g_extrasDbMinorVersionPath;
-}
-}  // namespace database_paths
 }  // namespace eth
 }  // namespace dev

--- a/libethereum/DatabasePaths.cpp
+++ b/libethereum/DatabasePaths.cpp
@@ -1,0 +1,85 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2014-2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#include "DatabasePaths.h"
+#include "libdevcore/CommonIO.h"
+#include "libdevcore/DBFactory.h"
+#include "libethcore/Exceptions.h"
+
+namespace dev
+{
+namespace eth
+{
+namespace database_paths
+{
+namespace fs = boost::filesystem;
+
+fs::path g_rootPath;
+fs::path g_chainPath;
+fs::path g_blocksDbPath;
+fs::path g_stateDbPath;
+fs::path g_extrasDbPath;
+fs::path g_extrasDbTempPath;
+fs::path g_extrasDbMinorVersionPath;
+
+bool databasePathsSet()
+{
+    return !g_rootPath.empty();
+}
+
+void setDatabasePaths(fs::path const& _rootPath, h256 const& _genesisHash)
+{
+    if (_genesisHash == h256{})
+    {
+        BOOST_THROW_EXCEPTION(InvalidHash());
+    }
+
+    g_rootPath = _rootPath.empty() ? db::databasePath() : _rootPath;
+    g_chainPath = g_rootPath / fs::path(toHex(_genesisHash.ref().cropped(0, 4)));
+    g_stateDbPath = g_chainPath / fs::path("state");
+    g_blocksDbPath = g_chainPath / fs::path("blocks");
+
+    auto const extrasRootPath = g_chainPath / fs::path(toString(c_databaseVersion));
+    g_extrasDbPath = extrasRootPath / fs::path("extras");
+    g_extrasDbTempPath = extrasRootPath / fs::path("extras.old");
+    g_extrasDbMinorVersionPath = g_extrasDbPath / fs::path("minor");
+}
+
+fs::path rootPath()
+{
+    return g_rootPath;
+}
+
+fs::path chainPath()
+{
+    return g_chainPath;
+}
+
+fs::path stateDatabasePath()
+{
+    return g_stateDbPath;
+}
+
+fs::path blocksDatabasePath()
+{
+    return g_blocksDbPath;
+}
+
+fs::path extrasDatabasePath()
+{
+    return g_extrasDbPath;
+}
+
+fs::path extrasDatabaseTemporaryPath()
+{
+    return g_extrasDbTempPath;
+}
+
+fs::path extrasDatabaseMinorVersionPath()
+{
+    return g_extrasDbMinorVersionPath;
+}
+}  // namespace database_paths
+}  // namespace eth
+}  // namespace dev

--- a/libethereum/DatabasePaths.h
+++ b/libethereum/DatabasePaths.h
@@ -1,0 +1,27 @@
+// Aleth: Ethereum C++ client, tools and libraries.
+// Copyright 2014-2019 Aleth Authors.
+// Licensed under the GNU General Public License, Version 3.
+
+#pragma once
+
+#include "libdevcore/FixedHash.h"
+#include <boost/filesystem/path.hpp>
+
+namespace dev
+{
+namespace eth
+{
+namespace database_paths
+{
+bool databasePathsSet();
+void setDatabasePaths(boost::filesystem::path const& _rootPath, h256 const& _genesisHash);
+boost::filesystem::path rootPath();
+boost::filesystem::path chainPath();
+boost::filesystem::path blocksDatabasePath();
+boost::filesystem::path stateDatabasePath();
+boost::filesystem::path extrasDatabasePath();
+boost::filesystem::path extrasDatabaseTemporaryPath();
+boost::filesystem::path extrasDatabaseMinorVersionPath();
+}  // namespace database_paths
+}  // namespace eth
+}  // namespace dev

--- a/libethereum/DatabasePaths.h
+++ b/libethereum/DatabasePaths.h
@@ -11,17 +11,26 @@ namespace dev
 {
 namespace eth
 {
-namespace database_paths
+class DatabasePaths
 {
-bool databasePathsSet();
-void setDatabasePaths(boost::filesystem::path const& _rootPath, h256 const& _genesisHash);
-boost::filesystem::path rootPath();
-boost::filesystem::path chainPath();
-boost::filesystem::path blocksDatabasePath();
-boost::filesystem::path stateDatabasePath();
-boost::filesystem::path extrasDatabasePath();
-boost::filesystem::path extrasDatabaseTemporaryPath();
-boost::filesystem::path extrasDatabaseMinorVersionPath();
-}  // namespace database_paths
+public:
+    DatabasePaths(boost::filesystem::path const& _rootPath, h256 const& _genesisHash) noexcept;
+    boost::filesystem::path const& rootPath() const noexcept;
+    boost::filesystem::path const& chainPath() const noexcept;
+    boost::filesystem::path const& blocksPath() const noexcept;
+    boost::filesystem::path const& statePath() const noexcept;
+    boost::filesystem::path const& extrasPath() const noexcept;
+    boost::filesystem::path const& extrasTemporaryPath() const noexcept;
+    boost::filesystem::path const& extrasMinorVersionPath() const noexcept;
+
+private:
+    boost::filesystem::path m_rootPath;
+    boost::filesystem::path m_chainPath;
+    boost::filesystem::path m_blocksPath;
+    boost::filesystem::path m_statePath;
+    boost::filesystem::path m_extrasPath;
+    boost::filesystem::path m_extrasTemporaryPath;
+    boost::filesystem::path m_extrasMinorVersionPath;
+};
 }  // namespace eth
 }  // namespace dev

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -264,7 +264,7 @@ public:
                 if (details.number < limitBlock)
                     // stop using parent hash traversal, fallback to using block numbers
                     break;
-                _h = details.parent;
+                _h = details.parentHash;
                 --_step;
             }
 

--- a/libethereum/State.cpp
+++ b/libethereum/State.cpp
@@ -53,6 +53,13 @@ OverlayDB State::openDB(fs::path const& _basePath, h256 const& _genesisHash, Wit
                 << "Deleting state database: " << db_paths::stateDatabasePath();
             fs::remove_all(db_paths::stateDatabasePath());
         }
+
+        clog(VerbosityDebug, "statedb")
+            << "Verifying path exists (and creating if not present): " << db_paths::chainPath();
+        fs::create_directories(db_paths::chainPath());
+        clog(VerbosityDebug, "statedb")
+            << "Ensuring permissions are set for path: " << db_paths::chainPath();
+        DEV_IGNORE_EXCEPTIONS(fs::permissions(db_paths::chainPath(), fs::owner_all));
     }
 
     try

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -351,19 +351,16 @@ Json::Value Eth::eth_getBlockByHash(string const& _blockHash, bool _includeTrans
 
         Json::Value ret;
         auto const blockDetails = client()->blockDetails(h);
+        auto const blockHeader = client()->blockInfo(h);
+        auto const uncleHashes = client()->uncleHashes(h);
+        auto* sealEngine = client()->sealEngine();
         if (_includeTransactions)
-            ret = toJson(client()->blockInfo(h), blockDetails,
-                client()->uncleHashes(h), client()->transactions(h), client()->sealEngine());
+            ret = toJson(
+                blockHeader, blockDetails, uncleHashes, client()->transactions(h), sealEngine);
         else
-            ret = toJson(client()->blockInfo(h), blockDetails,
-                client()->uncleHashes(h), client()->transactionHashes(h), client()->sealEngine());
-
-        // We need to explicitly set the "size" field to the block size in bytes since the
-        // BlockDetails "size" field refers to something else (size of BlockDetails RLP) and cannot
-        // be changed
-        ret["size"] = toJS(blockDetails.blockSizeBytes);
-
-		return ret;
+            ret = toJson(
+                blockHeader, blockDetails, uncleHashes, client()->transactionHashes(h), sealEngine);
+        return ret;
     }
     catch (...)
     {
@@ -381,18 +378,15 @@ Json::Value Eth::eth_getBlockByNumber(string const& _blockNumber, bool _includeT
 
         Json::Value ret;
         auto const blockDetails = client()->blockDetails(h);
+        auto const blockHeader = client()->blockInfo(h);
+        auto const uncleHashes = client()->uncleHashes(h);
+        auto* sealEngine = client()->sealEngine();
         if (_includeTransactions)
-            ret = toJson(client()->blockInfo(h), blockDetails, client()->uncleHashes(h),
-                client()->transactions(h), client()->sealEngine());
+            ret = toJson(
+                blockHeader, blockDetails, uncleHashes, client()->transactions(h), sealEngine);
         else
-            ret = toJson(client()->blockInfo(h), blockDetails, client()->uncleHashes(h),
-                client()->transactionHashes(h), client()->sealEngine());
-
-        // We need to explicitly set the "size" field to the block size in bytes since the
-        // BlockDetails "size" field refers to something else (size of BlockDetails RLP) and cannot
-        // be changed
-        ret["size"] = toJS(blockDetails.blockSizeBytes);
-
+            ret = toJson(
+                blockHeader, blockDetails, uncleHashes, client()->transactionHashes(h), sealEngine);
         return ret;
     }
 	catch (...)

--- a/libweb3jsonrpc/JsonHelper.cpp
+++ b/libweb3jsonrpc/JsonHelper.cpp
@@ -125,7 +125,7 @@ Json::Value toJson(dev::eth::BlockHeader const& _bi, BlockDetails const& _bd, Un
     if (_bi)
     {
         res["totalDifficulty"] = toJS(_bd.totalDifficulty);
-        res["size"] = toJS(_bd.size);
+        res["size"] = toJS(_bd.blockSizeBytes);
         res["uncles"] = Json::Value(Json::arrayValue);
         for (h256 h: _us)
             res["uncles"].append(toJS(h));
@@ -142,7 +142,7 @@ Json::Value toJson(dev::eth::BlockHeader const& _bi, BlockDetails const& _bd, Un
     if (_bi)
     {
         res["totalDifficulty"] = toJS(_bd.totalDifficulty);
-        res["size"] = toJS(_bd.size);
+        res["size"] = toJS(_bd.blockSizeBytes);
         res["uncles"] = Json::Value(Json::arrayValue);
         for (h256 h: _us)
             res["uncles"].append(toJS(h));


### PR DESCRIPTION
Fix #5797, #5814

Return the size of a block in bytes to calls to `web3.eth.getBlock`. This requires extending the `BlockDetails `structure (by adding a new `blockSizeBytes `field) which in turn requires incrementing the db minor version number (since `BlockDetails ` are stored in the Extras database) which triggers an automatic database rebuild (which can take a while depending on how many blocks are in your local chain).

I've also made some minor changes to the database rebuild code to handle edge cases:
* Detect a previously prematurely terminated rebuild and log an error / throw exception if detected
* Throw an exception on rebuild failure (previously only logged an error message)
* Only update the database minor version file after a successful rebuild
* Additional logging during database rebuild

Tested changes by calling web3.eth.getBlock with the following block numbers and comparing the results against Etherscan: 0, 1, 65001 (3 txs), 101146 (2 txs), 109424 (1 tx), 115367 (7 txs)
