### PR TITLE
Disable all compiler optimizations in Debug build

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -36,7 +36,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
     add_compile_options(-Wno-unknown-pragmas)
 
     # Configuration-specific compiler settings.
-    set(CMAKE_CXX_FLAGS_DEBUG          "-Og -g -DETH_DEBUG")
+    set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g -DETH_DEBUG")
     set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
     set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")


### PR DESCRIPTION
This really makes it slower, on my machine the full `testeth` run (without `--all`) takes ~17 minutes with `-Og` vs 23-25 minutes with `-O0`.

But I think it's worth to try it, as Debug is not built on CI, and I don't really run all of the tests locally often.