### PR TITLE
Get rid of precompile list in configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed: [#5806](https://github.com/ethereum/aleth/pull/5806) Optimize selfdestruct opcode in aleth-interpreter by reducing state accesses in certain out-of-gas scenarios.
 - Changed: [#5837](https://github.com/ethereum/aleth/pull/5837) [#5839](https://github.com/ethereum/aleth/pull/5839) [#5845](https://github.com/ethereum/aleth/pull/5845) [#5846](https://github.com/ethereum/aleth/pull/5846) Output format of `testeth --jsontrace` command changed to better match output of geth's evm tool and to integrate with evmlab project.
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
+- Removed: [#5840](https://github.com/ethereum/aleth/pull/5840) The list of precompiled contracts is not required in config files anymore.
 - Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).
 - Fixed: [#5811](https://github.com/ethereum/aleth/pull/5811) RPC methods querying transactions (`eth_getTransactionByHash`, `eth_getBlockByNumber`) return correct `v` value.
 - Fixed: [#5821](https://github.com/ethereum/aleth/pull/5821) `test_setChainParams` correctly initializes custom configuration of precompiled contracts.

--- a/doc/private_net_remix.rst
+++ b/doc/private_net_remix.rst
@@ -26,6 +26,7 @@ Enter and confirm a new password for this account when prompted.
       "byzantiumForkBlock": "0x00",
       "constantinopleForkBlock": "0x00",
       "constantinopleFixForkBlock": "0x00",
+      "istanbulForkBlock": "0x00",
       "minGasLimit": "0x5208",
       "maxGasLimit": "0x7fffffffffffffff",
       "tieBreakingGas": false,
@@ -49,14 +50,6 @@ Enter and confirm a new password for this account when prompted.
       "gasLimit": "0x989680"
     },
     "accounts": {
-      "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } }, "balance": "0x01" },
-      "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } }, "balance": "0x01" },
-      "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } }, "balance": "0x01" },
-      "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } }, "balance": "0x01" },
-      "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" }, "balance": "0x01" },
-      "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } }, "balance": "0x01" },
-      "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } }, "balance": "0x01" },
-      "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" }, "balance": "0x01" },
       "008a78302c6fe24cc74008c7bdae27b7243a7066" /* <= Enter your account address here */: {
           "balance" : "0x200000000000000000000000000000000000000000000000000000000000000"
       }
@@ -64,7 +57,7 @@ Enter and confirm a new password for this account when prompted.
   }
   
   
-This includes all forks activated at genesis, all precompiled contracts existing on the main net, and the initial balance for your account.
+This includes all forks activated at genesis and the initial balance for your account.
 
 Note that this format can change occasionally. For the latest format, please consult the source files in https://github.com/ethereum/aleth/tree/master/libethashseal/genesis.
 

--- a/libethashseal/genesis/mainNetwork.cpp
+++ b/libethashseal/genesis/mainNetwork.cpp
@@ -42,15 +42,6 @@ R"E(
         "gasLimit": "0x1388"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x42ae50" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x42ae50" } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x42ae50" } },
-        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x42ae50" } },
-        "0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression", "startingBlock": "0x8a61c8" } },
         "3282791d6fd713f1e94f4bfd565eaa78b3a0599d": {
         "balance": "1337000000000000000000"
         },

--- a/libethashseal/genesis/ropsten.cpp
+++ b/libethashseal/genesis/ropsten.cpp
@@ -41,16 +41,6 @@ R"E(
         "gasLimit": "0x1000000"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x19f0a0" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x19f0a0" } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x19f0a0" } },
