### PR TITLE
Allow submitting several transaction from the same sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed: [#5806](https://github.com/ethereum/aleth/pull/5806) Optimize selfdestruct opcode in aleth-interpreter by reducing state accesses in certain out-of-gas scenarios.
 - Changed: [#5837](https://github.com/ethereum/aleth/pull/5837) [#5839](https://github.com/ethereum/aleth/pull/5839) [#5845](https://github.com/ethereum/aleth/pull/5845) [#5846](https://github.com/ethereum/aleth/pull/5846) Output format of `testeth --jsontrace` command changed to better match output of geth's evm tool and to integrate with evmlab project.
 - Changed: [#5848](https://github.com/ethereum/aleth/pull/5848) `aleth-vm --codefile <PATH>` now reads bytecode file from path and `aleth-vm --codefile - <bytecode>` now reads bytecode from standard input.
+- Changed: [#5864](https://github.com/ethereum/aleth/pull/5864) Allow a user to send multiple transactions before a new block is mined.
 - Removed: [#5760](https://github.com/ethereum/aleth/pull/5760) Official support for Visual Studio 2015 has been dropped. Compilation with this compiler is expected to stop working after migration to C++14.
 - Removed: [#5840](https://github.com/ethereum/aleth/pull/5840) The list of precompiled contracts is not required in config files anymore.
 - Removed: [#5850](https://github.com/ethereum/aleth/pull/5850) accounts section is now optional in config files.

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -109,11 +109,10 @@ void Executive::initialize(Transaction const& _transaction)
             m_excepted = TransactionException::InvalidSignature;
             throw;
         }
-        if (m_t.nonce() < nonceReq)
+        if (m_t.nonce() != nonceReq)
         {
-            LOG(m_execLogger) << "Sender: " << m_t.sender().hex()
-                              << " Invalid Nonce: Required nonce >= " << nonceReq << ", received "
-                              << m_t.nonce();
+            LOG(m_execLogger) << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Required "
+                              << nonceReq << ", received " << m_t.nonce();
             m_excepted = TransactionException::InvalidNonce;
             BOOST_THROW_EXCEPTION(
                 InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));

--- a/libethereum/Executive.cpp
+++ b/libethereum/Executive.cpp
@@ -109,12 +109,14 @@ void Executive::initialize(Transaction const& _transaction)
             m_excepted = TransactionException::InvalidSignature;
             throw;
         }
-        if (m_t.nonce() != nonceReq)
+        if (m_t.nonce() < nonceReq)
         {
-            LOG(m_execLogger) << "Sender: " << m_t.sender().hex() << " Invalid Nonce: Require "
-                              << nonceReq << " Got " << m_t.nonce();
+            LOG(m_execLogger) << "Sender: " << m_t.sender().hex()
+                              << " Invalid Nonce: Required nonce >= " << nonceReq << ", received "
+                              << m_t.nonce();
             m_excepted = TransactionException::InvalidNonce;
-            BOOST_THROW_EXCEPTION(InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));
+            BOOST_THROW_EXCEPTION(
+                InvalidNonce() << RequirementError((bigint)nonceReq, (bigint)m_t.nonce()));
         }
 
         // Avoid unaffordable transactions.

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -263,6 +263,7 @@ BOOST_AUTO_TEST_CASE(eth_sendTransaction)
     auto address = coinbase.address();
     auto countAt = jsToU256(rpcClient->eth_getTransactionCount(toJS(address), "latest"));
 
+    // Verify initial account state
     BOOST_CHECK_EQUAL(countAt, web3->ethereum()->countAt(address));
     BOOST_CHECK_EQUAL(countAt, 0);
     auto balance = web3->ethereum()->balanceAt(address, 0);
@@ -309,6 +310,65 @@ BOOST_AUTO_TEST_CASE(eth_sendTransaction)
     BOOST_CHECK_EQUAL(jsToU256(balanceString2), txAmount);
     BOOST_CHECK_EQUAL(txAmount, balance2);
 }
+
+BOOST_AUTO_TEST_CASE(eth_sendMultipleTransactions)
+{
+    // Send multiple transactions from the same account before mining a block, should succeed
+    auto const senderAddress = coinbase.address();
+    auto countAt = jsToU256(rpcClient->eth_getTransactionCount(toJS(senderAddress), "latest"));
+
+    // Verify initial account state
+    BOOST_CHECK_EQUAL(countAt, web3->ethereum()->countAt(senderAddress));
+    BOOST_CHECK_EQUAL(countAt, 0);
+    auto senderBalance = web3->ethereum()->balanceAt(senderAddress, 0);
+    string senderBalanceString = rpcClient->eth_getBalance(toJS(senderAddress), "latest");
+    BOOST_CHECK_EQUAL(toJS(senderBalance), senderBalanceString);
+    BOOST_CHECK_EQUAL(jsToDecimal(senderBalanceString), "0");
+
+    // Mine a block and verify balance changes
+    dev::eth::mine(*(web3->ethereum()), 1);
+    BOOST_CHECK_EQUAL(web3->ethereum()->blockByNumber(LatestBlock).author(), senderAddress);
+    senderBalance = web3->ethereum()->balanceAt(senderAddress, LatestBlock);
+    senderBalanceString = rpcClient->eth_getBalance(toJS(senderAddress), "latest");
+
+    BOOST_REQUIRE_GT(senderBalance, 0);
+    BOOST_CHECK_EQUAL(toJS(senderBalance), senderBalanceString);
+
+    // Create and send a tx
+    auto const txAmount = senderBalance / 3u;
+    auto const gasPrice = 10 * dev::eth::szabo;
+    auto const gas = EVMSchedule().txGas;
+    auto const receiver = KeyPair::create();
+
+    Json::Value t;
+    t["from"] = toJS(senderAddress);
+    t["value"] = jsToDecimal(toJS(txAmount));
+    t["to"] = toJS(receiver.address());
+    t["data"] = toJS(bytes());
+    t["gas"] = toJS(gas);
+    t["gasPrice"] = toJS(gasPrice);
+
+    std::string txHash = rpcClient->eth_sendTransaction(t);
+    BOOST_REQUIRE(!txHash.empty());
+
+    // Send the tx again
+    txHash = rpcClient->eth_sendTransaction(t);
+
+    accountHolder->setAccounts({});
+    dev::eth::mine(*(web3->ethereum()), 1);
+
+    countAt = jsToU256(rpcClient->eth_getTransactionCount(toJS(senderAddress), "latest"));
+    auto const receiverBalance = web3->ethereum()->balanceAt(receiver.address());
+    string const receiverBalanceString =
+        rpcClient->eth_getBalance(toJS(receiver.address()), "latest");
+
+    BOOST_CHECK_EQUAL(countAt, web3->ethereum()->countAt(senderAddress));
+    BOOST_CHECK_EQUAL(countAt, 2);
+    BOOST_CHECK_EQUAL(toJS(receiverBalance), receiverBalanceString);
+    BOOST_CHECK_EQUAL(jsToU256(receiverBalanceString), 2 * txAmount);
+    BOOST_CHECK_EQUAL(txAmount * 2, receiverBalance);
+}
+
 
 BOOST_AUTO_TEST_CASE(eth_sendRawTransaction_validTransaction)
 {


### PR DESCRIPTION
Fix #5863 

The old check was restrictive - it prohibited the same account from sending multiple transactions before a new block was mined, because the check required that the new tx nonce match the nonce retrieved from the state in the most recent block in the local chain. The new check is more flexible - it requires that new tx nonces be greater than or equal to the required nonce.

These changes also add a test which verifies the new behavior.