### PR TITLE
Adapt testeth to be used with evmlab - part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed: [#5801](https://github.com/ethereum/aleth/pull/5801) `testeth -t BlockchainTests` command now doesn't run the tests for the forks before Istanbul. To run those tests use a separate LegacyTests suite with command `testeth -t LegacyTests/Constantinople/BlockchainTests`.
 - Changed: [#5807](https://github.com/ethereum/aleth/pull/5807) Optimize selfdestruct opcode in LegacyVM by reducing state accesses in certain out-of-gas scenarios.
 - Changed: [#5806](https://github.com/ethereum/aleth/pull/5806) Optimize selfdestruct opcode in aleth-interpreter by reducing state accesses in certain out-of-gas scenarios.
+- Changed: [#5837](https://github.com/ethereum/aleth/pull/5837) Output format of `testeth --jsontrace` command changed to better match output of geth's evm tool and to integrate with evmlab project.
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
 - Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).
 - Fixed: [#5811](https://github.com/ethereum/aleth/pull/5811) RPC methods querying transactions (`eth_getTransactionByHash`, `eth_getBlockByNumber`) return correct `v` value.

--- a/libethereum/StandardTrace.cpp
+++ b/libethereum/StandardTrace.cpp
@@ -101,7 +101,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
     r["pc"] = toString(PC);
     r["gas"] = toString(gas);
     r["gasCost"] = toString(gasCost);
-    r["depth"] = toString(ext.depth);
+    r["depth"] = toString(ext.depth + 1);  // depth in standard trace is 1-based
     if (!!newMemSize)
         r["memexpand"] = toString(newMemSize);
 

--- a/libethereum/StandardTrace.cpp
+++ b/libethereum/StandardTrace.cpp
@@ -95,8 +95,9 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
         r["storage"] = storage;
     }
 
+    r["op"] = static_cast<uint8_t>(inst);
     if (m_showMnemonics)
-        r["op"] = instructionInfo(inst).name;
+        r["opName"] = instructionInfo(inst).name;
     r["pc"] = toString(PC);
     r["gas"] = toString(gas);
     r["gasCost"] = toString(gasCost);

--- a/libethereum/StandardTrace.cpp
+++ b/libethereum/StandardTrace.cpp
@@ -82,7 +82,7 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
             }
             r["memory"] = memJson;
         }
-        r["memSize"] = memory.size();
+        r["memSize"] = static_cast<uint64_t>(memory.size());
     }
 
     if (!m_options.disableStorage &&

--- a/libethereum/Transaction.cpp
+++ b/libethereum/Transaction.cpp
@@ -74,7 +74,10 @@ std::ostream& dev::eth::operator<<(std::ostream& _out, TransactionException cons
 		case TransactionException::OutOfGas: _out << "OutOfGas"; break;
 		case TransactionException::OutOfStack: _out << "OutOfStack"; break;
 		case TransactionException::StackUnderflow: _out << "StackUnderflow"; break;
-		default: _out << "Unknown"; break;
+        case TransactionException::RevertInstruction:
+            _out << "RevertInstruction";
+            break;
+        default: _out << "Unknown"; break;
 	}
 	return _out;
 }

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -396,10 +396,19 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
             st.setOptions(Options::get().jsontraceOptions);
             out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed, st.onOp());
             cout << st.multilineTrace();
-            cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}";
         }
         else
             out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);
+
+        if (Options::get().jsontrace || !Options::get().singleTestFile.empty())
+        {
+            cout << R"({"output": ")" << toHex(out.first.output) << R"(", "gasUsed": ")"
+                 << out.first.gasUsed;
+            if (out.first.excepted != TransactionException::None)
+                cout << R"(", "error": ")" << out.first.excepted;
+            cout << "\"}\n";
+            cout << R"({"stateRoot": ")" << initialState.rootHash().hex() << "\"}\n";
+        }
 
         // the changeLog might be broken under --jsontrace, because it uses intialState.execute with Permanence::Committed rather than Permanence::Uncommitted
         eth::ChangeLog changeLog = initialState.changeLog();