-        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x19f0a0" } },
-        "0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression", "startingBlock": "0x62f756" } },
-        )E" + R"E(
         "0x0000000000000000000000000000000000000011": {
             "balance": "0"
         },

--- a/libethashseal/genesis/test/ByzantiumToConstantinopleFixAt5Test.cpp
+++ b/libethashseal/genesis/test/ByzantiumToConstantinopleFixAt5Test.cpp
@@ -40,14 +40,6 @@ static std::string const c_genesisInfoByzantiumToConstantinopleFixAt5Test = std:
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x05" } },
-"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x05", "linear": { "base": 500, "word": 0 } } },
-"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x05", "linear": { "base": 40000, "word": 0 } } },
-"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x05" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/EIP158ToByzantiumAt5Test.cpp
+++ b/libethashseal/genesis/test/EIP158ToByzantiumAt5Test.cpp
@@ -38,14 +38,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x05" } },
-"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x05", "linear": { "base": 500, "word": 0 } } },
-"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x05", "linear": { "base": 40000, "word": 0 } } },
-"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x05" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/berlinTest.cpp
+++ b/libethashseal/genesis/test/berlinTest.cpp
@@ -42,15 +42,6 @@ R"E(
         "gasLimit": "0x1388"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add" } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul" } },
-        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" } },
-        "0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression" } }
     }
 }
 )E";

--- a/libethashseal/genesis/test/byzantiumNoProofTest.cpp
+++ b/libethashseal/genesis/test/byzantiumNoProofTest.cpp
@@ -36,14 +36,6 @@ static std::string const c_genesisInfoByzantiumNoProofTest = R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/byzantiumTest.cpp
+++ b/libethashseal/genesis/test/byzantiumTest.cpp
@@ -38,14 +38,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/byzantiumTransitionTest.cpp
+++ b/libethashseal/genesis/test/byzantiumTransitionTest.cpp
@@ -37,14 +37,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x02" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x02", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x02", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x02" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/constantinopleFixTest.cpp
+++ b/libethashseal/genesis/test/constantinopleFixTest.cpp
@@ -40,14 +40,6 @@ static std::string const c_genesisInfoConstantinopleFixTest = std::string() +
         "gasLimit": "0x1388"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
-        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" } }
     }
 }
 )E";

--- a/libethashseal/genesis/test/constantinopleNoProofTest.cpp
+++ b/libethashseal/genesis/test/constantinopleNoProofTest.cpp
@@ -38,14 +38,6 @@ static std::string const c_genesisInfoConstantinopleNoProofTest = R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/constantinopleTest.cpp
+++ b/libethashseal/genesis/test/constantinopleTest.cpp
@@ -39,14 +39,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/eip150Test.cpp
+++ b/libethashseal/genesis/test/eip150Test.cpp
@@ -36,10 +36,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/eip158Test.cpp
+++ b/libethashseal/genesis/test/eip158Test.cpp
@@ -37,10 +37,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/experimentalTransitionTest.cpp
+++ b/libethashseal/genesis/test/experimentalTransitionTest.cpp
@@ -40,14 +40,6 @@ R"E(
         "gasLimit": "0x1388"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x02" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x02", "linear": { "base": 500, "word": 0 } } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x02", "linear": { "base": 40000, "word": 0 } } },
-        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x02" } }
     }
 }
 )E";

--- a/libethashseal/genesis/test/frontierNoProofTest.cpp
+++ b/libethashseal/genesis/test/frontierNoProofTest.cpp
@@ -34,10 +34,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/frontierTest.cpp
+++ b/libethashseal/genesis/test/frontierTest.cpp
@@ -34,10 +34,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/frontierToHomesteadAt5Test.cpp
+++ b/libethashseal/genesis/test/frontierToHomesteadAt5Test.cpp
@@ -35,10 +35,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/homesteadTest.cpp
+++ b/libethashseal/genesis/test/homesteadTest.cpp
@@ -35,10 +35,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/homesteadToDaoAt5Test.cpp
+++ b/libethashseal/genesis/test/homesteadToDaoAt5Test.cpp
@@ -36,10 +36,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/homesteadToEIP150At5Test.cpp
+++ b/libethashseal/genesis/test/homesteadToEIP150At5Test.cpp
@@ -36,10 +36,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/istanbulTest.cpp
+++ b/libethashseal/genesis/test/istanbulTest.cpp
@@ -41,15 +41,6 @@ R"E(
         "gasLimit": "0x1388"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add" } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul" } },
-        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product" } },
-        "0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression" } }
     }
 }
 )E";

--- a/libethashseal/genesis/test/istanbulTransitionTest.cpp
+++ b/libethashseal/genesis/test/istanbulTransitionTest.cpp
@@ -41,15 +41,6 @@ R"E(
         "gasLimit": "0x1388"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp" } },
