### PR TITLE
Revert "wait for 2 seconds on disconnect" changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.7.2] - Unreleased
 
 - Fixed: [#5834](https://github.com/ethereum/aleth/pull/5834) Fix segmentation fault during sync.
+- Fixed: [#5841](https://github.com/ethereum/aleth/pull/5841) Revert the change introduced in 1.7.0 to wait 2 secods after sending `Disconnect` to peer before closing the socket, as it caused instabilty during sync.
 
 ## [1.7.1] - 2019-11-18
 
@@ -27,6 +28,7 @@
 - Added: [#5700](https://github.com/ethereum/aleth/pull/5700) [#5725](https://github.com/ethereum/aleth/pull/5725) Istanbul support: EIP 1884 Repricing for trie-size-dependent opcodes.
 - Added: [#5701](https://github.com/ethereum/aleth/issues/5701) Outputs ENR text representation in admin.nodeInfo RPC.
 - Added: [#5705](https://github.com/ethereum/aleth/pull/5705) Istanbul support: EIP 1108 Reduce alt_bn128 precompile gas costs.
+- Added: [#5707](https://github.com/ethereum/aleth/pull/5707) Aleth waits for 2 seconds after sending disconnect to peer before closing socket.
 - Added: [#5709](https://github.com/ethereum/aleth/pull/5709) [#5728](https://github.com/ethereum/aleth/pull/5728) Istanbul support: EIP-2200 Structured Definitions for Net Gas Metering.
 - Added: [#5751](https://github.com/ethereum/aleth/pull/5751) Istanbul support: EIP-152 Add BLAKE2 compression function `F` precompile.
 - Added: [#5755](https://github.com/ethereum/aleth/pull/5755) testeth now runs `stChainId`, `stSLoadTest`, `stSelfBalance` tests for Istanbul.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 - Added: [#5700](https://github.com/ethereum/aleth/pull/5700) [#5725](https://github.com/ethereum/aleth/pull/5725) Istanbul support: EIP 1884 Repricing for trie-size-dependent opcodes.
 - Added: [#5701](https://github.com/ethereum/aleth/issues/5701) Outputs ENR text representation in admin.nodeInfo RPC.
 - Added: [#5705](https://github.com/ethereum/aleth/pull/5705) Istanbul support: EIP 1108 Reduce alt_bn128 precompile gas costs.
-- Added: [#5707](https://github.com/ethereum/aleth/pull/5707) Aleth waits for 2 seconds after sending disconnect to peer before closing socket.
 - Added: [#5709](https://github.com/ethereum/aleth/pull/5709) [#5728](https://github.com/ethereum/aleth/pull/5728) Istanbul support: EIP-2200 Structured Definitions for Net Gas Metering.
 - Added: [#5751](https://github.com/ethereum/aleth/pull/5751) Istanbul support: EIP-152 Add BLAKE2 compression function `F` precompile.
 - Added: [#5755](https://github.com/ethereum/aleth/pull/5755) testeth now runs `stChainId`, `stSLoadTest`, `stSelfBalance` tests for Istanbul.

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -1200,11 +1200,11 @@ void Host::forEachPeer(
             return;
 }
 
-std::unique_ptr<ba::steady_timer> Host::createTimer(std::chrono::seconds const& _expiryDelay,
+std::unique_ptr<ba::steady_timer> Host::createTimer(std::chrono::seconds const& _expiryTime,
     std::function<void(const boost::system::error_code& error)>&& _f)
 {
     std::unique_ptr<ba::steady_timer> timer{new ba::steady_timer{m_ioContext}};
-    timer->expires_after(_expiryDelay);
+    timer->expires_after(_expiryTime);
     timer->async_wait(_f);
     return timer;
 }

--- a/libp2p/Host.cpp
+++ b/libp2p/Host.cpp
@@ -1200,11 +1200,3 @@ void Host::forEachPeer(
             return;
 }
 
-std::unique_ptr<ba::steady_timer> Host::createTimer(std::chrono::seconds const& _expiryTime,
-    std::function<void(const boost::system::error_code& error)>&& _f)
-{
-    std::unique_ptr<ba::steady_timer> timer{new ba::steady_timer{m_ioContext}};
-    timer->expires_after(_expiryTime);
-    timer->async_wait(_f);
-    return timer;
-}

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -266,10 +266,10 @@ public:
 
     std::shared_ptr<CapabilityHostFace> capabilityHost() const { return m_capabilityHost; }
 
-    /// Execute work on the network thread after @a _expiryTime delay.
-    /// Returned timer should be kept alive until delay is over.
-    std::unique_ptr<ba::steady_timer> createTimer(std::chrono::seconds const& _expiryTime,
-        std::function<void(const boost::system::error_code& error)>&& _f);
+    std::shared_ptr<ba::steady_timer> createTimer()
+    {
+        return std::make_shared<ba::steady_timer>(m_ioContext);
+    }
 
 protected:
     /*

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -266,9 +266,9 @@ public:
 
     std::shared_ptr<CapabilityHostFace> capabilityHost() const { return m_capabilityHost; }
 
-    /// Execute work on the network thread after an @a _expiryDelay delay.
+    /// Execute work on the network thread after @a _expiryTime delay.
     /// Returned timer should be kept alive until delay is over.
-    std::unique_ptr<ba::steady_timer> createTimer(std::chrono::seconds const& _expiryDelay,
+    std::unique_ptr<ba::steady_timer> createTimer(std::chrono::seconds const& _expiryTime,
         std::function<void(const boost::system::error_code& error)>&& _f);
 
 protected:

--- a/libp2p/Host.h
+++ b/libp2p/Host.h
@@ -266,11 +266,6 @@ public:
 
     std::shared_ptr<CapabilityHostFace> capabilityHost() const { return m_capabilityHost; }
 
-    std::shared_ptr<ba::steady_timer> createTimer()
-    {
-        return std::make_shared<ba::steady_timer>(m_ioContext);
-    }
-
 protected:
     /*
      * Used by the host to run a capability's background work loop

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -206,9 +206,6 @@ bool Session::checkPacket(bytesConstRef _msg)
 
 void Session::send(bytes&& _msg)
 {
-    if (m_dropped)
-        return;
-
     bytesConstRef msg(&_msg);
     LOG(m_netLoggerDetail) << capabilityPacketTypeToString(_msg[0]) << " to";
     if (!checkPacket(msg))
@@ -279,6 +276,16 @@ void Session::drop(DisconnectReason _reason)
 {
     if (m_dropped)
         return;
+    bi::tcp::socket& socket = m_socket->ref();
+    if (socket.is_open())
+        try
+        {
+            boost::system::error_code ec;
+            LOG(m_netLoggerDetail) << "Closing (" << reasonOf(_reason) << ") connection with";
+            socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+            socket.close();
+        }
+        catch (...) {}
 
     m_peer->m_lastDisconnect = _reason;
     if (_reason == BadProtocol)
@@ -293,32 +300,13 @@ void Session::disconnect(DisconnectReason _reason)
 {
     clog(VerbosityTrace, "p2pcap") << "Disconnecting (our reason: " << reasonOf(_reason) << ") from " << m_logSuffix;
 
-    if (!m_dropped)
+    if (m_socket->ref().is_open())
     {
         RLPStream s;
         prep(s, DisconnectPacket, 1) << (int)_reason;
         sealAndSend(s);
-        auto disconnectTimer = m_server->createTimer();
-        auto self(shared_from_this());
-        disconnectTimer->expires_after(std::chrono::seconds(2));
-        disconnectTimer->async_wait([self, this, _reason](boost::system::error_code) {
-            bi::tcp::socket& socket = m_socket->ref();
-            if (socket.is_open())
-            try
-            {
-                boost::system::error_code ec;
-                LOG(m_netLoggerDetail)
-                    << "Closing (" << reasonOf(_reason) << ") connection with";
-                socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-                socket.close();
-            }
-            catch (...)
-            {
-            }
-        });
     }
-    else
-        drop(_reason);
+    drop(_reason);
 }
 
 void Session::start()

--- a/libp2p/Session.cpp
+++ b/libp2p/Session.cpp
@@ -299,24 +299,23 @@ void Session::disconnect(DisconnectReason _reason)
     RLPStream s;
     prep(s, DisconnectPacket, 1) << (int)_reason;
     sealAndSend(s);
-
+    auto disconnectTimer = m_server->createTimer();
     auto self(shared_from_this());
-    m_disconnectTimer = m_server->createTimer(
-        std::chrono::seconds(2), [self, this, _reason](boost::system::error_code) {
-            bi::tcp::socket& socket = m_socket->ref();
-            if (socket.is_open())
-                try
-                {
-                    boost::system::error_code ec;
-                    LOG(m_netLoggerDetail)
-                        << "Closing (" << reasonOf(_reason) << ") connection with";
-                    socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-                    socket.close();
-                }
-                catch (...)
-                {
-                }
-        });
+    disconnectTimer->expires_after(std::chrono::seconds(2));
+    disconnectTimer->async_wait([self, this, _reason](boost::system::error_code) {
+        bi::tcp::socket& socket = m_socket->ref();
+        if (socket.is_open())
+            try
+            {
+                boost::system::error_code ec;
+                LOG(m_netLoggerDetail) << "Closing (" << reasonOf(_reason) << ") connection with";
+                socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+                socket.close();
+            }
+            catch (...)
+            {
+            }
+    });
 
     drop(_reason);
 }

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -177,8 +177,6 @@ private:
 
     std::set<std::string> m_disabledCapabilities;
 
-    std::unique_ptr<ba::steady_timer> m_disconnectTimer;
-
     std::string m_logSuffix;
 
     Logger m_netLogger{createLogger(VerbosityDebug, "net")};

--- a/libp2p/Session.h
+++ b/libp2p/Session.h
@@ -84,7 +84,7 @@ public:
 
     void ping() override;
 
-    bool isConnected() const override { return !m_dropped; }
+    bool isConnected() const override { return m_socket->ref().is_open(); }
 
     NodeID id() const override;
 


### PR DESCRIPTION
Changes were causing frequent exceptions during syncing (see #5835, #5828) due to `Host::m_session`s and `EthereumPeer::m_peers` getting out-of-sync (if a peer reconnects during a pending disconnect), so we are reverting the changes in the 1.7 release until we can properly address the sync issues. 