### PR DESCRIPTION
Addresses 5 out of 6 tasks in https://github.com/ethereum/aleth/issues/5804

1. Add `memSize` field
2. Always output memory unless disabled; not only for memory-changing opcodes.
3. `depth` starts with 1
4. Rename `op` to `opName` and output opcode number in `op`
5. Output line with `output`, `gasUsed`, `error` after the execution

Examples of output:
```
> test/testeth -t GeneralStateTests -- --testfile /home/andrei/dev/sar00.json  --jsontrace {}
Test Case "customTestSuite": 
{"depth":"1","gas":"379000","gasCost":"3","memSize":0,"memory":[],"op":96,"opName":"PUSH1","pc":"0","stack":[],"storage":{"0x00":"0x03"}}
{"depth":"1","gas":"378997","gasCost":"3","memSize":0,"memory":[],"op":96,"opName":"PUSH1","pc":"2","stack":["0x00"]}
{"depth":"1","gas":"378994","gasCost":"3","memSize":0,"memory":[],"op":29,"opName":"SAR","pc":"4","stack":["0x00","0x00"]}
{"depth":"1","gas":"378991","gasCost":"3","memSize":0,"memory":[],"op":96,"opName":"PUSH1","pc":"5","stack":["0x00"]}
{"depth":"1","gas":"378988","gasCost":"0","memSize":0,"memory":[],"op":85,"opName":"SSTORE","pc":"7","stack":["0x00","0x00"]}
{"depth":"1","gas":"373988","gasCost":"0","memSize":0,"memory":[],"op":0,"opName":"STOP","pc":"8","stack":[],"storage":{}}
{"output": "", "gasUsed": "13006"}
{"stateRoot": "a4b37b548bc12ee198ce885d83b511302d9d8f6b2ec5775618b3893c60e0dc75"}

*** No errors detected
```
```
> test/testeth -t GeneralStateTests -- --testfile /home/andrei/dev/randomStatetestmartin-Wed_10_02_29-14338-0.json  --jsontrace {}
Test Case "customTestSuite": 
{"depth":"1","gas":"2956484","gasCost":"1","memSize":0,"memory":[],"op":91,"opName":"JUMPDEST","pc":"0","stack":[],"storage":{}}
{"depth":"1","gas":"2956483","gasCost":"2","memSize":0,"memory":[],"op":61,"opName":"RETURNDATASIZE","pc":"1","stack":[]}
{"depth":"1","gas":"2956481","gasCost":"2","memSize":0,"memory":[],"op":48,"opName":"ADDRESS","pc":"2","stack":["0x00"]}
{"depth":"1","gas":"2956479","gasCost":"3","memSize":0,"memory":[],"op":172,"opName":"PUSHC","pc":"3","stack":["0x00","0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b"]}
{"depth":"1","gas":"2956476","gasCost":"3","memSize":0,"memory":[],"op":172,"opName":"PUSHC","pc":"30","stack":["0x00","0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b","0xc940b5f2046740058558468f238b85db7f6bbe3f3d51e92a3e32"]}
{"depth":"1","gas":"2956473","gasCost":"3","memSize":0,"memory":[],"op":83,"opName":"MSTORE8","pc":"40","stack":["0x00","0xc94f5374fce5edbc8e2a8697c15331677e6ebf0b","0xc940b5f2046740058558468f238b85db7f6bbe3f3d51e92a3e32","0xb7f7c4147541c695f3"]}
{"output": "", "gasUsed": "3000000", "error": "OutOfGas"}
{"stateRoot": "a2b3391f7a85bf1ad08dc541a1b99da3c591c156351391f26ec88c557ff12134"}

*** No errors detected
```

Output of geth's `evm` for comparison: https://github.com/holiman/goevmlab/blob/master/evms/testdata/statetest1_geth_stderr.jsonl