### PR TITLE
Make RPC output same as Geth's for 2 RPC functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed: [#5827](https://github.com/ethereum/aleth/pull/5827) Detect database upgrades and automatically rebuild the database when they occur.
 - Fixed: [#5852](https://github.com/ethereum/aleth/pull/5852) Output correct original opcodes instead of synthetic `PUSHC`/`JUMPC`/`JUMPCI` in VM trace.
 - Fixed: [#5829](https://github.com/ethereum/aleth/pull/5829) web3.eth.getBlock now returns block size in bytes. This requires a (automatic) database rebuild which can take a while depending on how many blocks are in the local chain.
+- Fixed: [#5866](https://github.com/ethereum/aleth/pull/5866) Update output of `debug_accountRangeAt` and `eth_getTransactionCount` RPC functions to conform to Geth's output.
 
 ## [1.7.2] - 2019-11-22
 

--- a/libweb3jsonrpc/Debug.cpp
+++ b/libweb3jsonrpc/Debug.cpp
@@ -163,10 +163,10 @@ Json::Value Debug::debug_accountRange(
 
         Json::Value addressList(Json::objectValue);
         for (auto const& record : addressMap.first)
-            addressList[toString(record.first)] = toString(record.second);
+            addressList[toHexPrefixed(record.first)] = toHexPrefixed(record.second);
 
         ret["addressMap"] = addressList;
-        ret["nextKey"] = toString(addressMap.second);
+        ret["nextKey"] = toHexPrefixed(addressMap.second);
     }
     catch (Exception const& _e)
     {

--- a/libweb3jsonrpc/Eth.cpp
+++ b/libweb3jsonrpc/Eth.cpp
@@ -142,14 +142,14 @@ Json::Value Eth::eth_pendingTransactions()
 
 string Eth::eth_getTransactionCount(string const& _address, string const& _blockNumber)
 {
-	try
-	{
-		return toJS(client()->countAt(jsToAddress(_address), jsToBlockNumber(_blockNumber)));
-	}
-	catch (...)
-	{
-		BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
-	}
+    try
+    {
+        return toString(client()->countAt(jsToAddress(_address), jsToBlockNumber(_blockNumber)));
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(Errors::ERROR_RPC_INVALID_PARAMS));
+    }
 }
 
 Json::Value Eth::eth_getBlockTransactionCountByHash(string const& _blockHash)

--- a/test/unittests/libweb3jsonrpc/jsonrpc.cpp
+++ b/test/unittests/libweb3jsonrpc/jsonrpc.cpp
@@ -597,7 +597,7 @@ BOOST_AUTO_TEST_CASE(debugAccountRangeFinalBlockState)
 
     dev::eth::mine(*(web3->ethereum()), 1);
 
-    string receiverHash = toString(sha3(receiver));
+    string const receiverHash = toHexPrefixed(sha3(receiver));
 
     // receiver doesn't exist in the beginning of the 2nd block
     Json::Value result = rpcClient->debug_accountRange("2", 0, "0", 100);
@@ -606,7 +606,7 @@ BOOST_AUTO_TEST_CASE(debugAccountRangeFinalBlockState)
     // receiver exists in the end of the 2nd block
     result = rpcClient->debug_accountRange("2", 1, "0", 100);
     BOOST_CHECK(result["addressMap"].isMember(receiverHash));
-    BOOST_CHECK_EQUAL(result["addressMap"][receiverHash], toString(receiver));
+    BOOST_CHECK_EQUAL(result["addressMap"][receiverHash], toHexPrefixed(receiver));
 }
 
 BOOST_AUTO_TEST_CASE(debugStorageRangeAtFinalBlockState)


### PR DESCRIPTION
Fix https://github.com/ethereum/aleth/issues/5856

Make RPC output conform to Geth's output for `debug_accountRange `and `eth_getTransactionCount`.