-        "0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add" } },
-        "0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul" } },
-        "0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product"} },
-		"0000000000000000000000000000000000000009": { "precompiled": { "name": "blake2_compression", "startingBlock": "0x02" } }
     }
 }
 )E";

--- a/libethashseal/genesis/test/mainNetworkNoProofTest.cpp
+++ b/libethashseal/genesis/test/mainNetworkNoProofTest.cpp
@@ -39,14 +39,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock" : "0x2dc6c0" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock" : "0x2dc6c0", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock" : "0x2dc6c0", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock" : "0x2dc6c0" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/mainNetworkTest.cpp
+++ b/libethashseal/genesis/test/mainNetworkTest.cpp
@@ -39,14 +39,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock" : "0x2dc6c0" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock" : "0x2dc6c0", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock" : "0x2dc6c0", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock" : "0x2dc6c0" } }
 	}
 }
 )E";

--- a/libethashseal/genesis/test/transitionnetTest.cpp
+++ b/libethashseal/genesis/test/transitionnetTest.cpp
@@ -40,14 +40,6 @@ R"E(
 		"gasLimit": "0x1388"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-		"0000000000000000000000000000000000000005": { "precompiled": { "name": "modexp", "startingBlock": "0x10" } },
-		"0000000000000000000000000000000000000006": { "precompiled": { "name": "alt_bn128_G1_add", "startingBlock": "0x10", "linear": { "base": 500, "word": 0 } } },
-		"0000000000000000000000000000000000000007": { "precompiled": { "name": "alt_bn128_G1_mul", "startingBlock": "0x10", "linear": { "base": 40000, "word": 0 } } },
-		"0000000000000000000000000000000000000008": { "precompiled": { "name": "alt_bn128_pairing_product", "startingBlock": "0x10" } }
 	}
 }
 )E";

--- a/libethcore/ChainOperationParams.cpp
+++ b/libethcore/ChainOperationParams.cpp
@@ -12,15 +12,10 @@ using namespace dev;
 using namespace eth;
 
 PrecompiledContract::PrecompiledContract(
-    unsigned _base, unsigned _word, PrecompiledExecutor const& _exec, u256 const& _startingBlock)
-  : PrecompiledContract(
-        [=](bytesConstRef _in, ChainOperationParams const&, u256 const&) -> bigint {
-            bigint s = _in.size();
-            bigint b = _base;
-            bigint w = _word;
-            return b + (s + 31) / 32 * w;
-        },
-        _exec, _startingBlock)
+    std::string const& _name, u256 const& _startingBlock /*= 0*/)
+  : m_cost(PrecompiledRegistrar::pricer(_name)),
+    m_execute(PrecompiledRegistrar::executor(_name)),
+    m_startingBlock(_startingBlock)
 {}
 
 ChainOperationParams::ChainOperationParams():

