### PR TITLE
testeth treat nullrlp as invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [1.9.0] - Unreleased
 
-- Added: [#5893](https://github.com/ethereum/aleth/pull/5893) testeth: RlpTests treat empty `out` field as invalid.
 - Added: [#5868](https://github.com/ethereum/aleth/pull/5868) `test_importRawBlock` RPC method reports the detailed reason when import fails.
+- Changed: [#5893](https://github.com/ethereum/aleth/pull/5893) testeth: RlpTests treat empty `out` field as invalid.
 - Removed: [#5885](https://github.com/ethereum/aleth/pull/5885) Discontinue `testeth --filltests` support for BlockchainTests, TransitionTests, BCGeneralStateTests.
 
 ## [1.8.0] - 2019-12-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.9.0] - Unreleased
 
+- Added: [#5893](https://github.com/ethereum/aleth/pull/5893) testeth: RlpTests treat empty `out` field as invalid.
 - Added: [#5868](https://github.com/ethereum/aleth/pull/5868) `test_importRawBlock` RPC method reports the detailed reason when import fails.
 - Removed: [#5885](https://github.com/ethereum/aleth/pull/5885) Discontinue `testeth --filltests` support for BlockchainTests, TransitionTests, BCGeneralStateTests.
 

--- a/test/tools/jsontests/RLPTests.cpp
+++ b/test/tools/jsontests/RLPTests.cpp
@@ -87,6 +87,10 @@ void doRlpTests(json_spirit::mValue const& _input)
             bytes payloadToDecode = fromHex(o.at("out").get_str());
             RLP payload(payloadToDecode);
 
+            // treat null rlp as invalid
+            if (payload.isNull())
+                BOOST_THROW_EXCEPTION(Exception() << errinfo_comment("RLPTests: field `out` is set to Null"));
+
             // attempt to read all the contents of RLP
             ostringstream() << payload;
 


### PR DESCRIPTION
fetch tests with this PR
https://github.com/ethereum/tests/pull/614

includes this PR:
https://github.com/ethereum/aleth/pull/5891