### PR TITLE
Make accounts section optional in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Changed: [#5837](https://github.com/ethereum/aleth/pull/5837) [#5839](https://github.com/ethereum/aleth/pull/5839) [#5845](https://github.com/ethereum/aleth/pull/5845) [#5846](https://github.com/ethereum/aleth/pull/5846) Output format of `testeth --jsontrace` command changed to better match output of geth's evm tool and to integrate with evmlab project.
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
 - Removed: [#5840](https://github.com/ethereum/aleth/pull/5840) The list of precompiled contracts is not required in config files anymore.
+- Removed: [#5850](https://github.com/ethereum/aleth/pull/5850) accounts section is now optional in config files.
 - Fixed: [#5792](https://github.com/ethereum/aleth/pull/5792) Faster and cheaper execution of RPC functions which query blockchain state (e.g. getBalance).
 - Fixed: [#5811](https://github.com/ethereum/aleth/pull/5811) RPC methods querying transactions (`eth_getTransactionByHash`, `eth_getBlockByNumber`) return correct `v` value.
 - Fixed: [#5821](https://github.com/ethereum/aleth/pull/5821) `test_setChainParams` correctly initializes custom configuration of precompiled contracts.

--- a/libethereum/ChainParams.cpp
+++ b/libethereum/ChainParams.cpp
@@ -145,9 +145,11 @@ void ChainParams::loadConfig(
     string genesisStr = js::write_string(obj[c_genesis], false);
     loadGenesis(genesisStr, _stateRoot);
     // genesis state
-    string genesisStateStr = js::write_string(obj[c_accounts], false);
-
-    genesisState = jsonToAccountMap(genesisStateStr, accountStartNonce, nullptr, _configPath);
+    if (contains(obj, c_accounts))
+    {
+        string genesisStateStr = js::write_string(obj[c_accounts], false);
+        genesisState = jsonToAccountMap(genesisStateStr, accountStartNonce, nullptr, _configPath);
+    }
 
     precompiled.insert({Address{0x1}, PrecompiledContract{"ecrecover"}});
     precompiled.insert({Address{0x2}, PrecompiledContract{"sha256"}});

--- a/libethereum/ValidationSchemes.cpp
+++ b/libethereum/ValidationSchemes.cpp
@@ -69,7 +69,7 @@ void validateConfigJson(js::mObject const& _obj)
         {{c_sealEngine, {{js::str_type}, JsonFieldPresence::Required}},
             {c_params, {{js::obj_type}, JsonFieldPresence::Required}},
             {c_genesis, {{js::obj_type}, JsonFieldPresence::Required}},
-            {c_accounts, {{js::obj_type}, JsonFieldPresence::Required}}});
+            {c_accounts, {{js::obj_type}, JsonFieldPresence::Optional}}});
 
     requireJsonFields(_obj.at(c_genesis).get_obj(), "ChainParams::loadConfig::genesis",
         {{c_author, {{js::str_type}, JsonFieldPresence::Required}},
@@ -81,9 +81,12 @@ void validateConfigJson(js::mObject const& _obj)
             {c_mixHash, {{js::str_type}, JsonFieldPresence::Required}},
             {c_parentHash, {{js::str_type}, JsonFieldPresence::Optional}}});
 
-    js::mObject const& accounts = _obj.at(c_accounts).get_obj();
-    for (auto const& acc : accounts)
-        validateAccountObj(acc.second.get_obj());
+    if (_obj.count(c_accounts) != 0)
+    {
+        js::mObject const& accounts = _obj.at(c_accounts).get_obj();
+        for (auto const& acc : accounts)
+            validateAccountObj(acc.second.get_obj());
+    }
 }
 
 void validateAccountMaskObj(js::mObject const& _obj)

--- a/test/unittests/libethereum/ClientTest.cpp
+++ b/test/unittests/libethereum/ClientTest.cpp
@@ -66,8 +66,6 @@ static std::string const c_configString = R"(
         "gasLimit": "0x1000000000000",
         "difficulty": "0x020000",
         "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-    },
-    "accounts": {
     }
 }
 )";


### PR DESCRIPTION
Follow-up to https://github.com/ethereum/aleth/pull/5840

Now it's not required to include `accounts` in config at all.