--- a/libethcore/ChainOperationParams.h
+++ b/libethcore/ChainOperationParams.h
@@ -20,22 +20,7 @@ struct EVMSchedule;
 class PrecompiledContract
 {
 public:
-    PrecompiledContract() = default;
-    PrecompiledContract(
-        PrecompiledPricer const& _cost,
-        PrecompiledExecutor const& _exec,
-        u256 const& _startingBlock = 0
-    ):
-        m_cost(_cost),
-        m_execute(_exec),
-        m_startingBlock(_startingBlock)
-    {}
-    PrecompiledContract(
-        unsigned _base,
-        unsigned _word,
-        PrecompiledExecutor const& _exec,
-        u256 const& _startingBlock = 0
-    );
+    PrecompiledContract(std::string const& _name, u256 const& _startingBlock = 0);
 
     bigint cost(
         bytesConstRef _in, ChainOperationParams const& _chainParams, u256 const& _blockNumber) const

--- a/libethcore/Precompiled.cpp
+++ b/libethcore/Precompiled.cpp
@@ -34,6 +34,19 @@ PrecompiledPricer const& PrecompiledRegistrar::pricer(std::string const& _name)
 
 namespace
 {
+bigint linearPricer(unsigned _base, unsigned _word, bytesConstRef _in)
+{
+    bigint const s = _in.size();
+    bigint const b = _base;
+    bigint const w = _word;
+    return b + (s + 31) / 32 * w;
+}
+
+ETH_REGISTER_PRECOMPILED_PRICER(ecrecover)
+(bytesConstRef /*_in*/, ChainOperationParams const& /*_chainParams*/, u256 const& /*_blockNumber*/)
+{
+    return 3000;
+}
 
 ETH_REGISTER_PRECOMPILED(ecrecover)(bytesConstRef _in)
 {
@@ -69,14 +82,32 @@ ETH_REGISTER_PRECOMPILED(ecrecover)(bytesConstRef _in)
     return {true, {}};
 }
 
+ETH_REGISTER_PRECOMPILED_PRICER(sha256)
+(bytesConstRef _in, ChainOperationParams const& /*_chainParams*/, u256 const& /*_blockNumber*/)
+{
+    return linearPricer(60, 12, _in);
+}
+
 ETH_REGISTER_PRECOMPILED(sha256)(bytesConstRef _in)
 {
     return {true, dev::sha256(_in).asBytes()};
 }
 
+ETH_REGISTER_PRECOMPILED_PRICER(ripemd160)
+(bytesConstRef _in, ChainOperationParams const& /*_chainParams*/, u256 const& /*_blockNumber*/)
+{
+    return linearPricer(600, 120, _in);
+}
+
 ETH_REGISTER_PRECOMPILED(ripemd160)(bytesConstRef _in)
 {
     return {true, h256(dev::ripemd160(_in), h256::AlignRight).asBytes()};
+}
+
+ETH_REGISTER_PRECOMPILED_PRICER(identity)
+(bytesConstRef _in, ChainOperationParams const& /*_chainParams*/, u256 const& /*_blockNumber*/)
+{
+    return linearPricer(15, 3, _in);
 }
 
 ETH_REGISTER_PRECOMPILED(identity)(bytesConstRef _in)

--- a/libethereum/Account.cpp
+++ b/libethereum/Account.cpp
@@ -9,7 +9,6 @@
 #include <libdevcore/JsonUtils.h>
 #include <libdevcore/OverlayDB.h>
 #include <libethcore/ChainOperationParams.h>
-#include <libethcore/Precompiled.h>
 
 using namespace std;
 using namespace dev;
@@ -55,53 +54,9 @@ u256 Account::originalStorageValue(u256 const& _key, OverlayDB const& _db) const
 
 namespace js = json_spirit;
 
-namespace
-{
-
-uint64_t toUnsigned(js::mValue const& _v)
-{
-    switch (_v.type())
-    {
-    case js::int_type: return _v.get_uint64();
-    case js::str_type: return fromBigEndian<uint64_t>(fromHex(_v.get_str()));
-    default: return 0;
-    }
-}
-
-PrecompiledContract createPrecompiledContract(js::mObject const& _precompiled)
-{
-    auto n = _precompiled.at("name").get_str();
-    try
-    {
-        u256 startingBlock = 0;
-        if (_precompiled.count("startingBlock"))
-            startingBlock = u256(_precompiled.at("startingBlock").get_str());
-
-        if (!_precompiled.count("linear"))
-            return PrecompiledContract(PrecompiledRegistrar::pricer(n), PrecompiledRegistrar::executor(n), startingBlock);
-
-        auto const& l = _precompiled.at("linear").get_obj();
-        unsigned base = toUnsigned(l.at("base"));
-        unsigned word = toUnsigned(l.at("word"));
-        return PrecompiledContract(base, word, PrecompiledRegistrar::executor(n), startingBlock);
-    }
-    catch (PricerNotFound const&)
-    {
-        cwarn << "Couldn't create a precompiled contract account. Missing a pricer called:" << n;
-        throw;
-    }
-    catch (ExecutorNotFound const&)
-    {
-        // Oh dear - missing a plugin?
-        cwarn << "Couldn't create a precompiled contract account. Missing an executor called:" << n;
-        throw;
-    }
-}
-}
-
 // TODO move AccountMaskObj to libtesteth (it is used only in test logic)
 AccountMap dev::eth::jsonToAccountMap(std::string const& _json, u256 const& _defaultNonce,
-    AccountMaskMap* o_mask, PrecompiledContractMap* o_precompiled, const fs::path& _configPath)
+    AccountMaskMap* o_mask, const fs::path& _configPath)
 {
     auto u256Safe = [](std::string const& s) -> u256 {
         bigint ret(s);
@@ -192,12 +147,6 @@ AccountMap dev::eth::jsonToAccountMap(std::string const& _json, u256 const& _def
             if (!haveStorage && !haveCode && !haveNonce && !haveBalance &&
                 shouldNotExists)  // defined only shouldNotExists field
                 ret[a] = Account(0, 0);
-        }
-
-        if (o_precompiled && accountMaskJson.count(c_precompiled))
-        {
-            js::mObject p = accountMaskJson.at(c_precompiled).get_obj();
-            o_precompiled->insert(make_pair(a, createPrecompiledContract(p)));
         }
     }
 

--- a/libethereum/Account.h
+++ b/libethereum/Account.h
@@ -270,11 +270,7 @@ private:
 using AccountMap = std::unordered_map<Address, Account>;
 using AccountMaskMap = std::unordered_map<Address, AccountMask>;
 
-class PrecompiledContract;
-using PrecompiledContractMap = std::unordered_map<Address, PrecompiledContract>;
-
 AccountMap jsonToAccountMap(std::string const& _json, u256 const& _defaultNonce = 0,
-	AccountMaskMap* o_mask = nullptr, PrecompiledContractMap* o_precompiled = nullptr,
-	const boost::filesystem::path& _configPath = {});
+    AccountMaskMap* o_mask = nullptr, const boost::filesystem::path& _configPath = {});
 }
 }

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -147,8 +147,31 @@ void ChainParams::loadConfig(
     // genesis state
     string genesisStateStr = js::write_string(obj[c_accounts], false);
 
-    genesisState =
-        jsonToAccountMap(genesisStateStr, accountStartNonce, nullptr, &precompiled, _configPath);
+    genesisState = jsonToAccountMap(genesisStateStr, accountStartNonce, nullptr, _configPath);
+
+    precompiled.insert(
+        {Address{0x1}, PrecompiledContract{3000, 0, PrecompiledRegistrar::executor("ecrecover")}});
+    precompiled.insert(
+        {Address{0x2}, PrecompiledContract{60, 12, PrecompiledRegistrar::executor("sha256")}});
+    precompiled.insert(
+        {Address{0x3}, PrecompiledContract{600, 120, PrecompiledRegistrar::executor("ripemd160")}});
+    precompiled.insert(
+        {Address{0x4}, PrecompiledContract{15, 3, PrecompiledRegistrar::executor("identity")}});
+    precompiled.insert(
+        {Address{0x5}, PrecompiledContract{PrecompiledRegistrar::pricer("modexp"),
+                           PrecompiledRegistrar::executor("modexp"), byzantiumForkBlock}});
+    precompiled.insert({Address{0x6},
+        PrecompiledContract{PrecompiledRegistrar::pricer("alt_bn128_G1_add"),
+            PrecompiledRegistrar::executor("alt_bn128_G1_add"), byzantiumForkBlock}});
+    precompiled.insert({Address{0x7},
+        PrecompiledContract{PrecompiledRegistrar::pricer("alt_bn128_G1_mul"),
+            PrecompiledRegistrar::executor("alt_bn128_G1_mul"), byzantiumForkBlock}});
+    precompiled.insert({Address{0x8},
+        PrecompiledContract{PrecompiledRegistrar::pricer("alt_bn128_pairing_product"),
+            PrecompiledRegistrar::executor("alt_bn128_pairing_product"), byzantiumForkBlock}});
+    precompiled.insert({Address{0x9},
+        PrecompiledContract{PrecompiledRegistrar::pricer("blake2_compression"),
+            PrecompiledRegistrar::executor("blake2_compression"), istanbulForkBlock}});
 
     stateRoot = _stateRoot ? _stateRoot : calculateStateRoot(true);
 }

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -48,10 +48,10 @@ ChainParams::ChainParams()
     for (unsigned i = 1; i <= 4; ++i)
         genesisState[Address(i)] = Account(0, 1);
     // Setup default precompiled contracts as equal to genesis of Frontier.
