### PR TITLE
Adapt testeth to be used with evmlab - part 2

### DIFF
--- a/aleth-vm/main.cpp
+++ b/aleth-vm/main.cpp
@@ -82,7 +82,8 @@ int main(int argc, char** argv)
     u256 gas = maxBlockGasLimit();
     u256 gasPrice = 0;
     bool styledJson = true;
-    StandardTrace st;
+    Json::Value traceJson{Json::arrayValue};
+    StandardTrace st{traceJson};
     Network networkName = Network::MainNetworkTest;
     BlockHeader blockHeader;  // fake block to be executed in
     blockHeader.setGasLimit(maxBlockGasLimit());
@@ -353,7 +354,16 @@ int main(int argc, char** argv)
         }
     }
     else if (mode == Mode::Trace)
-        cout << (styledJson ? st.styledJson() : st.multilineTrace());
+    {
+        if (styledJson)
+            cout << Json::StyledWriter().write(traceJson);
+        else
+        {
+            Json::FastWriter writer;
+            for (auto const& traceOp : traceJson)
+                cout << writer.write(traceOp);
+        }
+    }
     else if (mode == Mode::OutputOnly)
         cout << toHex(output) << '\n';
     else if (mode == Mode::Test)

--- a/libethereum/StandardTrace.cpp
+++ b/libethereum/StandardTrace.cpp
@@ -5,7 +5,6 @@
 #include "StandardTrace.h"
 #include "ExtVM.h"
 #include <libevm/LegacyVM.h>
-#include <numeric>
 
 namespace dev
 {
@@ -17,9 +16,8 @@ bool changesStorage(Instruction _inst)
 {
     return _inst == Instruction::SSTORE;
 }
-}  // namespace
 
-StandardTrace::StandardTrace() : m_trace(Json::arrayValue) {}
+}  // namespace
 
 void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, bigint newMemSize,
     bigint gasCost, bigint gas, VMFace const* _vm, ExtVMFace const* voidExt)
@@ -105,23 +103,10 @@ void StandardTrace::operator()(uint64_t _steps, uint64_t PC, Instruction inst, b
     if (!!newMemSize)
         r["memexpand"] = toString(newMemSize);
 
-    m_trace.append(r);
-}
-
-std::string StandardTrace::styledJson() const
-{
-    return Json::StyledWriter().write(m_trace);
-}
-
-std::string StandardTrace::multilineTrace() const
-{
-    if (m_trace.empty())
-        return {};
-
-    // Each opcode trace on a separate line
-    return std::accumulate(std::next(m_trace.begin()), m_trace.end(),
-        Json::FastWriter().write(m_trace[0]),
-        [](std::string a, Json::Value b) { return a + Json::FastWriter().write(b); });
+    if (m_outValue)
+        m_outValue->append(r);
+    else
+        *m_outStream << m_fastWriter.write(r) << std::flush;
 }
 }  // namespace eth
 }  // namespace dev

--- a/libethereum/StandardTrace.h
+++ b/libethereum/StandardTrace.h
@@ -30,16 +30,16 @@ public:
         bool fullStorage = false;
     };
 
-    StandardTrace();
+    // Output json trace to stream, one line per op
+    explicit StandardTrace(std::ostream& _outStream) noexcept : m_outStream{&_outStream} {}
+    // Append json trace to given (array) value
+    explicit StandardTrace(Json::Value& _outValue) noexcept : m_outValue{&_outValue} {}
+
     void operator()(uint64_t _steps, uint64_t _PC, Instruction _inst, bigint _newMemSize,
         bigint _gasCost, bigint _gas, VMFace const* _vm, ExtVMFace const* _extVM);
 
     void setShowMnemonics() { m_showMnemonics = true; }
     void setOptions(DebugOptions _options) { m_options = _options; }
-
-    Json::Value jsonValue() const { return m_trace; }
-    std::string styledJson() const;
-    std::string multilineTrace() const;
 
     OnOpFunc onOp()
     {
@@ -52,7 +52,9 @@ public:
 private:
     bool m_showMnemonics = false;
     std::vector<Instruction> m_lastInst;
-    Json::Value m_trace;
+    std::ostream* m_outStream = nullptr;
+    Json::Value* m_outValue = nullptr;
+    Json::FastWriter m_fastWriter;
     DebugOptions m_options;
 };
 }  // namespace eth

--- a/libweb3jsonrpc/AdminEth.cpp
+++ b/libweb3jsonrpc/AdminEth.cpp
@@ -196,13 +196,14 @@ Json::Value AdminEth::admin_eth_vmTrace(string const& _blockNumberOrHash, int _t
         Executive e(s, block, _txIndex, m_eth.blockChain());
         try
         {
-            StandardTrace st;
+            Json::Value traceJson{Json::arrayValue};
+            StandardTrace st{traceJson};
             st.setShowMnemonics();
             e.initialize(t);
             if (!e.execute())
                 e.go(st.onOp());
             e.finalize();
-            ret["structLogs"] = st.jsonValue();
+            ret["structLogs"] = traceJson;
         }
         catch(Exception const& _e)
         {

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -68,14 +68,15 @@ State Debug::stateAt(std::string const& _blockHashOrNumber, int _txIndex) const
 
 Json::Value Debug::traceTransaction(Executive& _e, Transaction const& _t, Json::Value const& _json)
 {
-    StandardTrace st;
+    Json::Value traceJson{Json::arrayValue};
+    StandardTrace st{traceJson};
     st.setShowMnemonics();
     st.setOptions(debugOptions(_json));
     _e.initialize(_t);
     if (!_e.execute())
         _e.go(st.onOp());
     _e.finalize();
-    return st.jsonValue();
+    return traceJson;
 }
 
 Json::Value Debug::traceBlock(Block const& _block, Json::Value const& _json)

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -391,11 +391,10 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
         removeEmptyAccounts = m_envInfo->number() >= se->chainParams().EIP158ForkBlock;
         if (Options::get().jsontrace)
         {
-            StandardTrace st;
+            StandardTrace st{cout};
             st.setShowMnemonics();
             st.setOptions(Options::get().jsontraceOptions);
             out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed, st.onOp());
-            cout << st.multilineTrace();
         }
         else
             out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);


### PR DESCRIPTION
This adds to `StandardTrace` the option to output traces directly to the stream instead of accumulating them in JSON array.

Addresses last task in https://github.com/ethereum/aleth/issues/5804