### PR TITLE
Fix segmentation fault during syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed: [#5821](https://github.com/ethereum/aleth/pull/5821) `test_setChainParams` correctly initializes custom configuration of precompiled contracts.
 - Fixed: [#5826](https://github.com/ethereum/aleth/pull/5826) Fix blocking bug in database rebuild functionality - users can now rebuild their databases via Aleth's '-R' switch.
 - Fixed: [#5827](https://github.com/ethereum/aleth/pull/5827) Detect database upgrades and automatically rebuild the database when they occur.
+- Fixed: [#5834](https://github.com/ethereum/aleth/pull/5834) Fix segmentation fault during sync.
 
 ## [1.7.1] - 2019-11-18
 

--- a/libethereum/EthereumCapability.cpp
+++ b/libethereum/EthereumCapability.cpp
@@ -629,8 +629,8 @@ void EthereumCapability::onDisconnect(NodeID const& _peerID)
 bool EthereumCapability::interpretCapabilityPacket(
     NodeID const& _peerID, unsigned _id, RLP const& _r)
 {
-    auto& peer = m_peers[_peerID];
-    peer.setLastAsk(std::chrono::system_clock::to_time_t(chrono::system_clock::now()));
+    auto& remotePeer = peer(_peerID);
+    remotePeer.setLastAsk(std::chrono::system_clock::to_time_t(chrono::system_clock::now()));
 
     try
     {
@@ -648,10 +648,10 @@ bool EthereumCapability::interpretCapabilityPacket(
                           << networkId << " / " << genesisHash << ", TD: " << totalDifficulty
                           << " = " << latestHash;
 
-            peer.setStatus(
+            remotePeer.setStatus(
                 peerProtocolVersion, networkId, totalDifficulty, latestHash, genesisHash);
             setIdle(_peerID);
-            m_peerObserver->onPeerStatus(peer);
+            m_peerObserver->onPeerStatus(remotePeer);
             break;
         }
         case TransactionsPacket:
@@ -691,7 +691,7 @@ bool EthereumCapability::interpretCapabilityPacket(
         }
         case BlockHeadersPacket:
         {
-            if (peer.asking() != Asking::BlockHeaders)
+            if (remotePeer.asking() != Asking::BlockHeaders)
                 LOG(m_loggerImpolite) << "Peer " << _peerID
                                       << " giving us block headers when we didn't ask for them.";
             else
@@ -724,7 +724,7 @@ bool EthereumCapability::interpretCapabilityPacket(
         }
         case BlockBodiesPacket:
         {
-            if (peer.asking() != Asking::BlockBodies)
+            if (remotePeer.asking() != Asking::BlockBodies)
                 LOG(m_loggerImpolite)
                     << "Peer " << _peerID << " giving us block bodies when we didn't ask for them.";
             else
@@ -803,7 +803,7 @@ bool EthereumCapability::interpretCapabilityPacket(
         }
         case NodeDataPacket:
         {
-            if (peer.asking() != Asking::NodeData)
+            if (remotePeer.asking() != Asking::NodeData)
                 LOG(m_loggerImpolite)
                     << "Peer " << _peerID << " giving us node data when we didn't ask for them.";
             else
@@ -815,7 +815,7 @@ bool EthereumCapability::interpretCapabilityPacket(
         }
         case ReceiptsPacket:
         {
-            if (peer.asking() != Asking::Receipts)
+            if (remotePeer.asking() != Asking::Receipts)
                 LOG(m_loggerImpolite)
                     << "Peer " << _peerID << " giving us receipts when we didn't ask for them.";
             else

--- a/libethereum/EthereumPeer.h
+++ b/libethereum/EthereumPeer.h
@@ -17,7 +17,7 @@ namespace eth
 class EthereumPeer
 {
 public:
-    EthereumPeer() = default;
+    EthereumPeer() = delete;
     EthereumPeer(std::shared_ptr<p2p::CapabilityHostFace> _host, NodeID const& _peerID,
         u256 const& /*_capabilityVersion*/)
       : m_host(std::move(_host)), m_id(_peerID)


### PR DESCRIPTION
Fix #5832, #5633 

I suspect the segmentation fault is occurring when a peer reconnects while its disconnect is
still pending (see [here ](https://github.com/ethereum/aleth/issues/5633#issuecomment-550934074)for a detailed description), which results in a live `Session ` but no entry in
`EthereumCapability::m_peers`.

`EthereumCapability::interpretCapabilityPacket` directly accesses `m_peers` via the `[] `operator rather than using a lookup function, which can cause a segfault if the entry with the node ID has already been removed.

This fix will trigger an exception to be thrown when the peer being looked up is not present in `EthereumCapability::m_peers`. This isn't ideal, but is good enough for now until we can design a proper fix for the "reconnect during pending disconnect" issue (#5835)