-    precompiled.insert(make_pair(Address(1), PrecompiledContract(3000, 0, PrecompiledRegistrar::executor("ecrecover"))));
-    precompiled.insert(make_pair(Address(2), PrecompiledContract(60, 12, PrecompiledRegistrar::executor("sha256"))));
-    precompiled.insert(make_pair(Address(3), PrecompiledContract(600, 120, PrecompiledRegistrar::executor("ripemd160"))));
-    precompiled.insert(make_pair(Address(4), PrecompiledContract(15, 3, PrecompiledRegistrar::executor("identity"))));
+    precompiled.insert(make_pair(Address(1), PrecompiledContract("ecrecover")));
+    precompiled.insert(make_pair(Address(2), PrecompiledContract("sha256")));
+    precompiled.insert(make_pair(Address(3), PrecompiledContract("ripemd160")));
+    precompiled.insert(make_pair(Address(4), PrecompiledContract("identity")));
 }
 
 ChainParams::ChainParams(
@@ -149,29 +149,17 @@ void ChainParams::loadConfig(
 
     genesisState = jsonToAccountMap(genesisStateStr, accountStartNonce, nullptr, _configPath);
 
+    precompiled.insert({Address{0x1}, PrecompiledContract{"ecrecover"}});
+    precompiled.insert({Address{0x2}, PrecompiledContract{"sha256"}});
+    precompiled.insert({Address{0x3}, PrecompiledContract{"ripemd160"}});
+    precompiled.insert({Address{0x4}, PrecompiledContract{"identity"}});
+    precompiled.insert({Address{0x5}, PrecompiledContract{"modexp", byzantiumForkBlock}});
+    precompiled.insert({Address{0x6}, PrecompiledContract{"alt_bn128_G1_add", byzantiumForkBlock}});
+    precompiled.insert({Address{0x7}, PrecompiledContract{"alt_bn128_G1_mul", byzantiumForkBlock}});
     precompiled.insert(
-        {Address{0x1}, PrecompiledContract{3000, 0, PrecompiledRegistrar::executor("ecrecover")}});
+        {Address{0x8}, PrecompiledContract{"alt_bn128_pairing_product", byzantiumForkBlock}});
     precompiled.insert(
-        {Address{0x2}, PrecompiledContract{60, 12, PrecompiledRegistrar::executor("sha256")}});
-    precompiled.insert(
-        {Address{0x3}, PrecompiledContract{600, 120, PrecompiledRegistrar::executor("ripemd160")}});
-    precompiled.insert(
-        {Address{0x4}, PrecompiledContract{15, 3, PrecompiledRegistrar::executor("identity")}});
-    precompiled.insert(
-        {Address{0x5}, PrecompiledContract{PrecompiledRegistrar::pricer("modexp"),
-                           PrecompiledRegistrar::executor("modexp"), byzantiumForkBlock}});
-    precompiled.insert({Address{0x6},
-        PrecompiledContract{PrecompiledRegistrar::pricer("alt_bn128_G1_add"),
-            PrecompiledRegistrar::executor("alt_bn128_G1_add"), byzantiumForkBlock}});
-    precompiled.insert({Address{0x7},
-        PrecompiledContract{PrecompiledRegistrar::pricer("alt_bn128_G1_mul"),
-            PrecompiledRegistrar::executor("alt_bn128_G1_mul"), byzantiumForkBlock}});
-    precompiled.insert({Address{0x8},
-        PrecompiledContract{PrecompiledRegistrar::pricer("alt_bn128_pairing_product"),
-            PrecompiledRegistrar::executor("alt_bn128_pairing_product"), byzantiumForkBlock}});
-    precompiled.insert({Address{0x9},
-        PrecompiledContract{PrecompiledRegistrar::pricer("blake2_compression"),
-            PrecompiledRegistrar::executor("blake2_compression"), istanbulForkBlock}});
+        {Address{0x9}, PrecompiledContract{"blake2_compression", istanbulForkBlock}});
 
     stateRoot = _stateRoot ? _stateRoot : calculateStateRoot(true);
 }

