### PR TITLE
ClientTest::importRawBlock throws exception with a nested detailed error

### DIFF
--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -7,6 +7,7 @@
 #include "FixedHash.h"
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/exception/errinfo_api_function.hpp>
+#include <boost/exception/errinfo_nested_exception.hpp>
 #include <boost/exception/exception.hpp>
 #include <boost/exception/info.hpp>
 #include <boost/exception/info_tuple.hpp>
@@ -78,4 +79,5 @@ using errinfo_externalFunction = boost::errinfo_api_function;
 using errinfo_interface = boost::error_info<struct tag_interface, std::string>;
 using errinfo_path = boost::error_info<struct tag_path, std::string>;
 using errinfo_nodeID = boost::error_info<struct tag_nodeID, h512>;
+using errinfo_nestedException = boost::errinfo_nested_exception;
 }

--- a/libethereum/ClientTest.h
+++ b/libethereum/ClientTest.h
@@ -32,11 +32,19 @@ public:
     bool mineBlocks(unsigned _count) noexcept;
     void modifyTimestamp(int64_t _timestamp);
     void rewindToBlock(unsigned _number);
+    /// Import block data
+    /// @returns hash of the imported block
+    /// @throws ImportBlockFailed if import failed. If block is rejected by BlockQueue validation,
+    /// exception contains errinfo_importResult with the reason. If the reason is
+    /// ImportResult::Malformed, exception contains nested exception with exact validation error.
     h256 importRawBlock(std::string const& _blockRLP);
     bool completeSync();
 
 protected:
     unsigned const m_singleBlockMaxMiningTimeInSeconds = 60;
+    boost::exception_ptr m_lastImportError;
+    bytes m_lastBadBlock;
+    Mutex m_badBlockMutex;
 };
 
 ClientTest& asClientTest(Interface& _c);


### PR DESCRIPTION
This will allow for `test_importRawBlock` method to return more detailed error than just generic "malformed block" in case of invalid header. Required for retesteth to generate blockchain tests.

Somewhat hacky with some boost.exception magic, and won't work correctly if you send simultaneous `importRawBlock` requests. But it's a test method, and I wanted to minimize the changes for the normal operation mode (so avoided the changes in `BlockQueue`, `BlockChain`).