### PR TITLE
Pass options to EVMC class constructor instead of using globally set options

### DIFF
--- a/libevm/EVMC.cpp
+++ b/libevm/EVMC.cpp
@@ -32,13 +32,14 @@ evmc_revision toRevision(EVMSchedule const& _schedule) noexcept
 }
 }  // namespace
 
-EVMC::EVMC(evmc_vm* _vm) noexcept : evmc::VM(_vm)
+EVMC::EVMC(evmc_vm* _vm, std::vector<std::pair<std::string, std::string>> const& _options) noexcept
+  : evmc::VM(_vm)
 {
     assert(_vm != nullptr);
     assert(is_abi_compatible());
 
     // Set the options.
-    for (auto& pair : evmcOptions())
+    for (auto& pair : _options)
     {
         auto result = set_option(pair.first.c_str(), pair.second.c_str());
         switch (result)

--- a/libevm/EVMC.h
+++ b/libevm/EVMC.h
@@ -5,6 +5,9 @@
 #pragma once
 
 #include <libevm/VMFace.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace dev
 {
@@ -14,7 +17,7 @@ namespace eth
 class EVMC : public evmc::VM, public VMFace
 {
 public:
-    explicit EVMC(evmc_vm* _vm) noexcept;
+    EVMC(evmc_vm* _vm, std::vector<std::pair<std::string, std::string>> const& _options) noexcept;
 
     owning_bytes_ref exec(u256& io_gas, ExtVMFace& _ext, OnOpFunc const& _onOp) final;
 };

--- a/libevm/VMFactory.h
+++ b/libevm/VMFactory.h
@@ -18,9 +18,6 @@ enum class VMKind
     DLL
 };
 
-/// Returns the EVMC options parsed from command line.
-std::vector<std::pair<std::string, std::string>>& evmcOptions() noexcept;
-
 /// Provide a set of program options related to VMs.
 ///
 /// @param _lineLength  The line length for description text wrapping, the same as in

--- a/test/unittests/libevm/VMTest.cpp
+++ b/test/unittests/libevm/VMTest.cpp
@@ -208,7 +208,9 @@ public:
 class AlethInterpreterCreate2TestFixture: public Create2TestFixture
 {
 public:
-    AlethInterpreterCreate2TestFixture(): Create2TestFixture{new EVMC{evmc_create_aleth_interpreter()}} {}
+    AlethInterpreterCreate2TestFixture()
+      : Create2TestFixture{new EVMC{evmc_create_aleth_interpreter(), {}}}
+    {}
 };
 
 class ExtcodehashTestFixture : public TestOutputHelperFixture
@@ -376,7 +378,7 @@ class AlethInterpreterExtcodehashTestFixture : public ExtcodehashTestFixture
 {
 public:
     AlethInterpreterExtcodehashTestFixture()
-      : ExtcodehashTestFixture{new EVMC{evmc_create_aleth_interpreter()}}
+      : ExtcodehashTestFixture{new EVMC{evmc_create_aleth_interpreter(), {}}}
     {}
 };
 
@@ -546,7 +548,9 @@ public:
 class AlethInterpreterSstoreTestFixture : public SstoreTestFixture
 {
 public:
-    AlethInterpreterSstoreTestFixture() : SstoreTestFixture{new EVMC{evmc_create_aleth_interpreter()}} {}
+    AlethInterpreterSstoreTestFixture()
+      : SstoreTestFixture{new EVMC{evmc_create_aleth_interpreter(), {}}}
+    {}
 };
 
 class ChainIDTestFixture : public TestOutputHelperFixture
@@ -630,7 +634,8 @@ public:
 class AlethInterpreterChainIDTestFixture : public ChainIDTestFixture
 {
 public:
-    AlethInterpreterChainIDTestFixture() : ChainIDTestFixture{new EVMC{evmc_create_aleth_interpreter()}}
+    AlethInterpreterChainIDTestFixture()
+      : ChainIDTestFixture{new EVMC{evmc_create_aleth_interpreter(), {}}}
     {}
 };
 
@@ -749,7 +754,8 @@ public:
 class AlethInterpreterBalanceFixture : public BalanceFixture
 {
 public:
-    AlethInterpreterBalanceFixture() : BalanceFixture{new EVMC{evmc_create_aleth_interpreter()}} {}
+    AlethInterpreterBalanceFixture() : BalanceFixture{new EVMC{evmc_create_aleth_interpreter(), {}}}
+    {}
 };
 
 class PrecompileCallFixture : public TestOutputHelperFixture


### PR DESCRIPTION
This is a preparation for https://github.com/ethereum/aleth/pull/5855 where `EVMC` class is used not only for EVM, but also for precompiles, and EVMC options from command line shouldn't be set to precompiles VM.