--- a/libethereum/GenesisInfo.cpp
+++ b/libethereum/GenesisInfo.cpp
@@ -36,10 +36,6 @@ R"E(
 		"gasLimit": "0x2fefd8"
 	},
 	"accounts": {
-		"0000000000000000000000000000000000000001": { "wei": "1", "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-		"0000000000000000000000000000000000000002": { "wei": "1", "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-		"0000000000000000000000000000000000000003": { "wei": "1", "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-		"0000000000000000000000000000000000000004": { "wei": "1", "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
 		"00c9b024c2efc853ecabb8be2fb1d16ce8174ab1": { "wei": "1606938044258990275541962092341162602522202993782792835301376" }
 	}
 }

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -68,14 +68,6 @@ static std::string const c_configString = R"(
         "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "wei": "1", "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "wei": "1", "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "wei": "1", "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "wei": "1", "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
-        "0000000000000000000000000000000000000005": { "wei": "1", "precompiled": { "name": "modexp" } },
-        "0000000000000000000000000000000000000006": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_add", "linear": { "base": 500, "word": 0 } } },
-        "0000000000000000000000000000000000000007": { "wei": "1", "precompiled": { "name": "alt_bn128_G1_mul", "linear": { "base": 40000, "word": 0 } } },
-        "0000000000000000000000000000000000000008": { "wei": "1", "precompiled": { "name": "alt_bn128_pairing_product" } }
     }
 }
 )";

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(ClientTest_setChainParamsAuthor)
     BOOST_CHECK_EQUAL(testClient->author(), Address("0000000000000010000000000000000000000000"));
 }
 
