### PR TITLE
update tests (retesteth generated + geth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.9.0] - Unreleased
 
 - Added: [#5868](https://github.com/ethereum/aleth/pull/5868) `test_importRawBlock` RPC method reports the detailed reason when import fails.
-- Removed: [#5885](https://github.com/ethereum/aleth/pull/5885) Discontinue `testeth` --filltests support for BlockchainTests, TransitionTests, BCGeneralStateTests
+- Removed: [#5885](https://github.com/ethereum/aleth/pull/5885) Discontinue `testeth --filltests` support for BlockchainTests, TransitionTests, BCGeneralStateTests.
 
 ## [1.8.0] - 2019-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.9.0] - Unreleased
 
 - Added: [#5868](https://github.com/ethereum/aleth/pull/5868) `test_importRawBlock` RPC method reports the detailed reason when import fails.
+- Removed: [#5885](https://github.com/ethereum/aleth/pull/5885) Discontinue `testeth` --filltests support for BlockchainTests, TransitionTests, BCGeneralStateTests
 
 ## [1.8.0] - 2019-12-16
 

--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -1049,22 +1049,10 @@ void checkBlocks(TestBlock const& _blockFromFields, TestBlock const& _blockFromR
 }
 }
 
-class bcTransitionFixture {
-public:
-    bcTransitionFixture()
-    {
-        test::TransitionTestsSuite suite;
-        string const casename = boost::unit_test::framework::current_test_case().p_name;
-        boost::filesystem::path suiteFillerPath = suite.getFullPathFiller(casename).parent_path();
-        suite.runAllTestsInFolder(casename);
-        test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
-    }
-};
-
 BOOST_AUTO_TEST_SUITE(BlockchainTests)
 
 // Tests that contain only valid blocks and check that import is correct
-BOOST_FIXTURE_TEST_SUITE(ValidBlocks, bcTestFixture<test::BlockchainValidTestSuite>)
+BOOST_FIXTURE_TEST_SUITE(ValidBlocks, bcTestFixtureNotRefillable<test::BlockchainValidTestSuite>)
 BOOST_AUTO_TEST_CASE(bcBlockGasLimitTest) {}
 BOOST_AUTO_TEST_CASE(bcExploitTest) {}
 BOOST_AUTO_TEST_CASE(bcForkStressTest) {}
@@ -1080,7 +1068,7 @@ BOOST_AUTO_TEST_CASE(bcWalletTest) {}
 BOOST_AUTO_TEST_SUITE_END()
 
 // Tests that might have invalid blocks and check that those are rejected
-BOOST_FIXTURE_TEST_SUITE(InvalidBlocks, bcTestFixture<test::BlockchainInvalidTestSuite>)
+BOOST_FIXTURE_TEST_SUITE(InvalidBlocks, bcTestFixtureNotRefillable<test::BlockchainInvalidTestSuite>)
 BOOST_AUTO_TEST_CASE(bcBlockGasLimitTest) {}
 BOOST_AUTO_TEST_CASE(bcForgedTest) {}
 BOOST_AUTO_TEST_CASE(bcInvalidHeaderTest) {}
@@ -1091,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(bcUncleTest) {}
 BOOST_AUTO_TEST_SUITE_END()
 
 // Transition from fork to fork tests
-BOOST_FIXTURE_TEST_SUITE(TransitionTests, bcTransitionFixture)
+BOOST_FIXTURE_TEST_SUITE(TransitionTests, bcTestFixtureNotRefillable<test::TransitionTestsSuite>)
 BOOST_AUTO_TEST_CASE(bcByzantiumToConstantinopleFix) {}
 BOOST_AUTO_TEST_CASE(bcEIP158ToByzantium) {}
 BOOST_AUTO_TEST_CASE(bcFrontierToHomestead) {}

--- a/test/tools/jsontests/BlockChainTests.h
+++ b/test/tools/jsontests/BlockChainTests.h
@@ -41,14 +41,16 @@ class BCGeneralStateTestsSuite : public BlockchainValidTestSuite
 class bcGeneralTestsFixture : public StateTestFixtureBase<BCGeneralStateTestsSuite>
 {
 public:
-    bcGeneralTestsFixture() : StateTestFixtureBase({TestExecution::RequireOptionAll}) {}
+    bcGeneralTestsFixture()
+      : StateTestFixtureBase({TestExecution::RequireOptionAll, TestExecution::NotRefillable})
+    {}
 };
 
 template <class T>
 class bcTestFixture
 {
 public:
-    bcTestFixture(std::set<TestExecution> const& _execFlags = {})
+    bcTestFixture(std::set<TestExecution> const& _execFlags)
     {
         T suite;
         if (_execFlags.count(TestExecution::NotRefillable) &&
@@ -69,6 +71,13 @@ public:
         suite.runAllTestsInFolder(casename);
         test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
     }
+};
+
+template <class T>
+class bcTestFixtureNotRefillable : public bcTestFixture<T>
+{
+public:
+    bcTestFixtureNotRefillable() : bcTestFixture<T>({TestExecution::NotRefillable}) {}
 };
 
 class TransitionTestsSuite: public TestSuite


### PR DESCRIPTION
discontinue testeth --filltests suport for GeneralStateTests, BlockchainTests, TransitionTests
update tests to the branch generated by retesteth + geth 