### PR TITLE
Output original opcode instead of PUSHC/JUMPC/JUMPCI in VM trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixed: [#5821](https://github.com/ethereum/aleth/pull/5821) `test_setChainParams` correctly initializes custom configuration of precompiled contracts.
 - Fixed: [#5826](https://github.com/ethereum/aleth/pull/5826) Fix blocking bug in database rebuild functionality - users can now rebuild their databases via Aleth's '-R' switch.
 - Fixed: [#5827](https://github.com/ethereum/aleth/pull/5827) Detect database upgrades and automatically rebuild the database when they occur.
-- Fixed: [#5834](https://github.com/ethereum/aleth/pull/5834) Fix segmentation fault during sync.
+- Fixed: [#5852](https://github.com/ethereum/aleth/pull/5852) Output correct original opcodes instead of synthetic `PUSHC`/`JUMPC`/`JUMPCI` in VM trace.
 
 ## [1.7.2] - 2019-11-22
 

--- a/libevm/LegacyVM.h
+++ b/libevm/LegacyVM.h
@@ -117,7 +117,8 @@ private:
     std::vector<uint64_t> m_jumpDests;
     int64_t verifyJumpDest(u256 const& _dest, bool _throw = true);
 
-    void onOperation();
+    void onOperation() { onOperation(m_OP); }
+    void onOperation(Instruction _instr);
     void adjustStack(unsigned _removed, unsigned _added);
     uint64_t gasForMem(u512 const& _size);
     void updateSSGas();


### PR DESCRIPTION
Fixes https://github.com/ethereum/aleth/issues/5847

cc @holiman 