-BOOST_AUTO_TEST_CASE(ClientTest_setChainParamsCustomPrecompiles)
+BOOST_AUTO_TEST_CASE(ClientTest_setChainParamsPrecompilesAreIgnored)
 {
     ClientTest* testClient = asClientTest(getWeb3()->ethereum());
     testClient->setChainParams(c_configString);
@@ -132,8 +132,8 @@ BOOST_AUTO_TEST_CASE(ClientTest_setChainParamsCustomPrecompiles)
     testClient->setChainParams(configWithCustomPrecompiles);
 
     BOOST_CHECK_EQUAL(
-        testClient->chainParams().precompiled.at(ecrecoverAddress).startingBlock(), 0x28d138);
-    BOOST_CHECK(!contains(testClient->chainParams().precompiled, sha256Address));
+        testClient->chainParams().precompiled.at(ecrecoverAddress).startingBlock(), 0);
+    BOOST_CHECK(contains(testClient->chainParams().precompiled, sha256Address));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -54,10 +54,6 @@ static std::string const c_genesisConfigString = R"(
         "mixHash" : "0x00"
     },
     "accounts": {
-        "0000000000000000000000000000000000000001": { "precompiled": { "name": "ecrecover", "linear": { "base": 3000, "word": 0 } } },
-        "0000000000000000000000000000000000000002": { "precompiled": { "name": "sha256", "linear": { "base": 60, "word": 12 } } },
-        "0000000000000000000000000000000000000003": { "precompiled": { "name": "ripemd160", "linear": { "base": 600, "word": 120 } } },
-        "0000000000000000000000000000000000000004": { "precompiled": { "name": "identity", "linear": { "base": 15, "word": 3 } } },
         "0x095e7baea6a6c7c4c2dfeb977efac326af552d87" : {
             "balance" : "0x0de0b6b3a7640000",
             "code" : "0x6001600101600055",


### PR DESCRIPTION
Closes https://github.com/ethereum/aleth/issues/5825

1. Instead of filling `ChainOperationParams::precompiled` from config JSON, fill it with hard-coded list of 9 currently existing precompiles.
2. `PrecompiledContract` constructor changed to take precompile name string and starting block.
3. Price functions for linear cost precompiles created, to keep all pricers consistently in one place (instead of keeping price constants somewhere else, as before)
4. I've decided to consider `"precompile"` records in configs deprecated for now, so they will not generate validation error, but be ignored.

We could also get rid of `PrecompiledRegistrar` at some point, I think it's a useless complication.

cc @winsvega 