### PR TITLE
docker: Add all tools to aleth docker image

### DIFF
--- a/scripts/docker/aleth.dockerfile
+++ b/scripts/docker/aleth.dockerfile
@@ -35,7 +35,7 @@ ENTRYPOINT ["/usr/bin/testeth"]
 FROM alpine:latest AS aleth
 RUN apk add --no-cache python3 libstdc++
 RUN adduser -D aleth
-COPY --from=builder /usr/bin/aleth /source/scripts/aleth.py /source/scripts/dopple.py /usr/bin/
+COPY --from=builder /usr/bin/aleth* /source/scripts/aleth.py /source/scripts/dopple.py /usr/bin/
 COPY --from=builder /usr/share/aleth/ /usr/share/aleth/
 USER aleth
 EXPOSE 8545


### PR DESCRIPTION
This will additionally add: aleth-bootnode, aleth-key and aleth-vm. The aleth-key is probably useless but for simplicity it may stay.

The default entry point is still aleth.py, but you can use other tools as

```
docker run -it --rm --entrypoint /usr/bin/aleth-vm ethereum/aleth --version
aleth-vm 1.8.0-alpha.1-12+commit.43780e1c.dirty
Build: linux/release
```

Closes #5842.