### PR TITLE
Fix mainnet and ropsten configs for correct EC precompiles cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.1] - Unreleased
+
+- Fixed: [#5833](https://github.com/ethereum/aleth/pull/5833) Fix cost of ECADD and ECMULL for Istanbul in Mainnet and Ropsten chain configs.
+
 ## [1.7.0] - 2019-11-14
 
 - Added: [#5537](https://github.com/ethereum/aleth/pull/5537) Creating Ethereum Node Record (ENR) at program start.
@@ -81,7 +85,8 @@
 - Fixed: [#5181](https://github.com/ethereum/aleth/issues/5181) Fix building on PowerPC architecture where -mtune=generic is not available.
 
 
-[1.7.0]: https://github.com/ethereum/aleth/releases/tat/v1.7.0
+[1.7.1]: https://github.com/ethereum/aleth/compare/v1.7.0...release/1.7
+[1.7.0]: https://github.com/ethereum/aleth/releases/tag/v1.7.0
 [1.6.0]: https://github.com/ethereum/aleth/releases/tag/v1.6.0
 
 [EVMC]: https://github.com/ethereum/evmc

--- a/libethashseal/genesis/mainNetwork.cpp
+++ b/libethashseal/genesis/mainNetwork.cpp
@@ -47,10 +47,10 @@ R"E(
         "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
         "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
         "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x42ae50" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x42ae50", "linear": { "base": 500, "word": 0 } } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x42ae50", "linear": { "base": 40000, "word": 0 } } },
+        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x42ae50" } },
+        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x42ae50" } },
         "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x42ae50" } },
-		"0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression", "startingBlock": "0x8a61c8" } },
+        "0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression", "startingBlock": "0x8a61c8" } },
         "3282791d6fd713f1e94f4bfd565eaa78b3a0599d": {
         "balance": "1337000000000000000000"
         },

--- a/libethashseal/genesis/ropsten.cpp
+++ b/libethashseal/genesis/ropsten.cpp
@@ -46,10 +46,10 @@ R"E(
         "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
         "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
         "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x19f0a0" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x19f0a0", "linear": { "base": 500, "word": 0 } } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x19f0a0", "linear": { "base": 40000, "word": 0 } } },
+        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x19f0a0" } },
+        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x19f0a0" } },
         "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x19f0a0" } },
-		"0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression", "startingBlock": "0x62f756" } },
+        "0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression", "startingBlock": "0x62f756" } },
         )E" + R"E(
         "0x0000000000000000000000000000000000000011": {
             "balance": "0"


### PR DESCRIPTION
Without this change cost of ECADD and ECADD stays the same in Istanbul.

See also EIP-1108 implementation https://github.com/ethereum/aleth/pull/5705